### PR TITLE
Fix invite queue stall if confirmDialog throws

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1212,31 +1212,33 @@ async function processNextInvite() {
   isProcessingInvite = true;
   const { fromUserId, inviteData } = pendingInvites.shift();
 
-  const accept = await confirmDialog(
-    `${inviteData.fromName || 'Someone'} wants to connect.\n\nAccept contact invitation?`
-  );
+  try {
+    const accept = await confirmDialog(
+      `${inviteData.fromName || 'Someone'} wants to connect.\n\nAccept contact invitation?`
+    );
 
-  if (accept) {
-    try {
-      await acceptInvite(fromUserId, inviteData);
-      console.log('[INVITATIONS] Contact added:', inviteData.fromName);
-      await renderContactsList(lobbyDiv).catch(() => {});
-      alert(`Added ${inviteData.fromName} to your contacts!`);
-    } catch (e) {
-      console.error('[INVITATIONS] Failed to accept invite:', e);
-      alert('Failed to add contact. Please try again.');
+    if (accept) {
+      try {
+        await acceptInvite(fromUserId, inviteData);
+        console.log('[INVITATIONS] Contact added:', inviteData.fromName);
+        await renderContactsList(lobbyDiv).catch(() => {});
+        alert(`Added ${inviteData.fromName} to your contacts!`);
+      } catch (e) {
+        console.error('[INVITATIONS] Failed to accept invite:', e);
+        alert('Failed to add contact. Please try again.');
+      }
+    } else {
+      try {
+        await declineInvite(fromUserId);
+        console.log('[INVITATIONS] Invite declined');
+      } catch (e) {
+        console.error('[INVITATIONS] Failed to decline invite:', e);
+      }
     }
-  } else {
-    try {
-      await declineInvite(fromUserId);
-      console.log('[INVITATIONS] Invite declined');
-    } catch (e) {
-      console.error('[INVITATIONS] Failed to decline invite:', e);
-    }
+  } finally {
+    isProcessingInvite = false;
+    processNextInvite();
   }
-
-  isProcessingInvite = false;
-  processNextInvite();
 }
 
 /**


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Wraps confirmDialog call in try-finally block to prevent queue stall

- Ensures isProcessingInvite flag reset and next invite processing on any error

- Maintains existing error handling for accept/decline operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["confirmDialog call"] -->|"wrapped in try"| B["accept/decline logic"]
  B -->|"finally block"| C["reset isProcessingInvite"]
  C -->|"always executes"| D["processNextInvite"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Add error handling to invite queue processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.js

<ul><li>Wraps <code>confirmDialog</code> call and subsequent logic in try-finally block<br> <li> Moves <code>isProcessingInvite = false</code> and <code>processNextInvite()</code> to finally <br>block<br> <li> Ensures queue processing continues even if <code>confirmDialog</code> throws an <br>error<br> <li> Maintains all existing error handling for accept and decline <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/223/files#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79">+24/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured invite processing error handling and control flow for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->