### PR TITLE
Replace Font Awesome CDN with local npm package

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,6 @@
     <title>HangVidU</title>
     <link rel="stylesheet" href="/src/styles/main.css" />
     <link rel="icon" href="/favicon.ico" />
-    <!-- Font Awesome CDN - using CDN for easy icon library replacement -->
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
-      integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
   </head>
   <body>
     <div id="app" class="main-wrapper">

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "workbox-strategies": "^7.4.0"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^7.2.0",
     "@sentry/browser": "^10.38.0",
     "dexie": "^4.3.0",
     "firebase": "^12.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fortawesome/fontawesome-free':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@sentry/browser':
         specifier: ^10.38.0
         version: 10.38.0
@@ -985,6 +988,10 @@ packages:
 
   '@firebase/webchannel-wrapper@1.0.5':
     resolution: {integrity: sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==}
+
+  '@fortawesome/fontawesome-free@7.2.0':
+    resolution: {integrity: sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==}
+    engines: {node: '>=6'}
 
   '@grpc/grpc-js@1.9.15':
     resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
@@ -4226,6 +4233,8 @@ snapshots:
       tslib: 2.8.1
 
   '@firebase/webchannel-wrapper@1.0.5': {}
+
+  '@fortawesome/fontawesome-free@7.2.0': {}
 
   '@grpc/grpc-js@1.9.15':
     dependencies:

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@
 // HANGVIDU - P2P VIDEO CHAT WITH WATCH-TOGETHER MODE
 // ============================================================================
 
+import '@fortawesome/fontawesome-free/css/all.min.css';
 import './initSentry.js';
 import { set, get, remove } from 'firebase/database';
 import {


### PR DESCRIPTION
## Summary
- Removes Font Awesome CDN `<link>` from `index.html`
- Installs `@fortawesome/fontawesome-free` as a local dependency
- Imports it in `src/main.js` so Vite bundles the webfonts with the app

## Why
Icons loaded from `cdnjs.cloudflare.com` were slow or missing in some environments due to CDN latency, network conditions, or offline use (PWA). Icons now load from bundled local files with no external dependency.

## Test plan
- [ ] Test in offline/PWA mode — icons should still load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Font Awesome to version 7.2.0 with package-based asset distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->