### PR TITLE
sm bg fx

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -250,6 +250,14 @@ async function hangUp() {
     remoteVideo.srcObject = null;
   }
 
+  // Stop local media too
+  const localStream = getLocalStream();
+  if (localStream) {
+    localStream.getTracks().forEach((t) => t.stop());
+    localVideo.srcObject = null;
+    setLocalStream(null);
+  }
+
   await disconnect({ onStatusUpdate: updateStatus });
 
   // Reset UI


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix ICE candidate race condition by queuing candidates until remote description is set

- Add proper local media stream cleanup on disconnect and hangup

- Add validation checks to ensure local stream exists before connection

- Uncomment and restore local media cleanup in disconnect function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local Stream Validation"] --> B["Peer Connection Setup"]
  B --> C["Queue ICE Candidates"]
  C --> D["Set Remote Description"]
  D --> E["Drain Queued Candidates"]
  F["Hangup/Disconnect"] --> G["Stop All Media Tracks"]
  G --> H["Clear Stream References"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.js</strong><dd><code>Add local media cleanup on hangup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app.js

<ul><li>Add local media stream cleanup in <code>hangUp()</code> function<br> <li> Stop all local tracks and clear <code>localVideo.srcObject</code><br> <li> Reset local stream state using <code>setLocalStream(null)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/27/files#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>connection.js</strong><dd><code>Fix ICE timing and add stream validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/connection.js

<ul><li>Implement ICE candidate queuing mechanism with <code>pendingCalleeCandidates</code> <br>array<br> <li> Queue callee ICE candidates until remote description is set, then <br>drain queue<br> <li> Add validation to check <code>localStream</code> exists before connecting/joining<br> <li> Uncomment local media cleanup code in <code>disconnect()</code> function<br> <li> Add error handling for failed ICE candidate additions</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/27/files#diff-911e83a720918a13fb05ee22c8e0b4fac43c48df6e801f3bbd22b67bbc40b863">+32/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hanging up now fully stops microphone/camera and clears the local video preview.
  * Improved call setup reliability by buffering connection candidates until the call is ready, reducing failed connections.
  * Prevents joining a call without local media access, providing clearer feedback when permissions are missing.
  * Disconnecting now properly releases local media to prevent devices remaining in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->