### PR TITLE
make install button visible before install

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,6 @@ import {
   sharedVideoEl,
   callBtn,
   hangUpBtn,
-  linkContainer,
   shareLink,
   syncStatus,
   mutePartnerBtn,

--- a/src/style.css
+++ b/src/style.css
@@ -59,10 +59,11 @@ body {
 #hang-up-btn.hidden,
 #switch-camera-btn.hidden,
 #camera-btn.hidden,
+#install-btn.hidden,
 .chat-btn.hidden,
 .messages-box.hidden,
 .top-left-menu.hidden {
-  opacity: 0 !important;
+  opacity: 0 !important; /* Todo: Remove !important */
   pointer-events: none;
   visibility: hidden;
 
@@ -748,7 +749,6 @@ button:disabled {
 
 #install-btn {
   z-index: 1000;
-  display: none;
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install button now displays by default and properly hides when needed.

* **Style**
  * Updated install button styling to align with the app's standard visibility behavior for hidden elements.

* **Refactor**
  * Removed unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->