### PR TITLE
Fix contacts list sort order inconsistency

### DIFF
--- a/src/components/contacts/contacts.js
+++ b/src/components/contacts/contacts.js
@@ -24,7 +24,11 @@ function getSortedContactIds(contacts) {
   return Object.keys(contacts).sort((a, b) => {
     const aTime = contacts[a]?.lastInteractionAt || contacts[a]?.savedAt || 0;
     const bTime = contacts[b]?.lastInteractionAt || contacts[b]?.savedAt || 0;
-    return bTime - aTime;
+    if (aTime !== bTime) return bTime - aTime;
+    // Alphabetical by display name when timestamps are equal
+    const aName = (contacts[a]?.contactName || '').toLowerCase();
+    const bName = (contacts[b]?.contactName || '').toLowerCase();
+    return aName.localeCompare(bName);
   });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -2008,6 +2008,9 @@ CallController.on(
     cleanupRemoteStream();
     clearUrlParam();
 
+    // Re-render contacts list so sort order reflects updated lastInteractionAt
+    renderContactsList(lobbyDiv).catch(() => {});
+
     // Re-attach incoming listener so the next call on this room is detected
     if (roomId && reason !== 'page_unload') {
       listenForIncomingOnRoom(roomId);


### PR DESCRIPTION
## Summary
- Contacts with equal `lastInteractionAt` timestamps now fall back to alphabetical sort by display name instead of non-deterministic RTDB key order
- Contacts list re-renders on call cleanup so the most recently interacted contact moves to the top immediately when returning to lobby (previously `updateLastInteraction` was fire-and-forget with no subsequent re-render)

## Test plan
- [ ] Call a contact that isn't first in the list, verify it moves to top after hangup
- [ ] Add two contacts without calling either, verify they appear in alphabetical order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact sorting to use alphabetical ordering (case-insensitive) as a secondary tie-breaker when interaction times are equal.
  * Contact list now updates immediately after calls end to reflect the latest interaction times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->