### PR TITLE
feat: drag-and-drop file sending in messages

### DIFF
--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -27,6 +27,7 @@ import { createMessageBox } from './createMessageBox.js';
 import { createMessageTopBar } from './createMessageTopBar.js';
 import { devDebug } from '../../../shared/utils/dev/dev-utils.js';
 import { onTapGesture } from '../../../shared/components/ui/utils/detectDoubleClick.js';
+import { onFileDrop } from '../../../shared/components/ui/utils/onFileDrop.js';
 import { isSafeDownloadUrl } from '../../../shared/utils/security/validate-url.js';
 import { dispatchCommand } from '../../../shared/events/index.js';
 import { createImagePreviewNode } from './file-preview-renderer.js';
@@ -289,6 +290,12 @@ export function initMessagesUI() {
       setSendLabelText(originalText);
       fileInput.value = '';
     }
+  });
+
+  // Enable drag-and-drop file sending on the messages area
+  const cleanupFileDrop = onFileDrop(messagesBox, (files) => {
+    fileInput.files = files;
+    fileInput.dispatchEvent(new Event('change', { bubbles: true }));
   });
 
   // Position the messages box relative to toggle
@@ -1575,6 +1582,7 @@ export function initMessagesUI() {
     }
 
     detachRepositionHandlers();
+    cleanupFileDrop();
     // Remove document click/escape listeners created by onClickOutside
     if (typeof removeMessagesBoxClickOutside === 'function') {
       try {

--- a/src/shared/components/ui/utils/onFileDrop.js
+++ b/src/shared/components/ui/utils/onFileDrop.js
@@ -1,0 +1,92 @@
+/**
+ * Attaches drag-and-drop file detection to an element.
+ * Toggles a `dragover` attribute on the element while files are dragged over it.
+ * Calls `onDrop` with a FileList when files are dropped.
+ * Returns a cleanup function to remove all listeners.
+ *
+ * @param {HTMLElement} element - The drop target element.
+ * @param {(files: FileList) => void} onDrop - Called with the dropped FileList.
+ * @param {Object} [options]
+ * @param {string} [options.accept] - Comma-separated MIME types or extensions to filter (e.g. "image/*,.pdf").
+ * @returns {() => void} cleanup - Call to remove all attached listeners.
+ */
+export function onFileDrop(element, onDrop, options = {}) {
+  if (!element || typeof onDrop !== 'function') {
+    throw new Error('onFileDrop: valid element and onDrop callback required');
+  }
+
+  const { accept } = options;
+
+  let dragCounter = 0;
+
+  function hasFiles(e) {
+    return [...e.dataTransfer.items].some((i) => i.kind === 'file');
+  }
+
+  function handleDragEnter(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragCounter++;
+    if (dragCounter === 1) element.setAttribute('dragover', '');
+  }
+
+  function handleDragOver(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+  }
+
+  function handleDragLeave() {
+    dragCounter--;
+    if (dragCounter <= 0) {
+      dragCounter = 0;
+      element.removeAttribute('dragover');
+    }
+  }
+
+  function handleDrop(e) {
+    e.preventDefault();
+    dragCounter = 0;
+    element.removeAttribute('dragover');
+
+    const files = e.dataTransfer.files;
+    if (!files.length) return;
+
+    if (accept) {
+      const dt = new DataTransfer();
+      for (const file of files) {
+        if (matchesAccept(file, accept)) dt.items.add(file);
+      }
+      if (dt.files.length) onDrop(dt.files);
+    } else {
+      onDrop(files);
+    }
+  }
+
+  element.addEventListener('dragenter', handleDragEnter);
+  element.addEventListener('dragover', handleDragOver);
+  element.addEventListener('dragleave', handleDragLeave);
+  element.addEventListener('drop', handleDrop);
+
+  return function cleanup() {
+    element.removeEventListener('dragenter', handleDragEnter);
+    element.removeEventListener('dragover', handleDragOver);
+    element.removeEventListener('dragleave', handleDragLeave);
+    element.removeEventListener('drop', handleDrop);
+    element.removeAttribute('dragover');
+  };
+}
+
+/**
+ * @param {File} file
+ * @param {string} accept - Comma-separated rules, e.g. "image/*,.pdf,video/mp4"
+ */
+function matchesAccept(file, accept) {
+  return accept.split(',').some((rule) => {
+    rule = rule.trim();
+    if (!rule) return false;
+    if (rule.startsWith('.'))
+      return file.name.toLowerCase().endsWith(rule.toLowerCase());
+    if (rule.endsWith('/*')) return file.type.startsWith(rule.slice(0, -1));
+    return file.type === rule;
+  });
+}

--- a/src/shared/components/ui/utils/onFileDrop.js
+++ b/src/shared/components/ui/utils/onFileDrop.js
@@ -46,6 +46,8 @@ export function onFileDrop(element, onDrop, options = {}) {
   }
 
   function handleDrop(e) {
+    if (!hasFiles(e)) return;
+
     e.preventDefault();
     dragCounter = 0;
     element.removeAttribute('dragover');

--- a/src/shared/components/ui/utils/onFileDrop.js
+++ b/src/shared/components/ui/utils/onFileDrop.js
@@ -20,7 +20,9 @@ export function onFileDrop(element, onDrop, options = {}) {
   let dragCounter = 0;
 
   function hasFiles(e) {
-    return [...e.dataTransfer.items].some((i) => i.kind === 'file');
+    const items = e && e.dataTransfer && e.dataTransfer.items;
+    if (!items || typeof items.length !== 'number') return false;
+    return Array.from(items).some((i) => i.kind === 'file');
   }
 
   function handleDragEnter(e) {
@@ -48,8 +50,8 @@ export function onFileDrop(element, onDrop, options = {}) {
     dragCounter = 0;
     element.removeAttribute('dragover');
 
-    const files = e.dataTransfer.files;
-    if (!files.length) return;
+    const files = e.dataTransfer && e.dataTransfer.files;
+    if (!files || !files.length) return;
 
     if (accept) {
       const dt = new DataTransfer();

--- a/src/shared/styles/components/messages.css
+++ b/src/shared/styles/components/messages.css
@@ -95,6 +95,16 @@
   z-index: var(--z-mid);
 }
 
+.messages-box[dragover] {
+  outline: 2px dashed var(--border-accent, #666);
+  outline-offset: -4px;
+  background: color-mix(
+    in srgb,
+    var(--bg-secondary) 92%,
+    var(--border-accent, #666)
+  );
+}
+
 /* Slide / fade animation for show/hide
    - default state: hidden (out of view, non-interactive)
    - `.messages-box--open` toggles the visible state and drives transitions


### PR DESCRIPTION
## Summary
- Add reusable `onFileDrop` utility for drag-and-drop file detection
- Wire it into messages-ui so files can be dropped onto the message box
- Add dragover visual indicator styles on `#messages-box[dragover]`

## Test plan
- [ ] Drop a file onto the open message box — sends correctly
- [ ] Verify dragover outline appears/disappears on drag enter/leave
- [ ] Attach button file picker still works as before
- [ ] Test in-call (WebRTC) and out-of-call (persistent) file send paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop file upload to the messaging interface; users can drop files into the messages box and they flow into the existing upload workflow.
* **Style**
  * Added visual drag-over feedback (dashed outline and blended background) when files are dragged over the message area.
* **Bug Fixes**
  * Ensures drag handlers are cleaned up when the messaging UI is closed to avoid lingering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->