### PR TITLE
fix: Google Contacts import fails on Samsung mobile

### DIFF
--- a/src/components/contacts/add-contact-modal.js
+++ b/src/components/contacts/add-contact-modal.js
@@ -75,7 +75,6 @@ export async function showAddContactModal() {
     );
     const platformBtns = dialog.querySelectorAll('.platform-btn');
 
-    let currentPlatform = 'google';
     let allContacts = [];
     let filteredContacts = [];
     const selectedContacts = new Set();
@@ -99,8 +98,6 @@ export async function showAddContactModal() {
         // Update active state
         platformBtns.forEach((b) => b.classList.remove('active'));
         btn.classList.add('active');
-
-        currentPlatform = platform;
 
         // Import contacts for selected platform
         if (platform === 'google') {
@@ -134,7 +131,8 @@ export async function showAddContactModal() {
       );
     });
 
-    // Import Google Contacts function
+    // Import Google Contacts function — must be called from a user click
+    // so the browser allows the OAuth popup on mobile.
     async function importGoogleContacts() {
       importStatus.textContent = t('contact.import.requesting');
       importStatus.className = 'import-status loading';
@@ -143,8 +141,8 @@ export async function showAddContactModal() {
       filteredContacts = [];
 
       try {
-        // Step 1: Get access token
-        const accessToken = await requestContactsAccess();
+        // Step 1: Get access token (interactive to preserve user gesture)
+        const accessToken = await requestContactsAccess({ interactive: true });
 
         importStatus.textContent = t('contact.import.fetching');
 
@@ -241,11 +239,6 @@ export async function showAddContactModal() {
 
     document.body.appendChild(dialog);
     dialog.showModal();
-
-    // Auto-trigger import for the default active platform
-    if (currentPlatform === 'google') {
-      importGoogleContacts();
-    }
   });
 }
 

--- a/src/firebase/auth.js
+++ b/src/firebase/auth.js
@@ -649,13 +649,17 @@ function requestGISToken(cacheKey, scope, { interactive = false } = {}) {
 
 /**
  * Request Google Contacts access via Google Identity Services Token Model.
- * Uses silent-first flow (works without popup after initial consent).
+ * @param {Object} [options]
+ * @param {boolean} [options.interactive] - Skip silent attempt and go straight
+ *   to popup. Use when called from a click handler to preserve the user-gesture
+ *   context (mobile browsers block popups without a gesture).
  * @returns {Promise<string>} - Google access token with contacts scope
  */
-export function requestContactsAccess() {
+export function requestContactsAccess({ interactive = false } = {}) {
   return requestGISToken(
     'contacts',
     'https://www.googleapis.com/auth/contacts.readonly https://www.googleapis.com/auth/contacts.other.readonly',
+    { interactive },
   );
 }
 


### PR DESCRIPTION
## Summary

- On Samsung mobile, opening the add-contact modal immediately showed "Failed to load contacts" / "Import cancelled" because the OAuth popup was blocked
- Root cause: `dialog.showModal()` consumed the user activation, then the auto-triggered silent OAuth attempt failed and the async fallback to an interactive popup had no gesture context left — mobile browsers block it
- Fix: remove auto-trigger on modal open, require explicit tap on Google button, use `interactive: true` to go straight to popup (preserving gesture context)

## Test plan

- [ ] Open add-contact modal on Samsung mobile (Chrome / Samsung Internet) — should show empty state, not an error
- [ ] Tap Google button — OAuth popup should open normally
- [ ] Verify desktop flow still works (tap Google button, consent popup appears)
- [ ] Returning users with prior consent: popup flashes briefly then contacts load (acceptable tradeoff vs broken mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Contacts import now requires explicit user action (button click) instead of automatically triggering when opening the add contact modal.
  * Platform selection must be explicitly made via the UI before importing contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->