### PR TITLE
Fix broken avatars in messages UI

### DIFF
--- a/src/auth/components/AuthComponent.js
+++ b/src/auth/components/AuthComponent.js
@@ -92,7 +92,7 @@ export const initializeAuthUI = (parentElement, gapBetweenBtns = null) => {
       <span class="signing-in-indicator" style="display: [[signingInDisplay]]; color: var(--text-secondary, #888); font-size: 0.9rem;">...</span>
       <span class="signing-in-indicator" style="display: [[signingOutDisplay]]; color: var(--text-secondary, #888); font-size: 0.9rem;">...</span>
       <div class="user-info" style="display: [[userInfoDisplay]]">
-        <img src="[[userPhotoURL]]" alt="[[userName]]" class="user-avatar" style="display: [[userPhotoDisplay]]" onerror="handleAvatarError" />
+        <img src="[[userPhotoURL]]" alt="[[userName]]" class="user-avatar" style="display: [[userPhotoDisplay]]" referrerpolicy="no-referrer" onerror="handleAvatarError" />
         <span class="user-avatar-placeholder" style="display: [[avatarDisplay]]">👤</span>
         <span class="user-name">[[userName]]</span>
       </div>

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -47,6 +47,15 @@ export function renderAvatar(
       element.textContent = name ? name[0].toUpperCase() : 'U';
     };
     img.src = photoURL;
+    // Only animate slow loads — cached images are .complete synchronously
+    // and should appear instantly without a fade-in.
+    if (!img.complete) {
+      img.addEventListener(
+        'load',
+        () => img.classList.add('avatar-entry-animation'),
+        { once: true },
+      );
+    }
     element.appendChild(img);
     return;
   }

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -57,10 +57,11 @@ export function renderAvatar(
       img.remove();
       element.textContent = fallbackText;
     };
-    img.src = photoURL;
     // Animate only the first time we see this URL this session. Re-renders into
     // new <img> elements (e.g. switching conversations) are served from cache
     // and should appear instantly without a fade-in.
+    // Attach the listener before setting src so a synchronous cached load
+    // still fires it.
     if (!loadedPhotoURLs.has(photoURL)) {
       img.addEventListener(
         'load',
@@ -74,11 +75,11 @@ export function renderAvatar(
         { once: true },
       );
     }
+    img.src = photoURL;
     if (!img.parentNode) element.appendChild(img);
     return;
   }
 
-  if (prevImg) prevImg.remove();
   element.textContent = '';
 
   if (pending) return;

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -1,45 +1,57 @@
 /**
- * Apply avatar styling to an element: background image if available, otherwise fallback text
- * @param {HTMLElement} element - Avatar element to style
+ * Create a new avatar element and apply styling.
+ * @param {Object} options - See renderAvatar for options, plus:
+ * @param {string[]} [options.classList=['avatar']] - Classes to apply to the new element
+ * @returns {HTMLElement}
+ */
+export function createAvatar(options = {}) {
+  const element = document.createElement('span');
+  const { classList = ['avatar'] } = options;
+  classList.forEach((cls) => element.classList.add(cls));
+  renderAvatar(element, options);
+  return element;
+}
+
+/**
+ * Render an avatar into an element: <img> child if photoURL, else letter fallback.
+ * Idempotent per URL — safe to call repeatedly with the same photoURL.
+ * @param {HTMLElement} element
  * @param {Object} options
- * @param {string} [options.name] - Display name for deriving initial letter
- * @param {string} [options.photoURL] - Profile photo URL
- * @param {string} [options.customFallbackText] - Custom text to display instead of initial (e.g., 'Me')
- * @param {string} [options.imageClass='sender-avatar--image'] - Class to add when image is present
- * @param {boolean} [options.pending=false] - Photo state unknown (not yet fetched); render blank instead of letter fallback to avoid flicker
+ * @param {string} [options.name]
+ * @param {string} [options.photoURL]
+ * @param {boolean} [options.pending=false] - Photo unknown yet; render blank to avoid letter flicker
  */
 export function renderAvatar(
   element,
-  {
-    name = '',
-    photoURL = '',
-    customFallbackText = null,
-    imageClass = 'sender-avatar--image',
-    pending = false,
-  } = {},
+  { name = '', photoURL = '', pending = false } = {},
 ) {
   if (!element) return;
+  const stateKey = photoURL || (pending ? 'pending' : `letter:${name}`);
+  if (element.dataset.avatarState === stateKey) return;
+
+  element.dataset.avatarState = stateKey;
+  element.textContent = '';
+  const prevImg = element.querySelector(':scope > img');
+  if (prevImg) prevImg.remove();
 
   if (photoURL) {
-    element.style.backgroundImage = `url("${photoURL}")`;
-    element.style.backgroundSize = 'cover';
-    element.style.backgroundPosition = 'center';
-    element.classList.add(imageClass);
-    element.textContent = '';
+    const img = document.createElement('img');
+    img.alt = '';
+    img.decoding = 'async';
+    // Strip Referer — Google's lh3.googleusercontent.com 403s cross-origin
+    // requests that carry a referrer header.
+    img.referrerPolicy = 'no-referrer';
+    img.onerror = () => {
+      element.dataset.avatarState = `letter:${name}`;
+      img.remove();
+      element.textContent = name ? name[0].toUpperCase() : 'U';
+    };
+    img.src = photoURL;
+    element.appendChild(img);
     return;
   }
 
-  element.style.backgroundImage = '';
-  element.style.backgroundSize = '';
-  element.style.backgroundPosition = '';
-  element.classList.remove(imageClass);
+  if (pending) return;
 
-  if (pending) {
-    element.textContent = '';
-    return;
-  }
-
-  const fallbackText =
-    customFallbackText || (name ? name[0].toUpperCase() : 'U');
-  element.textContent = fallbackText;
+  element.textContent = name ? name[0].toUpperCase() : 'U';
 }

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -1,4 +1,5 @@
 const loadedPhotoURLs = new Set();
+const failedPhotoURLs = new Set();
 const maxCachedPhotoURLs = 100;
 
 /**
@@ -30,13 +31,18 @@ export function renderAvatar(
   { name = '', photoURL = '', pending = false } = {},
 ) {
   if (!element) return;
-  const stateKey = photoURL || (pending ? 'pending' : `letter:${name}`);
+  const usablePhoto = photoURL && !failedPhotoURLs.has(photoURL);
+  const stateKey = usablePhoto
+    ? photoURL
+    : pending && !photoURL
+      ? 'pending'
+      : `letter:${name}`;
   if (element.dataset.avatarState === stateKey) return;
 
   element.dataset.avatarState = stateKey;
   const prevImg = element.querySelector(':scope > img');
 
-  if (photoURL) {
+  if (usablePhoto) {
     // Reuse existing <img> so the previous frame keeps painting until the new
     // src decodes — avoids a background flash during conversation switches.
     const img = prevImg || document.createElement('img');
@@ -52,6 +58,7 @@ export function renderAvatar(
     const fallbackState = `letter:${name}`;
     const requestedState = stateKey;
     img.onerror = () => {
+      failedPhotoURLs.add(photoURL);
       if (element.dataset.avatarState !== requestedState) return;
       element.dataset.avatarState = fallbackState;
       img.remove();

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -1,4 +1,5 @@
 const loadedPhotoURLs = new Set();
+const maxCachedPhotoURLs = 100;
 
 /**
  * Create a new avatar element and apply styling.
@@ -32,17 +33,18 @@ export function renderAvatar(
   if (element.dataset.avatarState === stateKey) return;
 
   element.dataset.avatarState = stateKey;
-  element.textContent = '';
   const prevImg = element.querySelector(':scope > img');
-  if (prevImg) prevImg.remove();
 
   if (photoURL) {
-    const img = document.createElement('img');
+    // Reuse existing <img> so the previous frame keeps painting until the new
+    // src decodes — avoids a background flash during conversation switches.
+    const img = prevImg || document.createElement('img');
     img.alt = '';
     img.decoding = 'async';
     // Strip Referer — Google's lh3.googleusercontent.com 403s cross-origin
     // requests that carry a referrer header.
     img.referrerPolicy = 'no-referrer';
+    img.classList.remove('avatar-entry-animation');
     img.onerror = () => {
       element.dataset.avatarState = `letter:${name}`;
       img.remove();
@@ -56,15 +58,21 @@ export function renderAvatar(
       img.addEventListener(
         'load',
         () => {
+          if (loadedPhotoURLs.size >= maxCachedPhotoURLs) {
+            loadedPhotoURLs.clear();
+          }
           loadedPhotoURLs.add(photoURL);
           img.classList.add('avatar-entry-animation');
         },
         { once: true },
       );
     }
-    element.appendChild(img);
+    if (!img.parentNode) element.appendChild(img);
     return;
   }
+
+  if (prevImg) prevImg.remove();
+  element.textContent = '';
 
   if (pending) return;
 

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -11,6 +11,7 @@ export function createAvatar(options = {}) {
   const element = document.createElement('span');
   const { classList = ['avatar'] } = options;
   classList.forEach((cls) => element.classList.add(cls));
+  element.setAttribute('aria-hidden', 'true');
   renderAvatar(element, options);
   return element;
 }
@@ -45,10 +46,16 @@ export function renderAvatar(
     // requests that carry a referrer header.
     img.referrerPolicy = 'no-referrer';
     img.classList.remove('avatar-entry-animation');
+    // Guard onerror so stale image failures don't clobber newer avatars.
+    // Capture the current stateKey so the handler ignores superseded requests.
+    const fallbackText = name ? name[0].toUpperCase() : 'U';
+    const fallbackState = `letter:${name}`;
+    const requestedState = stateKey;
     img.onerror = () => {
-      element.dataset.avatarState = `letter:${name}`;
+      if (element.dataset.avatarState !== requestedState) return;
+      element.dataset.avatarState = fallbackState;
       img.remove();
-      element.textContent = name ? name[0].toUpperCase() : 'U';
+      element.textContent = fallbackText;
     };
     img.src = photoURL;
     // Animate only the first time we see this URL this session. Re-renders into

--- a/src/components/ui/utils/avatar.js
+++ b/src/components/ui/utils/avatar.js
@@ -1,3 +1,5 @@
+const loadedPhotoURLs = new Set();
+
 /**
  * Create a new avatar element and apply styling.
  * @param {Object} options - See renderAvatar for options, plus:
@@ -47,12 +49,16 @@ export function renderAvatar(
       element.textContent = name ? name[0].toUpperCase() : 'U';
     };
     img.src = photoURL;
-    // Only animate slow loads — cached images are .complete synchronously
+    // Animate only the first time we see this URL this session. Re-renders into
+    // new <img> elements (e.g. switching conversations) are served from cache
     // and should appear instantly without a fade-in.
-    if (!img.complete) {
+    if (!loadedPhotoURLs.has(photoURL)) {
       img.addEventListener(
         'load',
-        () => img.classList.add('avatar-entry-animation'),
+        () => {
+          loadedPhotoURLs.add(photoURL);
+          img.classList.add('avatar-entry-animation');
+        },
         { once: true },
       );
     }

--- a/src/features/messaging/components/createMessageTopBar.js
+++ b/src/features/messaging/components/createMessageTopBar.js
@@ -10,7 +10,7 @@ export function createMessageTopBar() {
       <i data-lucide="chevron-left" aria-hidden="true"></i>
     </button>
     <div class="messages-topbar-contact">
-      <span class="messages-topbar-avatar" aria-hidden="true"></span>
+      <span class="avatar" aria-hidden="true"></span>
       <span class="messages-topbar-name"></span>
     </div>
     <button type="button" class="messages-topbar-call" aria-label="${t('message.call')}">
@@ -20,17 +20,12 @@ export function createMessageTopBar() {
 
   const backBtn = root.querySelector('.messages-topbar-back');
   const callBtn = root.querySelector('.messages-topbar-call');
-  const avatar = root.querySelector('.messages-topbar-avatar');
+  const avatarSpan = root.querySelector('.avatar');
   const nameEl = root.querySelector('.messages-topbar-name');
 
   const setContact = ({ name = '', photoURL = '', pending = false } = {}) => {
     nameEl.textContent = name || t('shared.unknown');
-    renderAvatar(avatar, {
-      name,
-      photoURL,
-      pending,
-      imageClass: 'has-image',
-    });
+    renderAvatar(avatarSpan, { name, photoURL, pending });
   };
 
   const setBackHandler = (fn) => {

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -814,7 +814,7 @@ export function initMessagesUI() {
    * @param {Function} [uiOpts.onCallBack] - Callback for event "call back" button
    */
   function appendMessage(message, uiOpts = {}) {
-    const { onCallBack } = uiOpts;
+    const { onCallBack, conversationId: uiConversationId } = uiOpts;
     const type = message.type || 'text';
     const isLocal = isLocalMessage(message);
     const reactions = message.reactions;
@@ -835,7 +835,8 @@ export function initMessagesUI() {
 
     // Avatar (sibling to message-bubble) - only for remote messages
     if (isLocal === false) {
-      const conversationId = messagingController.getSelectedConversationId();
+      const conversationId =
+        uiConversationId ?? messagingController.getSelectedConversationId();
       const participantName =
         messagingController.getConversationDisplayName(conversationId) || 'U';
       const photoURL =
@@ -1180,7 +1181,7 @@ export function initMessagesUI() {
     // Render cached history
     const history = messagingController.getHistory(conversationId);
     if (history?.length > 0) {
-      appendCachedHistory({ history });
+      appendCachedHistory({ history }, conversationId);
     }
   }
 
@@ -1607,9 +1608,11 @@ export function initMessagesUI() {
    * Helper: Render messages from a session's cached history.
    * This provides the "instant" feel when switching back to a recent chat.
    */
-  function appendCachedHistory(session) {
+  function appendCachedHistory(session, conversationId) {
     if (!session || !session.history) return;
-    session.history.forEach((event) => renderMessage(event.message));
+    session.history.forEach((event) =>
+      renderMessage(event.message, conversationId),
+    );
   }
 
   let lastTimestamp = 0;
@@ -1618,7 +1621,7 @@ export function initMessagesUI() {
   /**
    * Core logic to process and render a message or reaction update.
    */
-  function renderMessage(message) {
+  function renderMessage(message, conversationId) {
     const timestamp = message.sentAt || Date.now();
 
     if (timestamp - lastTimestamp > TIMESTAMP_THRESHOLD) {
@@ -1630,7 +1633,7 @@ export function initMessagesUI() {
     }
     lastTimestamp = timestamp;
 
-    appendMessage(message);
+    appendMessage(message, { conversationId });
   }
 
   // --- Domain Event Listeners ---
@@ -1707,7 +1710,7 @@ export function initMessagesUI() {
         return;
       }
 
-      renderMessage(message);
+      renderMessage(message, conversationId);
 
       // Mark as read if UI is open and message is not from me
       if (isMessagesUIOpen() && !isLocalMessage(message)) {

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -1155,6 +1155,8 @@ export function initMessagesUI() {
    */
   function prepareConversation(conversationId, contactId) {
     if (!conversationId) return;
+    if (shownConversationId === conversationId) return;
+    shownConversationId = conversationId;
 
     if (markAsReadTimeout !== null) {
       clearTimeout(markAsReadTimeout);
@@ -1616,6 +1618,7 @@ export function initMessagesUI() {
   }
 
   let lastTimestamp = 0;
+  let shownConversationId = null;
   const TIMESTAMP_THRESHOLD = 5 * 60 * 1000; // 5 minutes
 
   /**
@@ -1672,6 +1675,9 @@ export function initMessagesUI() {
   messagingController.on(
     'conversation:closed',
     ({ conversationId }) => {
+      if (shownConversationId === conversationId) {
+        shownConversationId = null;
+      }
       clearMessages();
       refreshAttachButton();
     },

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -6,7 +6,10 @@ import {
   isHidden,
   showElement,
 } from '../../../components/ui/utils/ui-utils.js';
-import { renderAvatar } from '../../../components/ui/utils/avatar.js';
+import {
+  renderAvatar,
+  createAvatar,
+} from '../../../components/ui/utils/avatar.js';
 import { createMessageToggle } from './createMessageToggle.js';
 import { isIOSOrAndroidDevice } from '../../../utils/detect-device.js';
 
@@ -625,30 +628,6 @@ export function initMessagesUI() {
     p._reactionCleanup = () => gesture.destroy();
   }
 
-  /**
-   * Create an avatar span for a message.
-   * @param {boolean} isLocal - true for local user, false for remote
-   */
-  function createAvatar(isLocal) {
-    const avatarSpan = document.createElement('span');
-    avatarSpan.className =
-      'sender-avatar' + (isLocal ? ' sender-avatar--me' : '');
-    avatarSpan.setAttribute('aria-hidden', 'true');
-
-    if (isLocal) {
-      renderAvatar(avatarSpan, { customFallbackText: t('shared.me') });
-    } else {
-      const conversationId = messagingController.getSelectedConversationId();
-      const participantName =
-        messagingController.getConversationDisplayName(conversationId) || 'U';
-      const photoURL =
-        messagingController.getConversationPhotoURL(conversationId) || '';
-      renderAvatar(avatarSpan, { name: participantName, photoURL });
-    }
-
-    return avatarSpan;
-  }
-
   // --- Content builders ---
 
   function buildTextContent(text) {
@@ -856,14 +835,32 @@ export function initMessagesUI() {
 
     // Avatar (sibling to message-bubble) - only for remote messages
     if (isLocal === false) {
-      messageEntry.appendChild(createAvatar(false));
+      const conversationId = messagingController.getSelectedConversationId();
+      const participantName =
+        messagingController.getConversationDisplayName(conversationId) || 'U';
+      const photoURL =
+        messagingController.getConversationPhotoURL(conversationId) || '';
+      // If the sender's profile isn't loaded yet, render blank —
+      // conversation:meta-updated will refresh all avatars once it arrives.
+      const senderId = message.from;
+      const pending =
+        !photoURL &&
+        !!senderId &&
+        messagingController.getParticipantProfile(conversationId, senderId) ===
+          null;
+
+      const avatarSpan = createAvatar({
+        name: participantName,
+        photoURL,
+        pending,
+        classList: ['sender-avatar'],
+      });
+      messageEntry.appendChild(avatarSpan);
     }
 
     // message-bubble: container for content + reactions
     const messageBubble = document.createElement('div');
     messageBubble.className = 'message-bubble';
-
-    // p element inside message-bubble
     const p = document.createElement('p');
 
     // Type-specific content

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -1671,9 +1671,6 @@ export function initMessagesUI() {
     ({ conversationId }) => {
       clearMessages();
       refreshAttachButton();
-      if (messageTopBar) {
-        messageTopBar.setContact({ name: '', photoURL: '' });
-      }
     },
     { signal: ac.signal },
   );

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -840,14 +840,14 @@ export function initMessagesUI() {
         messagingController.getConversationDisplayName(conversationId) || 'U';
       const photoURL =
         messagingController.getConversationPhotoURL(conversationId) || '';
-      // If the sender's profile isn't loaded yet, render blank —
-      // conversation:meta-updated will refresh all avatars once it arrives.
+      // If the sender's profile isn't fetched yet, render blank —
+      // conversation:meta-updated will refresh all avatars once it resolves.
+      // A failed fetch counts as fetched, so we fall back to the letter instead.
       const senderId = message.from;
       const pending =
         !photoURL &&
         !!senderId &&
-        messagingController.getParticipantProfile(conversationId, senderId) ===
-          null;
+        !messagingController.isParticipantFetched(conversationId, senderId);
 
       const avatarSpan = createAvatar({
         name: participantName,
@@ -1170,8 +1170,7 @@ export function initMessagesUI() {
     // Profile not yet fetched — render blank avatar to avoid letter-fallback flicker
     const photoPending =
       !!contactId &&
-      messagingController.getParticipantProfile(conversationId, contactId) ===
-        null;
+      !messagingController.isParticipantFetched(conversationId, contactId);
 
     if (messageTopBar) {
       messageTopBar.setContact({ name, photoURL, pending: photoPending });

--- a/src/features/messaging/messaging-controller.js
+++ b/src/features/messaging/messaging-controller.js
@@ -220,12 +220,10 @@ export class MessagingController extends EventEmitter {
       });
 
       // Re-emit cached participants so UI can update after conversation switch
-      if (Object.keys(conversationState.participants).length > 0) {
-        this.emit('conversation:meta-updated', {
-          conversationId,
-          participants: { ...conversationState.participants },
-        });
-      }
+      this.emit('conversation:meta-updated', {
+        conversationId,
+        participants: { ...conversationState.participants },
+      });
 
       return;
     }
@@ -349,13 +347,30 @@ export class MessagingController extends EventEmitter {
     const state = this.conversations.get(conversationId);
     if (!state) return;
 
-    if (profile) {
-      state.participants[participantId] = profile;
-    }
+    // Always record the attempt — null means "fetched, no profile available".
+    // Lets callers distinguish "never fetched" (key absent) from "fetch resolved null".
+    state.participants[participantId] = profile || null;
     this.emit('conversation:meta-updated', {
       conversationId,
       participants: { ...state.participants },
     });
+  }
+
+  /**
+   * Returns true once a profile fetch has resolved (success or failure).
+   * Used to decide whether an avatar should render "pending" (blank) or
+   * fall back to a letter when no photoURL is available.
+   * @param {string} conversationId
+   * @param {string} participantId
+   * @returns {boolean}
+   */
+  isParticipantFetched(conversationId, participantId) {
+    const state = this.conversations.get(conversationId);
+    if (!state) return false;
+    return Object.prototype.hasOwnProperty.call(
+      state.participants,
+      participantId,
+    );
   }
 
   getSelectedConversationState() {

--- a/src/features/messaging/messaging-controller.test.js
+++ b/src/features/messaging/messaging-controller.test.js
@@ -232,13 +232,16 @@ describe('MessagingController', () => {
     await vi.waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
         conversationId: 'contactA_me',
-        participants: {},
+        participants: { contactA: null },
       });
     });
 
     expect(controller.getParticipantProfile('contactA_me', 'contactA')).toBe(
       null,
     );
+    expect(
+      controller.isParticipantFetched('contactA_me', 'contactA'),
+    ).toBe(true);
   });
 
   it('should prefer provided contactNickName over participant userName', async () => {

--- a/src/styles/components/messages.css
+++ b/src/styles/components/messages.css
@@ -443,7 +443,7 @@
 }
 
 /* Order rules: remote avatar on the left */
-#messages .message-entry .avatar.remote {
+#messages .message-entry .sender-avatar {
   order: 0;
 }
 #messages .message-entry.local .message-bubble {

--- a/src/styles/components/messages.css
+++ b/src/styles/components/messages.css
@@ -1,3 +1,13 @@
+@keyframes scale-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 /* ===== MESSAGES COMPONENT ===== */
 
 #messages {
@@ -122,19 +132,30 @@
     flex: 1;
   }
 
-  & .messages-topbar-avatar {
+  & .avatar {
     width: 28px;
     height: 28px;
+    flex-shrink: 0;
     border-radius: 50%;
-    background: #3757c1;
+    border: solid 1px rgba(122, 128, 135, 0.356);
+    background-color: rgba(43, 69, 156, 0.4);
     color: #ffffff;
+    text-shadow: var(--text-shadow-medium);
     font-size: 13px;
     font-weight: 600;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background-size: cover;
-    background-position: center;
+    overflow: hidden;
+    z-index: var(--z-low);
+
+    & > img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 50%;
+      animation: scale-in 220ms ease-out both;
+    }
   }
 
   & .messages-topbar-name {
@@ -408,28 +429,20 @@
   margin-right: 2px;
   font-size: 13px;
   line-height: 1;
+  overflow: hidden;
 }
 
-#messages .sender-avatar--image {
-  color: transparent;
-  text-shadow: none;
+#messages .sender-avatar > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  animation: scale-in 220ms ease-out both;
 }
 
-/* Slightly different avatar for local user (on right) */
-#messages .sender-avatar--me {
-  display: none; /* hide local avatar. TODO: Remove completely if deciding to not use local avatar */
-  background: #228332;
-  color: #ffffff;
-  margin-right: 0;
-  margin-left: 2px;
-}
-
-/* Order rules: avatar left for remote, right for local */
-#messages .message-entry .sender-avatar {
+/* Order rules: remote avatar on the left */
+#messages .message-entry .avatar.remote {
   order: 0;
-}
-#messages .message-entry.local .sender-avatar {
-  order: 1;
 }
 #messages .message-entry.local .message-bubble {
   order: 0;

--- a/src/styles/components/messages.css
+++ b/src/styles/components/messages.css
@@ -154,6 +154,9 @@
       height: 100%;
       object-fit: cover;
       border-radius: 50%;
+    }
+
+    & > img.avatar-entry-animation {
       animation: scale-in 220ms ease-out both;
     }
   }
@@ -437,7 +440,6 @@
   height: 100%;
   object-fit: cover;
   border-radius: 50%;
-  animation: scale-in 220ms ease-out both;
 }
 
 /* Order rules: remote avatar on the left */


### PR DESCRIPTION
## Summary
- Google profile photos (`lh3.googleusercontent.com`) were 403ing because `new Image()` sends a `Referer` header. Now rendered as `<img>` children with `referrerPolicy='no-referrer'`.
- Every `conversation:meta-updated` re-ran `renderAvatar` on every message entry, firing one `new Image()` per message for the same URL. Now idempotent via `dataset.avatarState` (keys: `pending` / `letter:<name>` / `<url>`).
- `appendMessage` now passes `pending: true` when the sender's profile isn't loaded yet, avoiding the letter-fallback flicker before the image arrives.
- Dropped the `new Image()` preloader, the `loading`/`ready` class juggling, the `imageClass` param, dead `.avatar-image` / `.loading` / `.ready` CSS, and debug logs.

## Test plan
- [x] Manual: open preloaded conversation — image loads on first try, single fetch per URL
- [x] Manual: click a contact — avatar renders blank first, then swaps to image without letter flicker
- [ ] Check other `.avatar` usages outside messages UI (topbar, etc.) still render

## Known follow-up
Unrelated: selecting a conversation via the "Conversation already open" path in `messaging-controller.js` can sometimes leave message avatars empty. Traced to event ordering / stale participants, not avatar logic. To investigate separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Avatars now use image elements with async decoding and privacy-safe loading; first-seen photos play a per-session scale-in animation. Top-bar and message avatar styling/cropping improved.
  * Remote avatars support a “pending” state that defers photo display until profile data is resolved.

* **Bug Fixes**
  * Failed or missing photos reliably fall back to the contact’s initial (or "U" when name is empty); pending avatars render blank until ready.
  * More consistent avatar load/error handling and avatar ordering in messaging UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->