### PR TITLE
Defer YouTube API loading to improve initial render

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,9 +238,6 @@
       </footer>
     </div>
 
-    <!-- GIS client loaded dynamically by onetap.js with locale-aware ?hl= param -->
-    <script src="https://www.youtube.com/iframe_api"></script>
-
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/media/youtube/youtube-player.js
+++ b/src/media/youtube/youtube-player.js
@@ -29,6 +29,7 @@ export const getYTBox = () => {
 // ============================================================================
 
 let ytApiLoadingPromise = null;
+const YT_API_LOAD_TIMEOUT = 15000; // 15 seconds
 
 // Dynamically load YouTube IFrame API if not already loaded
 export function ensureYouTubeAPILoaded() {
@@ -43,17 +44,45 @@ export function ensureYouTubeAPILoaded() {
   }
 
   // Start loading
-  ytApiLoadingPromise = new Promise((resolve) => {
+  ytApiLoadingPromise = new Promise((resolve, reject) => {
+    const previousReadyHandler = window.onYouTubeIframeAPIReady;
     const script = document.createElement('script');
     script.src = 'https://www.youtube.com/iframe_api';
     script.async = true;
 
+    const timeoutId = window.setTimeout(() => {
+      ytApiLoadingPromise = null;
+      reject(new Error('Timed out loading YouTube IFrame API'));
+    }, YT_API_LOAD_TIMEOUT);
+
     // Set up callback for when API is ready
     window.onYouTubeIframeAPIReady = () => {
+      window.clearTimeout(timeoutId);
+      if (typeof previousReadyHandler === 'function') {
+        previousReadyHandler();
+      }
       resolve();
     };
 
-    document.body.appendChild(script);
+    script.onerror = () => {
+      window.clearTimeout(timeoutId);
+      ytApiLoadingPromise = null;
+      // Restore previous handler to avoid breaking other listeners
+      window.onYouTubeIframeAPIReady = previousReadyHandler;
+      reject(new Error('Failed to load YouTube IFrame API script'));
+    };
+
+    script.onabort = () => {
+      window.clearTimeout(timeoutId);
+      ytApiLoadingPromise = null;
+      window.onYouTubeIframeAPIReady = previousReadyHandler;
+      reject(new Error('Aborted loading YouTube IFrame API script'));
+    };
+
+    (document.head || document.body).appendChild(script);
+  }).catch((error) => {
+    ytApiLoadingPromise = null;
+    throw error;
   });
 
   return ytApiLoadingPromise;

--- a/src/media/youtube/youtube-player.js
+++ b/src/media/youtube/youtube-player.js
@@ -28,18 +28,40 @@ export const getYTBox = () => {
 // YOUTUBE API INITIALIZATION
 // ============================================================================
 
+let ytApiLoadingPromise = null;
+
+// Dynamically load YouTube IFrame API if not already loaded
+export function ensureYouTubeAPILoaded() {
+  // Already loaded
+  if (window.YT && window.YT.Player) {
+    return Promise.resolve();
+  }
+
+  // Already loading, return existing promise
+  if (ytApiLoadingPromise) {
+    return ytApiLoadingPromise;
+  }
+
+  // Start loading
+  ytApiLoadingPromise = new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.src = 'https://www.youtube.com/iframe_api';
+    script.async = true;
+
+    // Set up callback for when API is ready
+    window.onYouTubeIframeAPIReady = () => {
+      resolve();
+    };
+
+    document.body.appendChild(script);
+  });
+
+  return ytApiLoadingPromise;
+}
+
 // Wait for YouTube IFrame API to be ready
 export function waitForYouTubeAPI() {
-  return new Promise((resolve) => {
-    if (window.YT && window.YT.Player) {
-      resolve();
-    } else {
-      // YouTube API calls this when ready
-      window.onYouTubeIframeAPIReady = () => {
-        resolve();
-      };
-    }
-  });
+  return ensureYouTubeAPILoaded();
 }
 
 // ============================================================================

--- a/src/media/youtube/youtube-search.js
+++ b/src/media/youtube/youtube-search.js
@@ -77,165 +77,170 @@ export async function initializeSearchUI() {
   if (isInitialized || _initializing) return false;
   _initializing = true;
 
-  // Load YouTube API lazily on demand
-  await ensureYouTubeAPILoaded();
+  try {
+    // Load YouTube API lazily on demand
+    await ensureYouTubeAPILoaded();
 
-  // Use robust access for dynamically loaded search elements
-  const { initializeYouTubeElements } = await import('../../elements.js');
-  const elements = await initializeYouTubeElements();
+    // Use robust access for dynamically loaded search elements
+    const { initializeYouTubeElements } = await import('../../elements.js');
+    const elements = await initializeYouTubeElements();
 
-  searchContainer = elements.searchContainer;
-  searchBtn = elements.searchBtn;
-  searchQuery = elements.searchQuery;
-  searchResults = elements.searchResults;
+    searchContainer = elements.searchContainer;
+    searchBtn = elements.searchBtn;
+    searchQuery = elements.searchQuery;
+    searchResults = elements.searchResults;
 
-  if (!searchContainer || !searchBtn || !searchQuery || !searchResults) {
-    console.error('YouTube search elements not found in DOM');
-    _initializing = false;
-    return false;
-  }
-
-  const isDirectUrl = (str) => {
-    return /^https?:\/\//i.test(str);
-  };
-
-  const focusResult = (index) => {
-    const items = searchResults?.querySelectorAll('.search-result-item') || [];
-    items.forEach((item, i) => {
-      if (i === index) {
-        item.classList.add('focused');
-        item.scrollIntoView({ block: 'nearest' });
-      } else {
-        item.classList.remove('focused');
-      }
-    });
-    focusedResultIndex = index ?? -1;
-  };
-
-  // Unified search handler
-  async function handleSearchQuery(query) {
-    if (!query) {
-      clearSearchResults();
-      hideElement(searchQuery);
-      return;
+    if (!searchContainer || !searchBtn || !searchQuery || !searchResults) {
+      console.error('YouTube search elements not found in DOM');
+      return false;
     }
 
-    if (hasLoadedSearchResults() && query === lastSearchQuery) {
-      displaySearchResults(searchResultsCache);
-    } else if (!isDirectUrl(query) && !isGoogleDriveUrl(query)) {
-      await searchYouTube(query);
-    } else {
-      // Treat as direct video link (with Google Drive support)
-      let url = query;
-      devDebug('Direct URL entered:', url);
-      if (isGoogleDriveUrl(query)) {
-        // Extract direct link from gdrive "View" link
-        url = toGoogleDriveDirectLink(query);
-        devDebug('Extracted Google Drive direct link:', url);
-      }
+    const isDirectUrl = (str) => {
+      return /^https?:\/\//i.test(str);
+    };
 
-      await handleVideoSelection({
-        url: url,
-        title: query,
-        channel: '',
-        thumbnail: '',
-        id: query,
+    const focusResult = (index) => {
+      const items = searchResults?.querySelectorAll('.search-result-item') || [];
+      items.forEach((item, i) => {
+        if (i === index) {
+          item.classList.add('focused');
+          item.scrollIntoView({ block: 'nearest' });
+        } else {
+          item.classList.remove('focused');
+        }
       });
+      focusedResultIndex = index ?? -1;
+    };
 
-      hideElement(searchResults);
-      searchQuery.value = '';
-      hideElement(searchQuery);
-      focusedResultIndex = -1;
-      return;
-    }
-  }
-
-  // Add search button event listener
-  searchBtn.onclick = async () => {
-    const query = searchQuery.value.trim();
-    if (isHidden(searchQuery)) {
-      showElement(searchQuery);
-      searchQuery.focus();
-      return;
-    }
-    await handleSearchQuery(query);
-  };
-
-  searchContainer.addEventListener('keydown', async (e) => {
-    const items = searchResults.querySelectorAll('.search-result-item');
-    if (items.length > 0 && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
-      // Navigate results
-      if (e.key === 'ArrowDown') {
-        let next = focusedResultIndex + 1;
-        if (next >= items.length) next = 0;
-        focusResult(next);
-      } else if (e.key === 'ArrowUp') {
-        let prev = focusedResultIndex - 1;
-        if (prev < 0) prev = focusedResultIndex === -1 ? 0 : items.length - 1;
-        focusResult(prev);
-      }
-      return;
-    }
-
-    if (e.key === 'Enter') {
-      // If a result is focused, select it
-      if (items.length > 0 && focusedResultIndex >= 0) {
-        items[focusedResultIndex].click();
+    // Unified search handler
+    async function handleSearchQuery(query) {
+      if (!query) {
+        clearSearchResults();
         hideElement(searchQuery);
+        return;
+      }
+
+      if (hasLoadedSearchResults() && query === lastSearchQuery) {
+        displaySearchResults(searchResultsCache);
+      } else if (!isDirectUrl(query) && !isGoogleDriveUrl(query)) {
+        await searchYouTube(query);
+      } else {
+        // Treat as direct video link (with Google Drive support)
+        let url = query;
+        devDebug('Direct URL entered:', url);
+        if (isGoogleDriveUrl(query)) {
+          // Extract direct link from gdrive "View" link
+          url = toGoogleDriveDirectLink(query);
+          devDebug('Extracted Google Drive direct link:', url);
+        }
+
+        await handleVideoSelection({
+          url: url,
+          title: query,
+          channel: '',
+          thumbnail: '',
+          id: query,
+        });
+
         hideElement(searchResults);
+        searchQuery.value = '';
+        hideElement(searchQuery);
         focusedResultIndex = -1;
         return;
       }
+    }
+
+    // Add search button event listener
+    searchBtn.onclick = async () => {
       const query = searchQuery.value.trim();
+      if (isHidden(searchQuery)) {
+        showElement(searchQuery);
+        searchQuery.focus();
+        return;
+      }
       await handleSearchQuery(query);
-    } else if (e.key === 'Escape') {
-      if (isSearchResultsElVisible()) clearSearchResults();
-      else if (searchQuery.value) searchQuery.value = '';
-      else hideElement(searchQuery);
+    };
+
+    searchContainer.addEventListener('keydown', async (e) => {
+      const items = searchResults.querySelectorAll('.search-result-item');
+      if (items.length > 0 && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+        // Navigate results
+        if (e.key === 'ArrowDown') {
+          let next = focusedResultIndex + 1;
+          if (next >= items.length) next = 0;
+          focusResult(next);
+        } else if (e.key === 'ArrowUp') {
+          let prev = focusedResultIndex - 1;
+          if (prev < 0) prev = focusedResultIndex === -1 ? 0 : items.length - 1;
+          focusResult(prev);
+        }
+        return;
+      }
+
+      if (e.key === 'Enter') {
+        // If a result is focused, select it
+        if (items.length > 0 && focusedResultIndex >= 0) {
+          items[focusedResultIndex].click();
+          hideElement(searchQuery);
+          hideElement(searchResults);
+          focusedResultIndex = -1;
+          return;
+        }
+        const query = searchQuery.value.trim();
+        await handleSearchQuery(query);
+      } else if (e.key === 'Escape') {
+        if (isSearchResultsElVisible()) clearSearchResults();
+        else if (searchQuery.value) searchQuery.value = '';
+        else hideElement(searchQuery);
+      }
+    });
+
+    searchQuery.addEventListener('input', () => {
+      if (searchQuery.value.trim() === '') {
+        clearSearchResults();
+      }
+      focusedResultIndex = -1;
+    });
+
+    const closeQueryCleanup = onClickOutside(
+      searchQuery,
+      () => hideElement(searchQuery),
+      {
+        ignore: [searchBtn],
+        esc: false, // already handled
+      },
+    );
+
+    cleanupFunctions.push(closeQueryCleanup);
+
+    const closeSearchResultsCleanup = onClickOutside(
+      searchResults,
+      () => hideElement(searchResults),
+      {
+        ignore: [searchBtn],
+        esc: false, // already handled
+      },
+    );
+
+    cleanupFunctions.push(closeSearchResultsCleanup);
+
+    // Check API availability
+    if (!YOUTUBE_API_KEY) {
+      searchBtn.disabled = true;
+      searchBtn.title = 'YouTube API key not configured';
+      console.warn('YouTube API key not found. Search will not be available.');
     }
-  });
 
-  searchQuery.addEventListener('input', () => {
-    if (searchQuery.value.trim() === '') {
-      clearSearchResults();
-    }
-    focusedResultIndex = -1;
-  });
+    devDebug('YouTube search UI initialized');
 
-  const closeQueryCleanup = onClickOutside(
-    searchQuery,
-    () => hideElement(searchQuery),
-    {
-      ignore: [searchBtn],
-      esc: false, // already handled
-    },
-  );
-
-  cleanupFunctions.push(closeQueryCleanup);
-
-  const closeSearchResultsCleanup = onClickOutside(
-    searchResults,
-    () => hideElement(searchResults),
-    {
-      ignore: [searchBtn],
-      esc: false, // already handled
-    },
-  );
-
-  cleanupFunctions.push(closeSearchResultsCleanup);
-
-  // Check API availability
-  if (!YOUTUBE_API_KEY) {
-    searchBtn.disabled = true;
-    searchBtn.title = 'YouTube API key not configured';
-    console.warn('YouTube API key not found. Search will not be available.');
+    isInitialized = true;
+    return true;
+  } catch (error) {
+    console.error('Failed to initialize YouTube search UI:', error);
+    return false;
+  } finally {
+    _initializing = false;
   }
-
-  devDebug('YouTube search UI initialized');
-
-  _initializing = false;
-  isInitialized = true;
-  return true;
 }
 
 /**

--- a/src/media/youtube/youtube-search.js
+++ b/src/media/youtube/youtube-search.js
@@ -10,6 +10,7 @@ import {
   hideElement,
 } from '../../components/ui/utils/ui-utils.js';
 import { handleVideoSelection } from '../../features/watch/watch-sync.js';
+import { ensureYouTubeAPILoaded } from './youtube-player.js';
 
 // ===== ELEMENTS =====
 
@@ -75,6 +76,9 @@ export function toGoogleDriveDirectLink(url) {
 export async function initializeSearchUI() {
   if (isInitialized || _initializing) return false;
   _initializing = true;
+
+  // Load YouTube API lazily on demand
+  await ensureYouTubeAPILoaded();
 
   // Use robust access for dynamically loaded search elements
   const { initializeYouTubeElements } = await import('../../elements.js');

--- a/src/media/youtube/youtube-search.js
+++ b/src/media/youtube/youtube-search.js
@@ -78,9 +78,6 @@ export async function initializeSearchUI() {
   _initializing = true;
 
   try {
-    // Load YouTube API lazily on demand
-    await ensureYouTubeAPILoaded();
-
     // Use robust access for dynamically loaded search elements
     const { initializeYouTubeElements } = await import('../../elements.js');
     const elements = await initializeYouTubeElements();
@@ -94,6 +91,14 @@ export async function initializeSearchUI() {
       console.error('YouTube search elements not found in DOM');
       return false;
     }
+
+    // Warm up iframe API in the background, but do not block search UI wiring.
+    ensureYouTubeAPILoaded().catch((error) => {
+      console.warn(
+        'YouTube IFrame API preload failed; it will retry on video playback:',
+        error,
+      );
+    });
 
     const isDirectUrl = (str) => {
       return /^https?:\/\//i.test(str);

--- a/src/vendors/firebase.js
+++ b/src/vendors/firebase.js
@@ -137,8 +137,10 @@ function initializeAppCheckDeferred() {
   }
 }
 
-// Defer by one microtask to avoid sync startup cost but initialize as early
-// as possible during app boot, minimizing race windows for first API calls.
+// Defer by one microtask to avoid synchronous startup work while still
+// initializing App Check as early as possible in app boot.
+// Note: microtasks usually run before first paint; this is intentional to
+// minimize the race window before first Firebase API calls.
 Promise.resolve().then(initializeAppCheckDeferred);
 
 export { initializeAppCheckDeferred };

--- a/src/vendors/firebase.js
+++ b/src/vendors/firebase.js
@@ -137,16 +137,8 @@ function initializeAppCheckDeferred() {
   }
 }
 
-// Schedule initialization after rendering is complete
-if (document.readyState === 'loading') {
-  document.addEventListener(
-    'DOMContentLoaded',
-    initializeAppCheckDeferred,
-    { once: true },
-  );
-} else {
-  // Page already loaded, schedule for next microtask
-  Promise.resolve().then(initializeAppCheckDeferred);
-}
+// Defer by one microtask to avoid sync startup cost but initialize as early
+// as possible during app boot, minimizing race windows for first API calls.
+Promise.resolve().then(initializeAppCheckDeferred);
 
 export { initializeAppCheckDeferred };

--- a/src/vendors/firebase.js
+++ b/src/vendors/firebase.js
@@ -115,14 +115,38 @@ else {
   }
 }
 
-// Initialize App Check if a provider was successfully determined
-if (appCheckProvider) {
+// ============================================================================
+// DEFERRED APP CHECK INITIALIZATION
+// ============================================================================
+// Initialize App Check after the main render to avoid blocking initial load
+// ReCaptcha Enterprise script will be loaded on-demand by Firebase's internal logic
+let appCheckInitialized = false;
+
+function initializeAppCheckDeferred() {
+  if (appCheckInitialized) return;
+  if (!appCheckProvider) return;
+
   try {
     initializeAppCheck(app, {
       provider: appCheckProvider,
-      isTokenAutoRefreshEnabled: true, // Recommended for a smooth user experience
+      isTokenAutoRefreshEnabled: true,
     });
+    appCheckInitialized = true;
   } catch (err) {
     console.error('[Firebase App Check] initializeAppCheck call failed:', err);
   }
 }
+
+// Schedule initialization after rendering is complete
+if (document.readyState === 'loading') {
+  document.addEventListener(
+    'DOMContentLoaded',
+    initializeAppCheckDeferred,
+    { once: true },
+  );
+} else {
+  // Page already loaded, schedule for next microtask
+  Promise.resolve().then(initializeAppCheckDeferred);
+}
+
+export { initializeAppCheckDeferred };

--- a/src/vendors/firebase.js
+++ b/src/vendors/firebase.js
@@ -118,7 +118,7 @@ else {
 // ============================================================================
 // DEFERRED APP CHECK INITIALIZATION
 // ============================================================================
-// Initialize App Check after the main render to avoid blocking initial load
+// Initialize App Check via microtask to avoid synchronous startup cost
 // ReCaptcha Enterprise script will be loaded on-demand by Firebase's internal logic
 let appCheckInitialized = false;
 


### PR DESCRIPTION
## Summary
- Remove synchronous YouTube iframe API script tag from index.html
- Add dynamic lazy-loading mechanism to youtube-player.js
- API loads on-demand when search UI initializes, not on page load

## Why
YouTube iframe API was render-blocking. This change defers loading until actually needed, improving Core Web Vitals on initial page load.

## Test
- [ ] Initial page load is faster (check DevTools Performance)
- [ ] YouTube search functionality works
- [ ] Watch-together video loading works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * YouTube integration now loads the IFrame API on demand (dynamic, cached load) and removes the static API script to reduce initial page load and avoid duplicate loads.
* **Bug Fixes / Stability**
  * YouTube search UI initialization is more resilient with guarded error handling and a non-blocking background API preload.
* **Chores**
  * App Check initialization deferred and guarded to avoid blocking startup and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->