### PR TITLE
BugFix: Logging out now properly resets the message UI and cleans up …

### DIFF
--- a/src/components/messages/messages-ui.js
+++ b/src/components/messages/messages-ui.js
@@ -488,6 +488,36 @@ export function initMessagesUI() {
     }
   }
 
+  /**
+   * Reset the messages UI for a new user session (e.g., on logout).
+   * Clears messages, session, and hides the UI without destroying DOM elements.
+   */
+  function reset() {
+    clearMessages();
+    currentSession = null;
+    fileTransfer = null;
+    isReceivingFile = false;
+    hideMessagesToggle();
+    hideElement(messagesBox);
+    messageToggle.clearBadge();
+
+    // Reset send button text in case file transfer was in progress
+    if (sendBtn) {
+      sendBtn.textContent = 'Send';
+    }
+
+    // Hide attachment button (will be shown again when FileTransfer is available)
+    hideElement(attachBtn);
+
+    // Clear inline positioning
+    messagesBox.style.top = '';
+    messagesBox.style.left = '';
+    messagesBox.style.bottom = '';
+    messagesBox.style.right = '';
+
+    detachRepositionHandlers();
+  }
+
   function cleanup() {
     // Cleanup message toggle
     if (messageToggle) {
@@ -531,6 +561,7 @@ export function initMessagesUI() {
     getCurrentSession,
     clearMessages,
     setFileTransfer,
+    reset,
     cleanup,
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1217,7 +1217,14 @@ window.onload = async () => {
 
       // Only clean up on actual logout (not initial load)
       if (isActualLogout) {
-        devDebug('[AUTH] User logged out - cleaning up incoming listeners');
+        devDebug('[AUTH] User logged out - cleaning up messaging and listeners');
+
+        // Clear messages UI to prevent previous user's messages from being visible
+        messagesUI.reset();
+
+        // Close all messaging sessions (stops RTDB listeners for old user's conversations)
+        messagingController.closeAllSessions();
+
         removeAllIncomingListeners();
       } else if (isActualLogin) {
         // On login, re-attach listeners for saved rooms


### PR DESCRIPTION
### **User description**
…previous conversations


___

### **PR Type**
Bug fix


___

### **Description**
- Add `reset()` function to messages UI for proper logout cleanup

- Clear messages, session state, and UI elements on logout

- Reset send button text and attachment button visibility

- Call `messagesUI.reset()` and `messagingController.closeAllSessions()` during logout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  logout["User Logout"] --> reset["messagesUI.reset()"]
  logout --> closeSession["messagingController.closeAllSessions()"]
  reset --> clearMsg["Clear Messages"]
  reset --> clearState["Clear Session State"]
  reset --> hideUI["Hide UI Elements"]
  reset --> resetBtn["Reset Send Button"]
  closeSession --> stopListeners["Stop RTDB Listeners"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messages-ui.js</strong><dd><code>Add reset function for logout cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/messages/messages-ui.js

<ul><li>Add new <code>reset()</code> function that clears messages, session state, and UI <br>elements<br> <li> Reset send button text to 'Send' and hide attachment button<br> <li> Clear inline positioning styles from messages box<br> <li> Detach repositioning handlers<br> <li> Export <code>reset</code> function in the public API</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/211/files#diff-c5187d5018cda3fa7f4329059bd24aad02f791f678b3d3db6bd2dcd1e57b3db7">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Call reset functions during logout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.js

<ul><li>Call <code>messagesUI.reset()</code> to clear messages UI on logout<br> <li> Call <code>messagingController.closeAllSessions()</code> to stop RTDB listeners<br> <li> Update debug message to reflect messaging cleanup<br> <li> Ensure previous user's messages are not visible after logout</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/211/files#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved logout process to ensure complete cleanup of the messaging interface, including resetting the message display and closing all active messaging sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->