### PR TITLE
replace roomId-based contact lookups with userId key lookups

### DIFF
--- a/src/components/contacts/contacts.js
+++ b/src/components/contacts/contacts.js
@@ -162,7 +162,7 @@ export async function resolveCallerName(userId, roomId) {
     if (roomId) {
       for (const contact of Object.values(contacts || {})) {
         if (contact?.roomId === roomId) {
-          return contact.contactName || contact.contactId || userId;
+          return contact.contactName || contact.contactId || 'Unknown'; // userId;
         }
       }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -94,7 +94,7 @@ import {
 } from './contacts/referral-handler.js';
 
 import {
-  getContactByRoomId,
+  getContactById,
   saveContactData,
   updateLastInteraction,
 } from './components/contacts/contacts.js';
@@ -831,7 +831,7 @@ export function listenForIncomingOnRoom(roomId) {
         );
 
         // Resolve caller name from contacts
-        const callerName = await resolveCallerName(roomId, joiningUserId);
+        const callerName = await resolveCallerName(joiningUserId, roomId);
 
         // Start incoming call ringtone and visual indicators
         ringtoneManager.playIncoming();
@@ -970,7 +970,8 @@ export function listenForIncomingOnRoom(roomId) {
     // UNLESS it is a saved contact - then we want to keep listening
     let savedContact = null;
     try {
-      savedContact = await getContactByRoomId(roomId);
+      const callerId = data.by;
+      savedContact = callerId ? await getContactById(callerId) : null;
     } catch (e) {
       console.warn('[LISTENER] Failed to check saved contact:', e);
     }
@@ -1004,7 +1005,7 @@ export function listenForIncomingOnRoom(roomId) {
       if (!status.hasMembers) {
         await removeRecentCall(roomId);
 
-        const savedContact = await getContactByRoomId(roomId);
+        const savedContact = await getContactById(leavingUserId);
         if (!savedContact) {
           removeIncomingListenersForRoom(roomId);
           devDebug(

--- a/src/notifications/push-notification-controller.js
+++ b/src/notifications/push-notification-controller.js
@@ -621,7 +621,7 @@ export class PushNotificationController {
         // Import resolveCallerName dynamically to avoid circular dependencies
         const { resolveCallerName } =
           await import('../components/contacts/contacts.js');
-        displayName = await resolveCallerName(roomId, callerId);
+        displayName = await resolveCallerName(callerId, roomId);
       } catch (error) {
         console.warn(
           '[PushNotificationController] Failed to resolve caller name:',

--- a/tests/unit/contact-lookups.test.js
+++ b/tests/unit/contact-lookups.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'firebase/database';
+
+// Mock all heavy dependencies so we only test lookup logic
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(),
+  set: vi.fn(),
+  get: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+  onValue: vi.fn(),
+  off: vi.fn(),
+}));
+vi.mock('../../src/storage/fb-rtdb/rtdb.js', () => ({ rtdb: {} }));
+vi.mock('../../src/firebase/auth.js', () => ({
+  getLoggedInUserId: vi.fn(() => 'my-uid'),
+  getCurrentUser: vi.fn(),
+}));
+vi.mock('../../src/components/calling/calling-ui.js', () => ({
+  hideCallingUI: vi.fn(),
+  showCallingUI: vi.fn(),
+}));
+vi.mock('../../src/components/base/confirm-dialog.js', () => ({
+  default: vi.fn(),
+}));
+vi.mock('../../src/utils/ui/ui-utils.js', () => ({
+  hideElement: vi.fn(),
+  showElement: vi.fn(),
+}));
+vi.mock('../../src/messaging/messaging-controller.js', () => ({
+  messagingController: {},
+}));
+vi.mock('../../src/components/messages/messages-ui.js', () => ({
+  messagesUI: {},
+}));
+vi.mock('../../src/components/messages/createMessageToggle.js', () => ({
+  createMessageToggle: vi.fn(),
+}));
+vi.mock('../../src/utils/room-id.js', () => ({
+  getDeterministicRoomId: vi.fn(),
+}));
+vi.mock('../../src/notifications/push-notification-controller.js', () => ({
+  pushNotificationController: {},
+}));
+
+import {
+  getContactByRoomId,
+  getContactById,
+  resolveCallerName,
+} from '../../src/components/contacts/contacts.js';
+
+const MOCK_CONTACTS = {
+  'user-alice': {
+    contactId: 'user-alice',
+    contactName: 'Alice',
+    roomId: 'room-abc',
+    savedAt: 1000,
+  },
+  'user-bob': {
+    contactId: 'user-bob',
+    contactName: 'Bob',
+    roomId: 'room-xyz',
+    savedAt: 2000,
+  },
+};
+
+beforeEach(() => {
+  // getContacts() calls Firebase get() when logged in
+  get.mockResolvedValue({
+    exists: () => true,
+    val: () => MOCK_CONTACTS,
+  });
+});
+
+// ── getContactByRoomId (current behavior) ──
+
+describe('getContactByRoomId', () => {
+  it('finds contact by roomId', async () => {
+    const result = await getContactByRoomId('room-abc');
+    expect(result).toEqual(MOCK_CONTACTS['user-alice']);
+  });
+
+  it('returns null for unknown roomId', async () => {
+    const result = await getContactByRoomId('room-unknown');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for falsy roomId', async () => {
+    expect(await getContactByRoomId(null)).toBeNull();
+    expect(await getContactByRoomId('')).toBeNull();
+  });
+});
+
+// ── getContactById (new helper) ──
+
+describe('getContactById', () => {
+  it('finds contact by userId (direct key)', async () => {
+    const result = await getContactById('user-alice');
+    expect(result).toEqual(MOCK_CONTACTS['user-alice']);
+  });
+
+  it('returns null for unknown userId', async () => {
+    const result = await getContactById('user-unknown');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for falsy userId', async () => {
+    expect(await getContactById(null)).toBeNull();
+    expect(await getContactById('')).toBeNull();
+  });
+});
+
+// ── resolveCallerName (new signature: (userId, roomId)) ──
+
+describe('resolveCallerName', () => {
+  it('resolves name by userId (direct key lookup)', async () => {
+    const name = await resolveCallerName('user-alice');
+    expect(name).toBe('Alice');
+  });
+
+  it('falls back to roomId scan when userId not in contacts', async () => {
+    const name = await resolveCallerName('user-unknown', 'room-abc');
+    expect(name).toBe('Alice');
+  });
+
+  it('returns userId when neither lookup matches', async () => {
+    const name = await resolveCallerName('user-unknown', 'room-unknown');
+    expect(name).toBe('user-unknown');
+  });
+
+  it('returns userId when no roomId provided', async () => {
+    const name = await resolveCallerName('user-unknown');
+    expect(name).toBe('user-unknown');
+  });
+
+  it('returns "Unknown" when no userId and no roomId', async () => {
+    const name = await resolveCallerName(null, null);
+    expect(name).toBe('Unknown');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `getContactById()` for O(1) direct key lookup (contacts are keyed by userId)
- Refactor `resolveCallerName(userId, roomId)` to try userId first, fall back to roomId scan
- Switch cancel handler and member-left handler from `getContactByRoomId` to `getContactById`
- Update `push-notification-controller.js` call site for new signature
- Add unit tests for all contact lookup functions

## Notes
- Missed call site (`main.js:~1838`) still uses `getContactByRoomId` via dynamic import — it lacks a contactId in the cleanup event payload and needs the call state plumbed through CallController
- `getContactByRoomId` is kept for that fallback and for any legacy contact data

## Test plan
- [x] All 254 existing tests pass
- [x] New tests cover getContactById, getContactByRoomId, resolveCallerName
- [ ] Manual: incoming call shows correct contact name
- [ ] Manual: cancel/leave preserves listener for saved contacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved contact lookup and name-resolution so incoming caller names are more reliably displayed and fall back sensibly when contacts are missing.
  * Adjusted lookup order and handling to reduce incorrect or unknown caller labels.

* **Tests**
  * Added unit tests covering contact lookup and caller-name resolution across various edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->