### PR TITLE
Decouple push notifications via command bus

### DIFF
--- a/docs/WIP_Architecture/BOUNDARY_ROLLOUT_STATUS.md
+++ b/docs/WIP_Architecture/BOUNDARY_ROLLOUT_STATUS.md
@@ -54,15 +54,15 @@ TODO Add:
 
 Command: `BOUNDARIES_ENFORCE_ALL=1 pnpm lint:boundaries`
 
-Snapshot: 2026-04-07
+Snapshot: 2026-04-10
 
-Total failures: `18`
+Total failures: `17`
 
 ### Failure categories
 
 - `feature -> feature`: `16`
 - `feature -> app`: `1`
-- `auth -> feature`: `1`
+- `auth -> feature`: `0`
 - `setup/*` failures: `0`
 
 ### `feature -> feature` by importing feature
@@ -71,18 +71,16 @@ Total failures: `18`
 - `messaging`: `2`
 - `watch`: `2`
 - `notifications`: `1`
-- `push-notifications`: `1`
 
 ### Current failing files
 
-- `src/auth/auth-actions.js` (1)
 - `src/features/call/WIP-start-call-refactor.js` (3)
 - `src/features/call/call-controller.js` (3)
 - `src/features/call/call-event-wiring.js` (3)
 - `src/features/call/room-listeners.js` (2)
 - `src/features/messaging/components/messages-ui.js` (1)
 - `src/features/messaging/handle-appbus-events.js` (1)
+- `src/features/messaging/messaging-controller.js` (1)
 - `src/features/notifications/components/enable-notifications-prompt.js` (1)
-- `src/features/push-notifications/push-notifications.js` (1)
 - `src/features/watch/watch-file-handler.js` (1)
 - `src/features/watch/watch-sync.js` (1)

--- a/docs/WIP_Architecture/HANDOFF.md
+++ b/docs/WIP_Architecture/HANDOFF.md
@@ -41,6 +41,10 @@ Completed in this branch:
 - removed direct `contacts -> messaging` import for conversation id helpers
 - added app-level notification projection in `src/setup/setupNotificationsHandlers.js`
 - changed `contacts` invite/referral flows to publish notification facts instead of importing notifications directly
+- decoupled push notifications from direct `auth`/`contacts` imports by routing through shared commands:
+  - `auth:cloud-function:call`
+  - `contacts:get-by-room-id`
+  - `push:disable`
 - replaced `setupMainAuthAppBusListeners` with `setupAuth` in `src/setup/setupAuth.js`:
   - setup is setup-layer-owned and idempotent
   - auth listeners are registered before `initAuth()` runs

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -12,10 +12,12 @@ Current ownership:
 - backend delivery logic lives under [functions/push-notifications](../functions/push-notifications)
 - service worker push handling lives under [src/features/push-notifications/sw](../src/features/push-notifications/sw)
 - in-app UI notifications remain separate under [src/features/notifications](../src/features/notifications)
+- cross-module lookups/calls are routed through shared commands instead of direct feature/auth imports
 
 Current behavior:
 
 - outgoing calls send push through the authenticated `sendCallNotification` function
+- runtime cloud-function transport is requested through auth-owned command handling (`auth:cloud-function:call`)
 - missed calls reuse the same call notification identity so the missed-call notification can replace the ringing notification for the same call attempt
 - message notifications are backend-driven from the RTDB trigger
 - when the app already has a visible focused window, native notification display is suppressed

--- a/eslint.boundaries.config.js
+++ b/eslint.boundaries.config.js
@@ -22,21 +22,6 @@ const ENFORCE_ALL = envEnabled('BOUNDARIES_ENFORCE_ALL', false);
 const ALL_FEATURES = discoverFeatures();
 const ALL_FEATURES_SET = new Set(ALL_FEATURES);
 
-// Boundary rollout (keep this short and practical):
-// - normal incremental mode: `pnpm lint:boundaries`
-// - hotspot scan (all rules + all features): `BOUNDARIES_ENFORCE_ALL=1 pnpm lint:boundaries`
-// - single-rule drill-down examples:
-//   - `BOUNDARIES_AUTH=1 pnpm lint:boundaries`
-//   - `BOUNDARIES_APP=1 pnpm lint:boundaries`
-//   - `BOUNDARIES_SETUP=1 pnpm lint:boundaries`
-// - specific feature set: `BOUNDARIES_ENFORCED_FEATURES=contacts,messaging pnpm lint:boundaries`
-const ENABLE_RULE = {
-  shared: envEnabled('BOUNDARIES_SHARED', true),
-  auth: envEnabled('BOUNDARIES_AUTH', true),
-  app: envEnabled('BOUNDARIES_APP', ENFORCE_ALL),
-  setup: envEnabled('BOUNDARIES_SETUP', ENFORCE_ALL),
-};
-
 // Incremental feature rollout:
 // - default: only what is already enforced + current WIP
 // - BOUNDARIES_ENFORCE_ALL=1: all discovered features
@@ -58,11 +43,30 @@ if (requestedFeatures) {
   }
 }
 
+// ____________________________________
+
+// Boundary rollout (incremental rules — modify freely):
+// - normal incremental mode: `pnpm lint:boundaries`
+// - hotspot scan (all rules + all features): `BOUNDARIES_ENFORCE_ALL=1 pnpm lint:boundaries`
+// - single-rule drill-down examples:
+//   - `BOUNDARIES_AUTH=1 pnpm lint:boundaries`
+//   - `BOUNDARIES_APP=1 pnpm lint:boundaries`
+//   - `BOUNDARIES_SETUP=1 pnpm lint:boundaries`
+// - specific feature set: `BOUNDARIES_ENFORCED_FEATURES=contacts,messaging pnpm lint:boundaries`
+
+const ENABLE_RULE = {
+  shared: envEnabled('BOUNDARIES_SHARED', true),
+  auth: envEnabled('BOUNDARIES_AUTH', true),
+  app: envEnabled('BOUNDARIES_APP', ENFORCE_ALL),
+  setup: envEnabled('BOUNDARIES_SETUP', ENFORCE_ALL),
+};
+
 const ENFORCED_FEATURES = requestedFeatures
   ? requestedFeatures
   : ENFORCE_ALL
     ? ALL_FEATURES
-    : ['contacts'];
+    : ['contacts', 'push-notifications'];
+
 const SHARED_TEMP_FEATURE_EXCEPTIONS = [
   'call',
   'messaging',

--- a/src/auth/auth-actions.js
+++ b/src/auth/auth-actions.js
@@ -10,7 +10,7 @@ import {
   signInWithGooglePopup,
   signOutFirebaseUser,
 } from './adapters/firebase-auth-adapter.js';
-import { dispatchCommandAndAwait } from '../events/index.js';
+import { dispatchCommand, dispatchCommandAndAwait } from '../events/index.js';
 import { t } from '../i18n/index.js';
 import { devDebug } from '../utils/dev/dev-utils.js';
 import { callCloudFunction } from './cloud-functions.js';
@@ -135,11 +135,7 @@ export async function signOutUser() {
 
   try {
     // Disable notifications and unregister the current Web Push subscription - Fire and forget
-    getPushNotifications()
-      ?.disable?.()
-      .catch((err) => {
-        console.warn('[AUTH] Failed to disable notifications on logout:', err);
-      });
+    dispatchCommand('push:disable', { reason: 'auth:signout' });
 
     await dispatchCommandAndAwait('user:presence:set-offline', {
       userId: auth.currentUser?.uid,

--- a/src/auth/auth-actions.js
+++ b/src/auth/auth-actions.js
@@ -10,10 +10,9 @@ import {
   signInWithGooglePopup,
   signOutFirebaseUser,
 } from './adapters/firebase-auth-adapter.js';
-import { dispatchCommand, dispatchCommandAndAwait } from '../events/index.js';
+import { dispatchCommandAndAwait } from '../events/index.js';
 import { t } from '../i18n/index.js';
 import { devDebug } from '../utils/dev/dev-utils.js';
-import { getPushNotifications } from '../features/push-notifications/index.js';
 import { callCloudFunction } from './cloud-functions.js';
 import {
   detectIOSStandalone,

--- a/src/auth/auth-command-listeners.js
+++ b/src/auth/auth-command-listeners.js
@@ -1,6 +1,7 @@
 import { handleCommand } from '../events/index.js';
 import {
   AUTH_COMMANDS,
+  parseAuthCloudFunctionCall,
   parseAuthDeleteAccountRequested,
   parseAuthLoginRequested,
   parseAuthLogoutRequested,
@@ -10,6 +11,7 @@ import {
   signInWithAccountSelection,
   signOutUser,
 } from './auth-actions.js';
+import { callCloudFunction } from './cloud-functions.js';
 
 let cleanupAuthCommandListeners = null;
 
@@ -54,6 +56,20 @@ export function setupAuthCommandListeners() {
         await deleteAccount({ scrubMessages: request.scrubMessages });
       } catch (e) {
         console.warn('[auth] delete-account command failed:', e);
+      }
+    },
+    { signal: ac.signal },
+  );
+
+  handleCommand(
+    AUTH_COMMANDS.CLOUD_FUNCTION_CALL,
+    async (payload) => {
+      try {
+        const request = parseAuthCloudFunctionCall(payload);
+        return await callCloudFunction(request.functionName, request.body);
+      } catch (e) {
+        console.warn('[auth] cloud-function command failed:', e);
+        throw e;
       }
     },
     { signal: ac.signal },

--- a/src/auth/auth-events-schema.js
+++ b/src/auth/auth-events-schema.js
@@ -4,6 +4,7 @@ export const AUTH_COMMANDS = {
   LOGIN_REQUESTED: 'auth:login-requested',
   LOGOUT_REQUESTED: 'auth:logout-requested',
   DELETE_ACCOUNT_REQUESTED: 'auth:delete-account-requested',
+  CLOUD_FUNCTION_CALL: 'auth:cloud-function:call',
 };
 
 const AuthCommandSourceSchema = z.literal('auth-ui');
@@ -21,6 +22,11 @@ export const AuthDeleteAccountRequestedSchema = z.object({
   scrubMessages: z.boolean(),
 });
 
+export const AuthCloudFunctionCallSchema = z.object({
+  functionName: z.string().min(1),
+  body: z.unknown().optional(),
+});
+
 export function parseAuthLoginRequested(data) {
   return AuthLoginRequestedSchema.parse(data);
 }
@@ -31,4 +37,8 @@ export function parseAuthLogoutRequested(data) {
 
 export function parseAuthDeleteAccountRequested(data) {
   return AuthDeleteAccountRequestedSchema.parse(data);
+}
+
+export function parseAuthCloudFunctionCall(data) {
+  return AuthCloudFunctionCallSchema.parse(data);
 }

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -24,7 +24,12 @@ Use this `src/events/` layer to define app semantics (`command` vs `event`) and 
 
 - Do not import `appBus` outside `src/events/`.
 - Commands ask for work; published events announce facts.
-- Prefer one clear command handler per command name.
+- Commands must have exactly one handler per command name.
+- `dispatchCommandAndAwait()` is command-RPC:
+  - throws when there is no handler
+  - throws when there is more than one handler
+  - throws when the handler throws/rejects
+  - returns the single handler result
 - If async bus behavior is needed, add it to `src/events/index.js` instead of importing `appBus` directly.
 
 ## Naming Guidance

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -11,6 +11,28 @@ import { EventEmitter } from '../lib/event-emitter/event-emitter.js';
  */
 const appBus = new EventEmitter();
 
+function getCommandHandlerCount(commandName) {
+  return appBus.listenerCount(commandName);
+}
+
+function assertExactlyOneCommandHandler(commandName) {
+  const handlerCount = getCommandHandlerCount(commandName);
+
+  if (handlerCount === 1) {
+    return;
+  }
+
+  if (handlerCount === 0) {
+    throw new Error(
+      `[events] Command "${commandName}" has no registered handler`,
+    );
+  }
+
+  throw new Error(
+    `[events] Command "${commandName}" has ${handlerCount} handlers (expected exactly 1)`,
+  );
+}
+
 /**
  * Send a command to the responsible handler
  *
@@ -18,6 +40,7 @@ const appBus = new EventEmitter();
  * @param {Object} [payload={}] - Command data
  */
 const dispatchCommand = (commandName, payload = {}) => {
+  assertExactlyOneCommandHandler(commandName);
   appBus.emit(commandName, payload);
 };
 
@@ -27,10 +50,31 @@ const dispatchCommand = (commandName, payload = {}) => {
  *
  * @param {string} commandName - Command name
  * @param {Object} [payload={}] - Command data
- * @returns {Promise<void>}
+ * Enforced semantics:
+ * - exactly one handler must be registered for this command
+ * - rejects if handler throws/rejects
+ * - resolves with the single handler's return value
+ *
+ * @returns {Promise<unknown>}
  */
 const dispatchCommandAndAwait = async (commandName, payload = {}) => {
-  await appBus.emitAsync(commandName, payload);
+  assertExactlyOneCommandHandler(commandName);
+
+  const settled = await appBus.emitAsync(commandName, payload, {
+    returnSettled: true,
+  });
+
+  const first = settled?.[0];
+  if (!first) {
+    throw new Error(
+      `[events] Command "${commandName}" did not produce a handler result`,
+    );
+  }
+  if (first.status === 'rejected') {
+    throw first.reason;
+  }
+
+  return first.value;
 };
 
 /**
@@ -38,10 +82,16 @@ const dispatchCommandAndAwait = async (commandName, payload = {}) => {
  * before moving to the next.
  *
  * @param {Array<[string, any]>} commands - Array of [commandName, payload] tuples
- * @returns {Promise<void>}
+ * @returns {Promise<unknown[]>}
  */
 const dispatchCommandAndAwaitSequential = async (commands) => {
-  await appBus.emitAsyncSequential(commands);
+  const results = [];
+
+  for (const [commandName, payload] of commands) {
+    results.push(await dispatchCommandAndAwait(commandName, payload));
+  }
+
+  return results;
 };
 
 /**

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -11,6 +11,8 @@ import { EventEmitter } from '../lib/event-emitter/event-emitter.js';
  */
 const appBus = new EventEmitter();
 
+// TODO(events): Isolate command listeners from event subscribers (e.g. namespaced topic or dedicated bus).
+
 function getCommandHandlerCount(commandName) {
   return appBus.listenerCount(commandName);
 }

--- a/src/events/index.test.js
+++ b/src/events/index.test.js
@@ -49,7 +49,9 @@ describe('src/events/index.js', () => {
       const handler = vi.fn();
       const unsub = handleCommand(name, handler);
       unsub();
-      dispatchCommand(name, {});
+      expect(() => dispatchCommand(name, {})).toThrow(
+        `Command "${name}" has no registered handler`,
+      );
       expect(handler).not.toHaveBeenCalled();
     });
 
@@ -59,8 +61,28 @@ describe('src/events/index.js', () => {
       const handler = vi.fn();
       handleCommand(name, handler, { signal: ac.signal });
       ac.abort();
-      dispatchCommand(name, {});
+      expect(() => dispatchCommand(name, {})).toThrow(
+        `Command "${name}" has no registered handler`,
+      );
       expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('throws when no command handler is registered', () => {
+      const name = uniqueName('dispatch-no-handler');
+      expect(() => dispatchCommand(name, {})).toThrow(
+        `Command "${name}" has no registered handler`,
+      );
+    });
+
+    it('throws when more than one command handler is registered', () => {
+      const name = uniqueName('dispatch-multi-handler');
+      const ac = new AbortController();
+      handleCommand(name, () => {}, { signal: ac.signal });
+      handleCommand(name, () => {}, { signal: ac.signal });
+      expect(() => dispatchCommand(name, {})).toThrow(
+        `Command "${name}" has 2 handlers`,
+      );
+      ac.abort();
     });
   });
 
@@ -76,10 +98,12 @@ describe('src/events/index.js', () => {
         async () => {
           await new Promise((res) => setTimeout(res, 5));
           resolved = true;
+          return 'ok';
         },
         { signal: ac.signal },
       );
-      await dispatchCommandAndAwait(name, {});
+      const result = await dispatchCommandAndAwait(name, {});
+      expect(result).toBe('ok');
       expect(resolved).toBe(true);
       ac.abort();
     });
@@ -94,18 +118,39 @@ describe('src/events/index.js', () => {
       ac.abort();
     });
 
-    it('resolves even when handler throws (error logged, not rethrown)', async () => {
+    it('rejects when handler throws', async () => {
       const name = uniqueName('dispatch-await-error');
       const ac = new AbortController();
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      handleCommand(name, async () => { throw new Error('handler error'); }, { signal: ac.signal });
-      try {
-        await expect(dispatchCommandAndAwait(name, {})).resolves.toBeUndefined();
-        expect(consoleSpy).toHaveBeenCalled();
-      } finally {
-        consoleSpy.mockRestore();
-        ac.abort();
-      }
+      handleCommand(
+        name,
+        async () => {
+          throw new Error('handler error');
+        },
+        { signal: ac.signal },
+      );
+      await expect(dispatchCommandAndAwait(name, {})).rejects.toThrow(
+        'handler error',
+      );
+      ac.abort();
+    });
+
+    it('rejects when no command handler is registered', async () => {
+      const name = uniqueName('dispatch-await-no-handler');
+      await expect(dispatchCommandAndAwait(name, {})).rejects.toThrow(
+        `Command "${name}" has no registered handler`,
+      );
+    });
+
+    it('rejects when more than one command handler is registered', async () => {
+      const name = uniqueName('dispatch-await-multi-handler');
+      const ac = new AbortController();
+      handleCommand(name, async () => 'first', { signal: ac.signal });
+      handleCommand(name, async () => 'second', { signal: ac.signal });
+
+      await expect(dispatchCommandAndAwait(name, {})).rejects.toThrow(
+        `Command "${name}" has 2 handlers`,
+      );
+      ac.abort();
     });
   });
 
@@ -157,15 +202,15 @@ describe('src/events/index.js', () => {
       ac.abort();
     });
 
-    it('resolves with undefined when no handlers registered', async () => {
+    it('rejects when a command has no registered handler', async () => {
       const name = uniqueName('seq-no-handler');
-      await expect(
-        dispatchCommandAndAwaitSequential([[name, {}]]),
-      ).resolves.toBeUndefined();
+      await expect(dispatchCommandAndAwaitSequential([[name, {}]])).rejects.toThrow(
+        `Command "${name}" has no registered handler`,
+      );
     });
 
-    it('resolves for an empty commands array', async () => {
-      await expect(dispatchCommandAndAwaitSequential([])).resolves.toBeUndefined();
+    it('resolves for an empty commands array with empty results', async () => {
+      await expect(dispatchCommandAndAwaitSequential([])).resolves.toEqual([]);
     });
   });
 

--- a/src/features/push-notifications/__tests__/push-notifications.browser.test.js
+++ b/src/features/push-notifications/__tests__/push-notifications.browser.test.js
@@ -1,5 +1,40 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('../../../events/index.js', () => ({
+  dispatchCommandAndAwait: vi.fn(async (commandName, payload = {}) => {
+    if (commandName === 'auth:cloud-function:call') {
+      const response = await fetch(
+        `https://example.com/${payload.functionName ?? ''}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload.body),
+        },
+      );
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const error = new Error(
+          body?.message ||
+            body?.error ||
+            `Function ${payload.functionName} failed with status ${response.status}`,
+        );
+        error.status = response.status;
+        error.payload = body;
+        throw error;
+      }
+      return { status: response.status, payload: body };
+    }
+
+    if (commandName === 'contacts:get-by-room-id') {
+      return null;
+    }
+
+    return undefined;
+  }),
+}));
+
 vi.mock('../../../auth/auth-setup.js', () => ({
   auth: {},
   initAuth: vi.fn(),

--- a/src/features/push-notifications/push-notifications.js
+++ b/src/features/push-notifications/push-notifications.js
@@ -1,9 +1,16 @@
 // Public app-facing push notifications facade.
 
-import { callCloudFunction } from '../../auth/cloud-functions.js';
-import { contactsService } from '../contacts/index.js'; // TODO: move? Check boundries
+import { dispatchCommandAndAwait } from '../../events/index.js';
 
 const PERMISSION_REQUEST_TIMEOUT_MS = 8000;
+const AUTH_CLOUD_FUNCTION_COMMAND = 'auth:cloud-function:call';
+
+async function callCloudFunction(functionName, body) {
+  return dispatchCommandAndAwait(AUTH_CLOUD_FUNCTION_COMMAND, {
+    functionName,
+    body,
+  });
+}
 
 function resolveCallNotificationType(type) {
   if (!type) {
@@ -518,7 +525,9 @@ export class PushNotifications {
 
     if (!callerName) {
       try {
-        const contact = await contactsService.getContactByRoomId(roomId);
+        const contact = await dispatchCommandAndAwait('contacts:get-by-room-id', {
+          roomId,
+        });
         callerLabel = contact?.contactNickName || callerId || 'Unknown caller';
       } catch (error) {
         console.warn(

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -88,9 +88,20 @@ export function setupAuth(options = {}) {
         'auth:logout',
         async () => {
           try {
-            await renderContactsList(lobbyElement);
+            // Disable notifications and unregister the current Web Push subscription - Fire and forget
+            getPushNotifications()
+              ?.disable?.()
+              .catch((err) => {
+                console.warn(
+                  '[AUTH] Failed to disable notifications on logout:',
+                  err,
+                );
+              });
+
             devDebug('[AUTH] User logged out - cleaning up listeners');
             cleanupLoginScopedListeners();
+
+            setTimeout(async () => await renderContactsList(lobbyElement), 5); // Temp fix, rendering will be moved anyways
           } catch (e) {
             console.warn('[AUTH] Failed to handle auth:logout:', e);
           }
@@ -109,13 +120,16 @@ export function setupAuth(options = {}) {
             );
 
             await renderContactsList(lobbyElement).catch((e) =>
-              console.warn('[AUTH] Failed to render contacts list on login:', e),
+              console.warn(
+                '[AUTH] Failed to render contacts list on login:',
+                e,
+              ),
             );
 
             cleanupLoginScopedListeners();
             if (!isInitialResolution) {
-              const maybeSavedRoomsCleanup = await startListeningForSavedRooms()
-                .catch((e) => {
+              const maybeSavedRoomsCleanup =
+                await startListeningForSavedRooms().catch((e) => {
                   console.warn('Failed to re-attach saved-room listeners', e);
                   return undefined;
                 });

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -88,20 +88,10 @@ export function setupAuth(options = {}) {
         'auth:logout',
         async () => {
           try {
-            // Disable notifications and unregister the current Web Push subscription - Fire and forget
-            getPushNotifications()
-              ?.disable?.()
-              .catch((err) => {
-                console.warn(
-                  '[AUTH] Failed to disable notifications on logout:',
-                  err,
-                );
-              });
-
             devDebug('[AUTH] User logged out - cleaning up listeners');
             cleanupLoginScopedListeners();
 
-            setTimeout(async () => await renderContactsList(lobbyElement), 5); // Temp fix, rendering will be moved anyways
+            await renderContactsList(lobbyElement);
           } catch (e) {
             console.warn('[AUTH] Failed to handle auth:logout:', e);
           }

--- a/src/setup/setupMainAppBusListeners.js
+++ b/src/setup/setupMainAppBusListeners.js
@@ -7,6 +7,7 @@ import {
   listenForIncomingOnRoom,
   removeIncomingListenersForRoom,
 } from '../features/call/room-listeners.js';
+import { getPushNotifications } from '../features/push-notifications/index.js';
 import { setUserOffline } from '../features/presence/index.js';
 import { clearUrlParam } from '../utils/url.js';
 import { onCallDisconnected } from '../components/ui/core/call-lifecycle-ui.js';
@@ -44,6 +45,38 @@ export function setupMainAppBusListeners() {
             await setUserOffline(userId);
           } catch (e) {
             console.warn('Failed to set user presence offline:', e);
+          }
+        },
+        { signal: ac.signal },
+      );
+
+      handleCommand(
+        'push:disable',
+        async () => {
+          try {
+            await getPushNotifications()?.disable?.();
+          } catch (e) {
+            console.warn('[push] Failed to disable notifications:', e);
+          }
+        },
+        { signal: ac.signal },
+      );
+
+      handleCommand(
+        'contacts:get-by-room-id',
+        async ({ roomId } = {}) => {
+          if (!roomId) {
+            return null;
+          }
+
+          try {
+            return await contactsService.getContactByRoomId(roomId);
+          } catch (e) {
+            console.warn(
+              'Failed to resolve contact on contacts:get-by-room-id:',
+              e,
+            );
+            return null;
           }
         },
         { signal: ac.signal },

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -107,7 +107,6 @@ describe('setupAuth', () => {
     const teardown = await setupAuth({ lobbyElement });
 
     await mocks.handlers.get('auth:logout')({});
-    await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mocks.renderContactsList).toHaveBeenCalledWith(lobbyElement);
     expect(mocks.removeAllIncomingListeners).toHaveBeenCalled();

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -107,6 +107,7 @@ describe('setupAuth', () => {
     const teardown = await setupAuth({ lobbyElement });
 
     await mocks.handlers.get('auth:logout')({});
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mocks.renderContactsList).toHaveBeenCalledWith(lobbyElement);
     expect(mocks.removeAllIncomingListeners).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- route push cloud-function calls through `auth:cloud-function:call` command
- switch logout push disable to `push:disable` command
- remove direct `push-notifications -> auth` and `push-notifications -> contacts` imports
- handle `contacts:get-by-room-id` in setup composition

## Why
This unblocks boundary enforcement while keeping behavior and architecture direction (cross-module interactions via commands/events).

## Validation
- `pnpm lint:b:feature push-notifications`
- `pnpm exec eslint src/features/push-notifications/push-notifications.js src/setup/setupMainAppBusListeners.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cross-module interactions now route through a shared command system, decoupling push notifications, contacts, and cloud-function calls; awaited commands return handler results.

* **Bug Fixes**
  * Sign-out triggers push-disable via the command system; contact lookups use routed requests with safe fallbacks and improved error propagation for cloud-function calls.

* **Tests**
  * Expanded command-dispatch and cloud-function tests to cover handler-count and error behaviors.

* **Documentation**
  * Updated architecture and push-notifications docs to reflect the new routing and handler rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->