### PR TITLE
feat: add message push notifications and refactor FCM helpers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,5 +16,21 @@
     "source": "functions",
     "runtime": "nodejs20",
     "region": "europe-west1"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "database": {
+      "port": 9000
+    },
+    "functions": {
+      "port": 5001
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
   }
 }

--- a/src/components/auth/AuthComponent.js
+++ b/src/components/auth/AuthComponent.js
@@ -61,11 +61,6 @@ export const initializeAuthUI = (parentElement, gapBetweenBtns = null) => {
   const initialLoggedIn = isLoggedIn();
   devDebug('[AuthComponent] Initial logged-in state:', initialLoggedIn);
 
-  // DEV-only: Delete Account button is for dev/testing. Will be properly integrated into settings UI later.
-  const deleteAccountBtn = isDev()
-    ? '<button id="delete-account-btn" class="delete-account-btn" style="display: none" onclick="handleDeleteAccount">Delete Account</button>'
-    : '';
-
   authComponent = createComponent({
     initialProps: {
       isLoggedIn: initialLoggedIn,
@@ -82,7 +77,7 @@ export const initializeAuthUI = (parentElement, gapBetweenBtns = null) => {
     template: `
       <button style="margin-right: [[loginBtnMarginRightPx]]px; display: [[loginBtnDisplay]]" id="goog-login-btn" class="login-btn" onclick="handleLogin">Login</button>
       <button style="display: [[logoutBtnDisplay]]" id="goog-logout-btn" class="logout-btn" onclick="handleLogout">Logout</button>
-      [[deleteAccountBtn]]
+      ${isDev() ? '<button id="delete-account-btn" class="delete-account-btn" onclick="handleDeleteAccount">Delete Account</button>' : ''}
       <span class="signing-in-indicator" style="display: [[signingInDisplay]]; color: var(--text-secondary, #888); font-size: 0.9rem;">Signing in...</span>
       <div class="user-info" style="display: [[userInfoDisplay]]">
         <img src="[[userPhotoURL]]" alt="[[userName]]" class="user-avatar" style="display: [[userPhotoDisplay]]" />

--- a/src/notifications/push-notification-controller.js
+++ b/src/notifications/push-notification-controller.js
@@ -2,6 +2,7 @@
 // Unified notification API with transport abstraction
 
 import { FCMTransport } from './transports/fcm-transport.js';
+import { getLoggedInUserId } from '../firebase/auth.js';
 
 /**
  * PushNotificationController - Core notification API
@@ -463,6 +464,16 @@ export class PushNotificationController {
       '[PushNotificationController] Foreground message received:',
       payload,
     );
+
+    // Ignore notifications about the current user's own actions
+    const senderId = payload?.data?.senderId || payload?.data?.callerId;
+    const currentUserId = getLoggedInUserId();
+    if (senderId && currentUserId && senderId === currentUserId) {
+      console.log(
+        '[PushNotificationController] Ignoring self-notification',
+      );
+      return;
+    }
 
     // Notify callbacks
     this.notificationCallbacks.forEach((callback) => {


### PR DESCRIPTION
- Add sendMessageNotification RTDB trigger for chat message push notifications
- Extract sendFCMToUser shared helper with stale token cleanup
- Refactor sendCallNotification to use shared helper
- Add emulator config to firebase.json
- Simplify push notification setup on auth state change
- Filter out self-notifications in push controller
- Simplify delete account button rendering in AuthComponent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push notifications for new messages in conversations.

* **Bug Fixes**
  * Prevented users from receiving notifications for their own actions.

* **Chores**
  * Simplified push notification permission handling.
  * Refactored token management for improved maintainability.
  * Updated local development emulator configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->