### PR TITLE
add exit button for watch mode MVP - Currently added to chat-controls…

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,13 @@
       </div>
 
       <div id="chat-controls" class="chat-controls bottom">
+        <button
+          class="chat-btn hidden"
+          id="exit-watch-mode-btn"
+          title="Exit watch mode"
+        >
+          <i class="fa fa-times"></i>
+        </button>
         <button class="chat-btn" id="call-btn">
           <i class="fa fa-phone"></i>
         </button>

--- a/src/components/ui/watch-mode.js
+++ b/src/components/ui/watch-mode.js
@@ -13,6 +13,7 @@ import {
   mutePartnerBtn,
   cameraBtn,
   switchCameraBtn,
+  exitWatchModeBtn,
   localBoxEl,
   remoteBoxEl,
 } from '../../elements.js';
@@ -80,6 +81,9 @@ export function enterWatchMode() {
   hideElement(cameraBtn);
   hideElement(switchCameraBtn);
 
+  // Show exit watch mode button
+  showElement(exitWatchModeBtn);
+
   showElement(chatControls);
 
   if (!isRemoteVideoVideoActive()) {
@@ -124,6 +128,9 @@ export function enterWatchMode() {
 
 export function exitWatchMode() {
   if (!isWatchModeActive()) return;
+
+  // Hide exit watch mode button
+  hideElement(exitWatchModeBtn);
 
   showElement(callBtn);
   showElement(hangUpBtn);

--- a/src/elements.js
+++ b/src/elements.js
@@ -33,6 +33,7 @@ let mutePartnerBtn = null;
 let fullscreenPartnerBtn = null;
 let micBtn = null;
 let cameraBtn = null;
+let exitWatchModeBtn = null;
 let appPipBtn = null;
 let appTitleH1 = null;
 let appTitleA = null;
@@ -63,6 +64,7 @@ function initializeElements() {
   fullscreenPartnerBtn = getElement('fullscreen-partner-btn');
   micBtn = getElement('mic-btn');
   cameraBtn = getElement('camera-btn');
+  exitWatchModeBtn = getElement('exit-watch-mode-btn');
 
   appPipBtn = getElement('app-pip-btn');
 
@@ -101,6 +103,7 @@ export const getElements = () => ({
   fullscreenPartnerBtn,
   micBtn,
   cameraBtn,
+  exitWatchModeBtn,
   appPipBtn,
   appTitleH1,
   appTitleA,
@@ -130,6 +133,7 @@ export {
   fullscreenPartnerBtn,
   micBtn,
   cameraBtn,
+  exitWatchModeBtn,
   appPipBtn,
   appTitleH1,
   appTitleA,

--- a/src/main.js
+++ b/src/main.js
@@ -62,6 +62,7 @@ import {
   micBtn,
   cameraBtn,
   switchCameraBtn,
+  exitWatchModeBtn,
   chatControls,
   localBoxEl,
   remoteBoxEl,
@@ -1061,6 +1062,19 @@ lobbyCallBtn.onclick = handleCall;
 // };
 
 // copyLinkBtn.onclick = async () => await handleCopyLink();
+
+if (exitWatchModeBtn) {
+  exitWatchModeBtn.onclick = () => {
+    if (getLastWatched() === 'yt') {
+      pauseYouTubeVideo();
+      hideYouTubePlayer();
+    } else if (getLastWatched() === 'url') {
+      sharedVideoEl.pause();
+      hideElement(sharedBoxEl);
+    }
+    exitWatchMode();
+  };
+}
 
 hangUpBtn.onclick = async () => {
   console.debug('Hanging up...');

--- a/src/styles/components/chat-controls.css
+++ b/src/styles/components/chat-controls.css
@@ -87,6 +87,20 @@
   transform: scale(1.25);
 }
 
+#exit-watch-mode-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+}
+
+#exit-watch-mode-btn:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.8);
+}
+
+.chat-controls.watch-mode #exit-watch-mode-btn {
+  order: -1; /* Place at top of vertical stack */
+}
+
 #hang-up-btn {
   background-color: rgb(255, 80, 80, 1);
 }


### PR DESCRIPTION
…, might need repositioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Exit watch mode" button to the chat controls, enabling users to quickly stop viewing shared content and return to normal mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->