### PR TITLE
v1 msg-UI unification complete. A few remaining bugs: 1st contact msg…

### DIFF
--- a/session_vs_conversation.md
+++ b/session_vs_conversation.md
@@ -1,0 +1,66 @@
+Session vs Conversation: proposed refactoring/renaming, to be reviewed and verified or rejected.
+
+Summary
+
+- Recommendation: make the core transport/storage conversation-centric (use `conversationId`) while keeping small convenience helpers for `contactId` (e.g., `openSessionForContact`) to preserve existing UI flows.
+
+Pros of using `conversationId`
+
+- Aligns with storage: direct mapping to `/conversations/{conversationId}` avoids repeated derivation logic.
+- Supports multi-party: naturally models groups, threads, channels and future multi-participant features.
+- Opaque/portable ID: can be generated without exposing participant user IDs; supports versioning/metadata.
+- Multiple session contexts: enables threads or topic-based sessions with the same participants.
+- Easier cross-device sync: canonical conversation key reduces per-device derivation mismatch.
+
+Cons of using `conversationId`
+
+- Less direct for 1:1 UI: UI needs a mapping layer `conversationId -> primaryContact/participants` for display.
+- Caller responsibility: code that opens sessions must know/resolve the `conversationId` (or use helpers).
+- Access control: must validate membership server/client-side when opening/listening to a conversation.
+- Migration effort: existing `contactId`-centric code (badges, toggles, lists) needs small updates.
+- Duplicate conversation risk: requires deterministic creation/lookup rules for 1:1 conversations.
+
+Main implications
+
+- API change surface: `MessagingController` and transport can accept `conversationId` (new methods) and keep `contactId`-based helpers for compatibility.
+- Transport simplification: transports operate directly on `conversationId`, removing `_getConversationId` coupling to UI/controller internals.
+- Data model: need a canonical conversation creation/lookup flow (deterministic for 1:1; canonical central creation for groups).
+- UI mapping and badges: UI must maintain `conversationId -> participants/primaryContact` mapping and adapt unread/badge logic accordingly.
+- Security: every open/listen/send should validate participant membership.
+- Extensibility: easier to add conversation-level metadata, settings, pinned messages, threads, and group features.
+
+Minimal implementation (non-breaking, keep changes small)
+
+1. Transport: add small conversation-centric wrappers in transport implementations (no breaking rename):
+
+   - `sendToConversation(conversationId, text)`
+   - `listenToConversation(conversationId, onMessage)`
+   - `getUnreadCountForConversation(conversationId)`
+   - `markAsReadForConversation(conversationId)`
+   - `listenToUnreadCountForConversation(conversationId, cb)`
+     These call the same DB paths as current code but accept `conversationId` directly.
+
+2. Controller: add a convenience method in `MessagingController`:
+
+   - `openSessionForConversation(conversationId, {onMessage, onUnreadChange})`
+   - Store conversation sessions under a namespaced key (e.g., `conversation:{conversationId}`) to avoid colliding with `contactId` keys.
+   - The method should use transport conversation-centric APIs when available and fall back to existing contact-based functions if not.
+
+3. Keep `openSession(contactId, ...)` as-is for backward compatibility; optionally add `openSessionForContact(contactId)` that resolves/creates the canonical conversation and delegates to `openSessionForConversation`.
+
+4. UI: adapt message list / toggles to map `conversationId` → display data (primary contact, title, avatar). Keep per-contact convenience UI by exposing a small resolve helper.
+
+5. Migration checklist (minimal):
+   - Add transport conversation methods to implementations (`src/messaging/transports/*`) as thin wrappers.
+   - Add `openSessionForConversation` to `src/messaging/messaging-controller.js` (store namespaced session keys).
+   - Update any code that currently calls transport `_getConversationId` or expects controller to derive conversation IDs; replace with match to helpers.
+   - Add small unit test(s) for both contact-based and conversation-based session flows.
+
+Why this approach
+
+- Minimal surface change: existing APIs still work; new conversation APIs are additive.
+- Eases future features (groups, metadata) while keeping current UX stable.
+
+Next steps (suggested)
+
+- I can produce a tiny patch that adds the thin transport wrappers and `openSessionForConversation` (2–3 files changed). Want me to prepare that patch now?


### PR DESCRIPTION
### **User description**
…-toggle + in-call vs contact badge count mismatch + new-message animation for contackt toggles..


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor messaging UI to use singleton pattern with session management

- Fix badge clearing logic by tracking active session in UI state

- Simplify session initialization and message sending flow

- Add conversation-centric design proposal documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["contacts.js<br/>openContactMessages"] -->|uses| B["messagesUI<br/>singleton"]
  B -->|manages| C["currentSession<br/>state"]
  C -->|sends via| D["session.send"]
  B -->|clears badges| E["contact toggle<br/>& message UI"]
  F["Design Doc<br/>session vs conversation"] -.->|proposes| G["Future refactoring<br/>conversation-centric"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contacts.js</strong><dd><code>Migrate to messagesUI singleton pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/contacts/contacts.js

<ul><li>Changed import from <code>initMessagesUI</code> function to <code>messagesUI</code> singleton <br>instance<br> <li> Simplified session opening logic by removing per-session UI references<br> <li> Removed deferred session initialization pattern; now uses global <br><code>messagesUI</code> singleton<br> <li> Added <code>messagesUI.setSession()</code> call to track active session in UI state</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/190/files#diff-43847634d2d821fb264d7edbd9ddc34e1652250461315b3c51c10c21753c3267">+15/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>messages-ui.js</strong><dd><code>Convert to singleton with session state tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/messages/messages-ui.js

<ul><li>Converted <code>initMessagesUI()</code> from factory function to initialization <br>function returning singleton<br> <li> Added <code>currentSession</code> state variable to track active messaging session<br> <li> Replaced <code>messagingController.getAllSessions()</code> lookup with direct <br><code>currentSession</code> reference for badge clearing<br> <li> Added <code>setSession()</code>, <code>getCurrentSession()</code>, and <code>clearMessages()</code> public <br>methods<br> <li> Updated message sending to use <code>currentSession.send()</code> instead of <br>injected <code>sendFn</code> callback<br> <li> Exported <code>messagesUI</code> singleton instance at module level</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/190/files#diff-c5187d5018cda3fa7f4329059bd24aad02f791f678b3d3db6bd2dcd1e57b3db7">+46/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session_vs_conversation.md</strong><dd><code>Add session vs conversation refactoring proposal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

session_vs_conversation.md

<ul><li>New documentation proposing refactoring from contact-centric to <br>conversation-centric architecture<br> <li> Outlines pros/cons of using <code>conversationId</code> instead of <code>contactId</code> for <br>core transport/storage<br> <li> Provides minimal implementation strategy with backward compatibility<br> <li> Includes migration checklist and rationale for conversation-based <br>design</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/190/files#diff-4da6103f74c9a30ae41e7111d4dae864b2720577384768a76beee4be8f2f2361">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to session and messaging management architecture for enhanced maintainability and future scalability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->