### PR TITLE
fix: stop ringtone when caller cancels before callee accepts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -814,6 +814,11 @@ export function listenForIncomingOnRoom(roomId) {
     const data =
       snapshot && typeof snapshot.val === 'function' ? snapshot.val() : null;
     if (!data) return;
+
+    // Stop ringtone and visual indicators when call is cancelled
+    ringtoneManager.stop();
+    callIndicators.stopCallIndicators();
+
     try {
       const { dismissActiveConfirmDialog } =
         await import('./components/base/confirm-dialog.js');
@@ -1553,7 +1558,6 @@ CallController.on('memberLeft', ({ memberId }) => {
   console.info('Partner has left the call');
 });
 
-
 // Business logic for cleanup (UI handled in bind-call-ui.js)
 CallController.on(
   'cleanup',
@@ -1565,10 +1569,10 @@ CallController.on(
       role,
       wasConnected,
     });
-    
-  // UI cleanup
-  // hideCallingUI(); // ! Moved to bind-call-ui.js
-  // onCallDisconnected(); // ! Moved to bind-call-ui.js
+
+    // UI cleanup
+    // hideCallingUI(); // ! Moved to bind-call-ui.js
+    // onCallDisconnected(); // ! Moved to bind-call-ui.js
 
     // UI cleanup
     // hideCallingUI(); // ! Moved to bind-call-ui.js


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Incoming call cancellations now immediately stop the ringtone and dismiss all call indicators, preventing leftover audio or visual notifications from persisting.

* **New Features**
  * Missed call notifications are now automatically sent to saved contacts when incoming calls are not answered, keeping them informed of attempted calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->