### PR TITLE
Skip avatar letter fallback while profile is pending

### DIFF
--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -6,6 +6,7 @@
  * @param {string} [options.photoURL] - Profile photo URL
  * @param {string} [options.customFallbackText] - Custom text to display instead of initial (e.g., 'Me')
  * @param {string} [options.imageClass='sender-avatar--image'] - Class to add when image is present
+ * @param {boolean} [options.pending=false] - Photo state unknown (not yet fetched); render blank instead of letter fallback to avoid flicker
  */
 export function renderAvatar(
   element,
@@ -14,25 +15,31 @@ export function renderAvatar(
     photoURL = '',
     customFallbackText = null,
     imageClass = 'sender-avatar--image',
+    pending = false,
   } = {},
 ) {
   if (!element) return;
-
-  // Determine fallback text: custom text, or first letter of name, or 'U'
-  const fallbackText =
-    customFallbackText || (name ? name[0].toUpperCase() : 'U');
 
   if (photoURL) {
     element.style.backgroundImage = `url("${photoURL}")`;
     element.style.backgroundSize = 'cover';
     element.style.backgroundPosition = 'center';
     element.classList.add(imageClass);
-    element.textContent = ''; // Hide text when showing image
-  } else {
-    element.style.backgroundImage = '';
-    element.style.backgroundSize = '';
-    element.style.backgroundPosition = '';
-    element.classList.remove(imageClass);
-    element.textContent = fallbackText;
+    element.textContent = '';
+    return;
   }
+
+  element.style.backgroundImage = '';
+  element.style.backgroundSize = '';
+  element.style.backgroundPosition = '';
+  element.classList.remove(imageClass);
+
+  if (pending) {
+    element.textContent = '';
+    return;
+  }
+
+  const fallbackText =
+    customFallbackText || (name ? name[0].toUpperCase() : 'U');
+  element.textContent = fallbackText;
 }

--- a/src/features/messaging/components/createMessageTopBar.js
+++ b/src/features/messaging/components/createMessageTopBar.js
@@ -23,9 +23,14 @@ export function createMessageTopBar() {
   const avatar = root.querySelector('.messages-topbar-avatar');
   const nameEl = root.querySelector('.messages-topbar-name');
 
-  const setContact = ({ name = '', photoURL = '' } = {}) => {
+  const setContact = ({ name = '', photoURL = '', pending = false } = {}) => {
     nameEl.textContent = name || t('shared.unknown');
-    renderAvatar(avatar, { name, photoURL, imageClass: 'has-image' });
+    renderAvatar(avatar, {
+      name,
+      photoURL,
+      pending,
+      imageClass: 'has-image',
+    });
   };
 
   const setBackHandler = (fn) => {

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -1170,9 +1170,14 @@ export function initMessagesUI() {
       messagingController.getConversationDisplayName(conversationId) || '';
     const photoURL =
       messagingController.getConversationPhotoURL(conversationId) || '';
+    // Profile not yet fetched — render blank avatar to avoid letter-fallback flicker
+    const photoPending =
+      !!contactId &&
+      messagingController.getParticipantProfile(conversationId, contactId) ===
+        null;
 
     if (messageTopBar) {
-      messageTopBar.setContact({ name, photoURL });
+      messageTopBar.setContact({ name, photoURL, pending: photoPending });
     }
     refreshAttachButton();
 

--- a/src/features/messaging/messaging-controller.js
+++ b/src/features/messaging/messaging-controller.js
@@ -339,6 +339,7 @@ export class MessagingController extends EventEmitter {
 
   /**
    * Update a participant's cached profile and emit meta update event.
+   * Emits even when profile is missing/fetch failed so UI can clear loading states.
    * @param {string} conversationId
    * @param {string} participantId
    * @param {ParticipantProfile|null} profile
@@ -346,9 +347,11 @@ export class MessagingController extends EventEmitter {
    */
   _updateParticipantMeta(conversationId, participantId, profile) {
     const state = this.conversations.get(conversationId);
-    if (!state || !profile) return;
+    if (!state) return;
 
-    state.participants[participantId] = profile;
+    if (profile) {
+      state.participants[participantId] = profile;
+    }
     this.emit('conversation:meta-updated', {
       conversationId,
       participants: { ...state.participants },

--- a/src/features/messaging/messaging-controller.test.js
+++ b/src/features/messaging/messaging-controller.test.js
@@ -219,6 +219,28 @@ describe('MessagingController', () => {
     );
   });
 
+  it('should still emit conversation:meta-updated when participant profile fetch fails', async () => {
+    mockGetUserProfile.mockRejectedValueOnce(new Error('network down'));
+
+    const spy = vi.fn();
+    controller.on('conversation:meta-updated', spy);
+
+    await controller.selectConversation('contactA_me', {
+      remoteParticipantIds: ['contactA'],
+    });
+
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        conversationId: 'contactA_me',
+        participants: {},
+      });
+    });
+
+    expect(controller.getParticipantProfile('contactA_me', 'contactA')).toBe(
+      null,
+    );
+  });
+
   it('should prefer provided contactNickName over participant userName', async () => {
     mockGetUserProfile.mockResolvedValueOnce({
       userName: 'Google Name',


### PR DESCRIPTION
## Summary
- Adds `pending` option to `renderAvatar`. When `pending && !photoURL`, the element is left blank (no letter fallback) instead of showing a one-character placeholder.
- `createMessageTopBar.setContact` threads `pending` through to `renderAvatar`.
- `prepareConversation` in messages-ui uses the existing `messagingController.getParticipantProfile(conversationId, contactId)` to detect "profile not yet fetched" and sets `pending: true` on the initial `setContact` call. When `conversation:meta-updated` fires, `setContact` is called again without `pending`, so the real photo (or letter fallback for users with no photo) is rendered.

Result: no more "letter → photo" flicker on first visit to a conversation. Revisits within MRU cache are unchanged (they already had the photo cached).

## Known pre-existing issue
During testing I observed an intermittent regression where topbar avatars render as a blank blue background even after the real `photoURL` is applied. Diagnostic logs confirmed `renderAvatar` is called with the correct URL and `has-image` class, so the JS state is correct — the issue appears to be below the JS layer (most likely `lh3.googleusercontent.com` CDN failures or browser image cache). It reproduced inconsistently across runs of identical code, including before this change. Not caused by this PR, but worth tracking separately — likely requires checking Network tab for failed image loads and/or adding error handling for broken avatar URLs.

## Test plan
- [ ] Open a conversation for the first time in a session — avatar should render blank, then fill with the real photo (no letter flash)
- [ ] Revisit the same conversation — avatar should render photo immediately
- [ ] Open a conversation with a contact who has no profile photo — letter fallback should still render after `meta-updated` arrives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatars in messaging now remain blank while a profile photo is loading, preventing flicker from fallback initials.
  * Conversation participant metadata updates reliably even when a profile fetch fails, keeping UI state consistent.

* **Tests**
  * Added test coverage to ensure metadata updates and null-profile behavior when profile fetches fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->