### PR TITLE
Restore workbox-window dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@sentry/browser": "^10.36.0",
     "dexie": "^4.2.1",
     "firebase": "^12.8.0",
+    "workbox-window": "^7.4.0",
     "zod": "^4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       firebase:
         specifier: ^12.8.0
         version: 12.8.0
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
vite-plugin-pwa with registerType: 'autoUpdate' requires workbox-window as a peer dependency for the virtual:pwa-register module to function properly. The previous removal was incorrect as it broke the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added workbox-window (v7.4.0) as a runtime dependency to enhance application capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->