### PR TITLE
Hide attachment button in message ui when FileTransfer is not initial…

### DIFF
--- a/src/file-transfer.js
+++ b/src/file-transfer.js
@@ -1,6 +1,6 @@
 // Simple chunking:  64KB chunks
 const CHUNK_SIZE = 64 * 1024; // 64KB
-const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+const MAX_FILE_SIZE = 900 * 1024 * 1024; // 900MB
 
 export class FileTransfer {
   constructor(dataChannel) {

--- a/src/messaging/messaging-controller.js
+++ b/src/messaging/messaging-controller.js
@@ -25,7 +25,9 @@ export class MessagingController {
    */
   constructor(transport, fileTransport = null) {
     if (!transport) {
-      throw new Error('MessagingController requires a transport implementation');
+      throw new Error(
+        'MessagingController requires a transport implementation'
+      );
     }
 
     this.transport = transport;
@@ -65,7 +67,9 @@ export class MessagingController {
 
     // Return existing session if already open
     if (this.sessions.has(contactId)) {
-      console.warn(`[MessagingController] Session already open for ${contactId}`);
+      console.info(
+        `[MessagingController] Session already open for ${contactId}`
+      );
       return this.sessions.get(contactId);
     }
 
@@ -79,10 +83,20 @@ export class MessagingController {
         }
 
         // Notify unread count changes (only for received messages)
-        if (!isSentByMe && onUnreadChange && typeof onUnreadChange === 'function') {
-          this.transport.getUnreadCount(contactId)
-            .then(count => onUnreadChange(count))
-            .catch(err => console.warn('[MessagingController] Failed to get unread count:', err));
+        if (
+          !isSentByMe &&
+          onUnreadChange &&
+          typeof onUnreadChange === 'function'
+        ) {
+          this.transport
+            .getUnreadCount(contactId)
+            .then((count) => onUnreadChange(count))
+            .catch((err) =>
+              console.warn(
+                '[MessagingController] Failed to get unread count:',
+                err
+              )
+            );
         }
       }
     );
@@ -98,7 +112,9 @@ export class MessagingController {
        */
       send: (text) => {
         if (!text || typeof text !== 'string') {
-          return Promise.reject(new Error('Message text must be a non-empty string'));
+          return Promise.reject(
+            new Error('Message text must be a non-empty string')
+          );
         }
         return this.transport.send(contactId, text);
       },
@@ -241,7 +257,9 @@ export class MessagingController {
    */
   async sendFile(file, onProgress) {
     if (!this.fileTransport) {
-      throw new Error('File transport not available. Files can only be sent during active calls.');
+      throw new Error(
+        'File transport not available. Files can only be sent during active calls.'
+      );
     }
 
     if (!this.fileTransport.isReady()) {


### PR DESCRIPTION
### **User description**
…ized


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Hide attachment button until FileTransfer is initialized

- Support clickable file downloads instead of auto-download

- Increase max file size from 100MB to 900MB

- Improve code formatting and error messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FileTransfer Instance"] -->|"setFileTransfer(instance)"| B["Show/Hide Attach Button"]
  B -->|"if available"| C["Enable File Sending"]
  B -->|"if unavailable"| D["Disable File Sending"]
  E["File Received"] -->|"onFileReceived"| F["Create Download Link"]
  F -->|"appendChatMessage with options"| G["Clickable Download in UI"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messages-ui.js</strong><dd><code>Add FileTransfer-aware attachment button and clickable downloads</code></dd></summary>
<hr>

src/components/messages/messages-ui.js

<ul><li>Hide attachment button by default on initialization<br> <li> Show/hide attachment button based on FileTransfer availability in <br><code>setFileTransfer()</code><br> <li> Enhance <code>appendChatMessage()</code> to support clickable file downloads with <br>optional parameters<br> <li> Replace auto-download behavior with user-initiated downloads via <br>clickable links</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/202/files#diff-c5187d5018cda3fa7f4329059bd24aad02f791f678b3d3db6bd2dcd1e57b3db7">+35/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>file-transfer.js</strong><dd><code>Increase maximum file transfer size limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/file-transfer.js

- Increase `MAX_FILE_SIZE` from 100MB to 900MB


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/202/files#diff-7c95bf9c9815d2c5205de34ed14bf2da4dff7d7b7d9f59d3900c548158bcfd64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messaging-controller.js</strong><dd><code>Improve code formatting and error messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/messaging/messaging-controller.js

<ul><li>Improve code formatting with consistent line breaks for readability<br> <li> Change console.warn to console.info for session already open message<br> <li> Refactor promise chains with better formatting for error handling<br> <li> Update JSDoc comment to clarify FileTransfer can be set to null</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/202/files#diff-ebed139c72a7020a7559723258babba30aa9cc0e8e60175bf9662800e1856a07">+26/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Files received in conversations now display as clickable download links within messages
  * Attachment button automatically shows when file transfer is active and hides when inactive
  * Maximum file transfer size increased to 900MB, enabling larger file uploads and downloads

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->