### PR TITLE
Fix clickOutside dynamic ignore list and refactor ReactionManager for per-user tracking

### DIFF
--- a/src/utils/ui/clickOutside.js
+++ b/src/utils/ui/clickOutside.js
@@ -29,12 +29,14 @@ export function onClickOutside(element, onClick, options = {}) {
     ignoreInputBlur = false, // New option: ignore clicks that blur input elements
   } = options;
 
-  // Normalize ignore list to HTMLElement references
-  let ignoreList = options.ignore || [];
-  if (typeof ignoreList === 'function') {
-    ignoreList = ignoreList();
-  }
-  ignoreList = Array.isArray(ignoreList) ? ignoreList.filter(Boolean) : [];
+  // Resolve ignore list lazily on each click (supports dynamic ignore elements)
+  const resolveIgnoreList = () => {
+    let list = options.ignore || [];
+    if (typeof list === 'function') {
+      list = list();
+    }
+    return Array.isArray(list) ? list.filter(Boolean) : [];
+  };
 
   // Track if an input was focused before the click (for mobile keyboard handling)
   let inputWasFocused = false;
@@ -46,7 +48,8 @@ export function onClickOutside(element, onClick, options = {}) {
       // If click is inside the element, ignore
       if (element.contains(target)) return;
 
-      // If click is inside any ignore element, ignore
+      // If click is inside any ignore element, ignore (evaluated on each click)
+      const ignoreList = resolveIgnoreList();
       for (const ign of ignoreList) {
         if (ign && ign.contains && ign.contains(target)) return;
         if (ign === target) return;


### PR DESCRIPTION
## Summary

- **Fix clickOutside bug**: Evaluate ignore list lazily on each click event, fixing the bug where messages UI closed unexpectedly when clicking the reaction picker (the picker element wasn't in the ignore list at setup time)
- **Refactor ReactionManager for per-user tracking**: Store `Set<userId>` per reaction type instead of simple counts, enabling accurate per-user reaction toggling (future-proofs for group chats)
- **Fix JSON comparison**: Replace `JSON.stringify` comparison with proper object comparison function for conflict detection
- **Maintain backward compatibility**: `removeReaction` without userId removes one arbitrary entry (with debug log)

## Changes

| File | Changes |
|------|---------|
| `src/utils/ui/clickOutside.js` | Lazy ignore list evaluation via `resolveIgnoreList()` |
| `src/messaging/reactions/ReactionManager.js` | Per-user data structure + `getUserReactionType()`, `syncFromRemote()` methods |
| `src/components/messages/messages-ui.js` | Use per-user API, fix JSON comparison |

## Test plan

- [x] All 537 tests pass (Chromium, Firefox, WebKit)
- [x] Build succeeds
- [x] Deployed to Firebase and GitHub Pages
- [ ] Manual: Long-press message → click reaction from picker → messages UI stays open
- [ ] Manual: Double-tap toggles only current user's reaction
- [ ] Manual: Both users can add reactions to same message independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message reaction tracking to properly associate reactions with individual users and maintain accurate, real-time synchronization across conversations.
  * Enhanced click-outside detection mechanism for more reliable handling of dynamic UI elements and consistent dismissal of popups and modals.

* **Improvements**
  * Optimized reaction state management for better performance and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->