### PR TITLE
feat: support multiple file upload via drag-and-drop

### DIFF
--- a/src/features/messaging/components/createMessageBox.js
+++ b/src/features/messaging/components/createMessageBox.js
@@ -28,7 +28,7 @@ export function createMessageBox() {
         <textarea id="messages-input" placeholder="" rows="1"></textarea>
 
         <div class="message-attachments">
-          <input type="file" id="file-input" style="display: none" />
+          <input type="file" id="file-input" multiple style="display: none" />
           <button type="button" id="attach-file-btn" title="">
             <i data-lucide="paperclip" aria-hidden="true"></i>
           </button>

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -214,11 +214,8 @@ export function initMessagesUI() {
     fileInput.click();
   });
 
-  // Handle file selection for sending
-  fileInput.addEventListener('change', async (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
+  // Send a single file through the appropriate channel
+  async function sendFile(file) {
     const originalText = getSendLabelText();
     const sendLabelStartMs = performance.now();
     setSendLabelText(t('message.sending'));
@@ -288,14 +285,20 @@ export function initMessagesUI() {
       });
     } finally {
       setSendLabelText(originalText);
-      fileInput.value = '';
     }
+  }
+
+  // Handle file selection for sending (supports multiple files)
+  fileInput.addEventListener('change', async (e) => {
+    const files = [...e.target.files];
+    if (!files.length) return;
+    for (const file of files) await sendFile(file);
+    fileInput.value = '';
   });
 
   // Enable drag-and-drop file sending on the messages area
-  const cleanupFileDrop = onFileDrop(messagesBox, (files) => {
-    fileInput.files = files;
-    fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+  const cleanupFileDrop = onFileDrop(messagesBox, async (files) => {
+    for (const file of files) await sendFile(file);
   });
 
   // Position the messages box relative to toggle


### PR DESCRIPTION
## Summary
- Add `multiple` attribute to file input for multi-select in native picker
- Extract `sendFile(file)` from inline change handler for reuse
- Drop handler calls `sendFile` directly instead of proxying through fileInput — files send sequentially with per-file progress UI

## Test plan
- [ ] Drag multiple files onto message area, verify all send sequentially
- [ ] Use file picker button to select multiple files, verify all send
- [ ] Single file drag-and-drop still works
- [ ] Single file picker still works
- [ ] Progress UI displays correctly per file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Users can now select and attach multiple files at once, instead of being limited to a single file per action.
* Enhanced file-sending workflow to efficiently process multiple attachments.
* Improved drag-and-drop functionality for better file upload experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->