### PR TITLE
temp hide non-working install-info button in prod

### DIFF
--- a/src/pwa/PWA.js
+++ b/src/pwa/PWA.js
@@ -3,6 +3,7 @@ import {
   debugVisibility,
   devDebug,
   isDev,
+  isProd,
   tempInfo,
   tempWarn,
 } from '../utils/dev/dev-utils';
@@ -66,7 +67,10 @@ function setupPWA() {
       title: 'Show Install Instructions',
     });
 
-    showElement(installBtnComponent);
+    // TODO: Fix ui message not displaying (at least on IOS)
+    // For now, just hide in prod
+    if (isProd()) hideElement(installBtnComponent);
+    else showElement(installBtnComponent);
 
     installBtn.onclick = () => {
       alert(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Hide non-functional install info button in production environment

- Add conditional visibility based on environment (prod vs dev)

- Import `isProd` utility for environment detection

- Add TODO comment documenting UI message display issue on iOS


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["iOS Install Button"] --> B{"isProd()?"}
  B -->|Yes| C["Hide Element"]
  B -->|No| D["Show Element"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PWA.js</strong><dd><code>Conditionally hide iOS install button in production</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pwa/PWA.js

<ul><li>Import <code>isProd</code> utility function from dev-utils<br> <li> Add conditional logic to hide install button in production<br> <li> Show install button only in development environment<br> <li> Add TODO comment explaining the temporary workaround for iOS UI <br>message display issue</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/115/files#diff-1bc4b7e9e3043609ac494e58612bb05c9e3669ba5835756eae6691384bd7b9d2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS install button behavior to correctly display based on environment configuration, ensuring proper functionality across production and non-production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->