### PR TITLE
fix: update Firebase SDK to 12.8.0 in service workers

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -3,10 +3,10 @@
 // This is a static file for dev mode - production uses the bundled version from src/
 
 importScripts(
-  'https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js',
+  'https://www.gstatic.com/firebasejs/12.8.0/firebase-app-compat.js',
 );
 importScripts(
-  'https://www.gstatic.com/firebasejs/9.22.0/firebase-messaging-compat.js',
+  'https://www.gstatic.com/firebasejs/12.8.0/firebase-messaging-compat.js',
 );
 
 // Firebase configuration - hardcoded for dev mode

--- a/src/sw.js
+++ b/src/sw.js
@@ -8,10 +8,10 @@ import { NetworkFirst } from 'workbox-strategies';
 // Import Firebase messaging for service worker context
 // Note: Using compat version for service worker compatibility
 importScripts(
-  'https://www.gstatic.com/firebasejs/10.8.0/firebase-app-compat.js',
+  'https://www.gstatic.com/firebasejs/12.8.0/firebase-app-compat.js',
 );
 importScripts(
-  'https://www.gstatic.com/firebasejs/10.8.0/firebase-messaging-compat.js',
+  'https://www.gstatic.com/firebasejs/12.8.0/firebase-messaging-compat.js',
 );
 
 // ============================================================================


### PR DESCRIPTION
Match CDN version with npm package to prevent FCM compatibility issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firebase SDK dependencies to version 12.8.0 for improved compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->