### PR TITLE
fix(messaging): Prevent image preview from opening during scroll

### DIFF
--- a/src/features/messaging/components/file-preview-renderer.js
+++ b/src/features/messaging/components/file-preview-renderer.js
@@ -10,7 +10,41 @@ export function createImagePreviewNode({ fileName, previewUrl }) {
   img.src = previewUrl;
   img.alt = fileName;
 
-  const openPreview = () => {
+  let startX = 0;
+  let startY = 0;
+  let hasMoved = false;
+
+  img.addEventListener(
+    'touchstart',
+    (e) => {
+      if (e.touches.length > 0) {
+        startX = e.touches[0].clientX;
+        startY = e.touches[0].clientY;
+      }
+      hasMoved = false;
+    },
+    { passive: true },
+  );
+
+  img.addEventListener(
+    'touchmove',
+    (e) => {
+      if (e.touches.length > 0) {
+        const moveX = e.touches[0].clientX;
+        const moveY = e.touches[0].clientY;
+        if (Math.abs(moveX - startX) > 10 || Math.abs(moveY - startY) > 10) {
+          hasMoved = true;
+        }
+      }
+    },
+    { passive: true },
+  );
+
+  const openPreview = (e) => {
+    if (hasMoved) {
+      hasMoved = false; // Prevent preview for the drag/scroll interaction, but reset for future pointer events
+      return;
+    }
     showImagePreview(previewUrl, fileName);
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image previews in messaging no longer open unintentionally when you drag or scroll on touch devices. The preview is suppressed if your touch interaction moves beyond a small threshold, preventing accidental preview pop-ups and improving touch scrolling and dragging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->