### PR TITLE
Message-ui improvements: line-wrapping + spacing

### DIFF
--- a/src/components/contacts/contacts.js
+++ b/src/components/contacts/contacts.js
@@ -239,7 +239,7 @@ function attachContactListeners(container, lobbyElement) {
       let roomId = nameEl.getAttribute('data-room-id');
       const contactName = nameEl.getAttribute('data-contact-name');
       const contactId = nameEl.getAttribute('data-contact-id');
-      
+
       // If no roomId is saved, generate and persist it
       if (!roomId && contactId) {
         const myUserId = getLoggedInUserId();
@@ -256,7 +256,7 @@ function attachContactListeners(container, lobbyElement) {
           }
         }
       }
-      
+
       if (roomId) {
         // QUICK FIX: Ensure listener is active for this room before calling
         listenForIncomingOnRoom(roomId);
@@ -301,7 +301,7 @@ function attachContactListeners(container, lobbyElement) {
 export function openContactMessages(
   contactId,
   contactName,
-  openMessageBox = false
+  openMessageBox = false,
 ) {
   if (!getLoggedInUserId()) {
     alert('Please sign in to send messages');
@@ -335,7 +335,7 @@ export function openContactMessages(
     onMessage: (text, msgData, isSentByMe) => {
       // Display message in UI with correct prefix
       if (isSentByMe) {
-        messagesUI.appendChatMessage(`You: ${text}`);
+        messagesUI.appendChatMessage(`${text}`, { isSentByMe: true });
       } else {
         // Only count as unread if message hasn't been read yet
         const isUnread = !msgData.read;
@@ -388,7 +388,7 @@ function setupPresenceIndicators(contactIds) {
   contactIds.forEach((contactId) => {
     const presenceRef = ref(rtdb, `users/${contactId}/presence`);
     const indicatorEl = document.querySelector(
-      `.presence-indicator[data-contact-id="${contactId}"]`
+      `.presence-indicator[data-contact-id="${contactId}"]`,
     );
 
     if (!indicatorEl) return;
@@ -431,7 +431,7 @@ async function createContactMessageToggles(container, contactIds, contacts) {
 
   if (toggleReplacementInProgress) {
     console.debug(
-      '[CONTACTS] Toggle replacement still in progress after waiting, skipping'
+      '[CONTACTS] Toggle replacement still in progress after waiting, skipping',
     );
     return;
   }
@@ -466,12 +466,12 @@ async function createContactMessageToggles(container, contactIds, contacts) {
     for (const contactId of contactIds) {
       const contact = contacts[contactId];
       const toggleContainer = container.querySelector(
-        `.contact-msg-toggle-container[data-contact-id="${contactId}"]`
+        `.contact-msg-toggle-container[data-contact-id="${contactId}"]`,
       );
 
       if (!toggleContainer) {
         console.warn(
-          `[CONTACTS] No toggle container found for contact ${contactId}`
+          `[CONTACTS] No toggle container found for contact ${contactId}`,
         );
         continue;
       }
@@ -487,7 +487,7 @@ async function createContactMessageToggles(container, contactIds, contacts) {
 
       if (!toggle) {
         console.error(
-          `[CONTACTS] Failed to create toggle for contact ${contactId}`
+          `[CONTACTS] Failed to create toggle for contact ${contactId}`,
         );
         continue;
       }
@@ -500,7 +500,7 @@ async function createContactMessageToggles(container, contactIds, contacts) {
         contactId,
         (count) => {
           toggle.setUnreadCount(count);
-        }
+        },
       );
 
       // Track unsubscribe function for cleanup
@@ -521,10 +521,10 @@ async function createContactMessageToggles(container, contactIds, contacts) {
           .catch((err) =>
             console.warn(
               `[CONTACTS] Failed to get unread count for ${contactId}:`,
-              err
-            )
-          )
-      )
+              err,
+            ),
+          ),
+      ),
     );
   } finally {
     // Clear timeout and reset flag
@@ -602,7 +602,7 @@ function setupMessageBadgeListeners(container, contactIds) {
     const messagesRef = ref(rtdb, `conversations/${conversationId}/messages`);
 
     const btn = container.querySelector(
-      `.contact-message-btn[data-contact-id="${contactId}"]`
+      `.contact-message-btn[data-contact-id="${contactId}"]`,
     );
     if (!btn) return;
 
@@ -633,7 +633,7 @@ function setupMessageBadgeListeners(container, contactIds) {
  */
 function clearContactBadge(contactId) {
   const btn = document.querySelector(
-    `.contact-message-btn[data-contact-id="${contactId}"]`
+    `.contact-message-btn[data-contact-id="${contactId}"]`,
   );
   if (btn) {
     updateContactBadge(btn, 0);

--- a/src/styles/components/messages.css
+++ b/src/styles/components/messages.css
@@ -83,12 +83,92 @@
   word-break: break-word; /* Fallback for older browsers */
 }
 
+/* Layout: always render avatar + text in DOM; use flex + order to position */
+#messages p {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#messages p.message-local {
+  justify-content: flex-end;
+}
+
+#messages p.message-remote {
+  justify-content: flex-start;
+}
+
+/* Hide avatar for system/file messages (temporary placeholder behavior) */
+#messages p.message-system .sender-avatar {
+  display: none;
+}
+
+#messages p.message-system .message-text {
+  margin-left: 0;
+}
+
 #messages p:first-child {
   margin-top: 0;
 }
 
 #messages p:last-child {
   margin-bottom: 0;
+}
+
+/* Message alignment by sender */
+#messages .message-local {
+  text-align: right;
+}
+
+#messages .message-remote {
+  text-align: left;
+}
+
+/* Sender avatar (single-letter placeholder) */
+#messages .sender-avatar {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  max-width: 24px;
+  max-height: 24px;
+  aspect-ratio: 1 / 1;
+  flex: 0 0 24px; /* prevent flexbox from stretching avatar */
+  border-radius: 50%;
+  background: #3757c1;
+  color: #ffffff;
+  text-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.45),
+    0 0 1px rgba(0, 0, 0, 0.25);
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  margin-right: 8px;
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* Slightly different avatar for local user (on right) */
+#messages .sender-avatar--me {
+  background: #228332; /* subtle green */
+  color: #ffffff;
+  margin-right: 0;
+  margin-left: 8px;
+}
+
+/* Order rules: avatar left for remote, right for local */
+#messages .sender-avatar {
+  order: 0;
+}
+#messages .message-text {
+  order: 1;
+}
+#messages p.message-local .sender-avatar {
+  order: 1;
+}
+#messages p.message-local .message-text {
+  order: 0;
 }
 
 /* Messages Form (extracted from inline styles) */


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add native CSS `field-sizing` support with JS fallback for textarea auto-grow

- Implement Enter-to-send and Shift+Enter-for-newline keyboard shortcuts

- Improve message display with proper line-wrapping and spacing

- Reset textarea height after sending messages and clearing input


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Native field-sizing<br/>CSS support"] -->|"Fallback"| B["JS auto-grow<br/>textarea"]
  C["Enter key<br/>handler"] -->|"Sends"| D["sendMessage()<br/>function"]
  E["Message display<br/>styling"] -->|"Improves"| F["Line-wrapping &<br/>spacing"]
  D -->|"Resets"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messages-ui.js</strong><dd><code>Add keyboard shortcuts and textarea height reset logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/messages/messages-ui.js

<ul><li>Detect native <code>field-sizing</code> CSS support and conditionally apply JS <br>fallback for textarea auto-grow<br> <li> Extract message sending logic into reusable <code>sendMessage()</code> function<br> <li> Add keyboard event listener for Enter-to-send (Shift+Enter for <br>newline) functionality<br> <li> Expose <code>resetInputHeight()</code> function to reset textarea height after <br>clearing input<br> <li> Call <code>resetInputHeight()</code> when clearing messages and after sending</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/235/files#diff-c5187d5018cda3fa7f4329059bd24aad02f791f678b3d3db6bd2dcd1e57b3db7">+33/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>messages.css</strong><dd><code>Improve textarea sizing and message text wrapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/styles/components/messages.css

<ul><li>Add <code>overflow-x: hidden</code> to prevent horizontal scrolling in messages <br>container<br> <li> Style message paragraphs with <code>white-space: pre-wrap</code> to preserve line <br>breaks from Shift+Enter<br> <li> Add <code>overflow-wrap: break-word</code> and <code>word-break: break-word</code> for long word <br>wrapping<br> <li> Replace <code>place-content: center</code> with <code>align-content: start</code> to align text <br>at top<br> <li> Implement native <code>field-sizing: content</code> with <code>min-height: 1lh</code> and <br><code>max-height: 5lh</code> for textarea<br> <li> Add <code>overflow-y: auto</code> to show scrollbar when textarea reaches <br>max-height</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/HangVidU/pull/235/files#diff-2396edc59c63e50ef7be53f636e58e8cdd714ce3b1b785d7f6d0934685f84200">+25/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enter-to-send (Shift+Enter for newline) and a more reliable auto-growing message input with broader browser fallback.
  * Messaging now shows proper sent/received styling and supports in-chat file attachments with Download vs Watch Together prompts.

* **Bug Fixes / UX**
  * Input height reliably resets after send/clear and UI resets.
  * Opening contacts now ensures stable call/message setup and consistent message rendering.

* **Style**
  * Improved message layout, avatar positioning, line-break preservation, and word wrapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->