### PR TITLE
Fix logout messaging cleanup and clear local storage

### DIFF
--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -30,10 +30,35 @@ function runSafe(fn, label) {
   }
 }
 
+const LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT = ['locale', 'recentCalls'];
+const LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT = ['debug:', 'referral'];
+
 function clearLocalStorageOnLogout() {
   try {
     if (typeof localStorage !== 'undefined') {
+      const preservedEntries = [];
+
+      for (let index = 0; index < localStorage.length; index += 1) {
+        const key = localStorage.key(index);
+
+        if (
+          key &&
+          (LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT.includes(key) ||
+            LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT.some((prefix) =>
+              key.startsWith(prefix)
+            ))
+        ) {
+          preservedEntries.push([key, localStorage.getItem(key)]);
+        }
+      }
+
       localStorage.clear();
+
+      preservedEntries.forEach(([key, value]) => {
+        if (value !== null) {
+          localStorage.setItem(key, value);
+        }
+      });
     }
   } catch (error) {
     console.warn('[setupAuth] Failed to clear localStorage on logout:', error);

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -32,10 +32,11 @@ function runSafe(fn, label) {
 
 const LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT = [
   'locale',
-  'recentCalls',
-  'referredBy',
+  // Only keeping safe non-user scoped keys (keeping these comments for now while testing)
+  // 'recentCalls',
+  // 'referredBy',
 ];
-const LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT = ['debug:', 'referral'];
+const LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT = ['debug:']; // 'referral'
 
 function clearLocalStorageOnLogout() {
   try {
@@ -53,7 +54,7 @@ function clearLocalStorageOnLogout() {
         key &&
         (LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT.includes(key) ||
           LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT.some((prefix) =>
-            key.startsWith(prefix)
+            key.startsWith(prefix),
           ))
       ) {
         preservedEntries.push([key, storage.getItem(key)]);

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -84,11 +84,14 @@ export function setupAuth(options = {}) {
     };
 
     const runMainLogoutCleanup = () => {
-      cleanupLoginScopedListeners();
-      messagingController.closeAllConversations();
-      messagesUI.reset();
+      runSafe(cleanupLoginScopedListeners, 'cleanupLoginScopedListeners');
+      runSafe(
+        () => messagingController.closeAllConversations(),
+        'messagingController.closeAllConversations',
+      );
+      runSafe(() => messagesUI?.reset?.(), 'messagesUI.reset');
       // NOTE: Local storage is cleared on log out.
-      clearLocalStorageOnLogout();
+      runSafe(clearLocalStorageOnLogout, 'clearLocalStorageOnLogout');
     };
 
     try {

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -5,6 +5,8 @@ import {
   removeAllIncomingListeners,
   startListeningForSavedRooms,
 } from '../features/call/room-listeners.js';
+import { messagingController } from '../features/messaging/messaging-controller.js';
+import { messagesUI } from '../features/messaging/components/messages-ui.js';
 import {
   cleanupInviteListeners,
   setupInviteListener,
@@ -25,6 +27,16 @@ function runSafe(fn, label) {
     fn?.();
   } catch (error) {
     console.warn(`[setupAuth] ${label} failed:`, error);
+  }
+}
+
+function clearLocalStorageOnLogout() {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  } catch (error) {
+    console.warn('[setupAuth] Failed to clear localStorage on logout:', error);
   }
 }
 
@@ -71,6 +83,14 @@ export function setupAuth(options = {}) {
       };
     };
 
+    const runMainLogoutCleanup = () => {
+      cleanupLoginScopedListeners();
+      messagingController.closeAllConversations();
+      messagesUI.reset();
+      // NOTE: Local storage is cleared on log out.
+      clearLocalStorageOnLogout();
+    };
+
     try {
       subscribe(
         'evt:auth:session:ready',
@@ -89,7 +109,7 @@ export function setupAuth(options = {}) {
         async () => {
           try {
             devDebug('[AUTH] User logged out - cleaning up listeners');
-            cleanupLoginScopedListeners();
+            runMainLogoutCleanup();
 
             await renderContactsList(lobbyElement);
           } catch (e) {

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -116,7 +116,7 @@ export function setupAuth(options = {}) {
       );
       runSafe(() => messagesUI?.reset?.(), 'messagesUI.reset');
       // NOTE: Local storage is cleared on log out.
-      runSafe(clearLocalStorageOnLogout, 'clearLocalStorageOnLogout');
+      clearLocalStorageOnLogout();
     };
 
     try {

--- a/src/setup/setupAuth.js
+++ b/src/setup/setupAuth.js
@@ -30,36 +30,43 @@ function runSafe(fn, label) {
   }
 }
 
-const LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT = ['locale', 'recentCalls'];
+const LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT = [
+  'locale',
+  'recentCalls',
+  'referredBy',
+];
 const LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT = ['debug:', 'referral'];
 
 function clearLocalStorageOnLogout() {
   try {
-    if (typeof localStorage !== 'undefined') {
-      const preservedEntries = [];
-
-      for (let index = 0; index < localStorage.length; index += 1) {
-        const key = localStorage.key(index);
-
-        if (
-          key &&
-          (LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT.includes(key) ||
-            LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT.some((prefix) =>
-              key.startsWith(prefix)
-            ))
-        ) {
-          preservedEntries.push([key, localStorage.getItem(key)]);
-        }
-      }
-
-      localStorage.clear();
-
-      preservedEntries.forEach(([key, value]) => {
-        if (value !== null) {
-          localStorage.setItem(key, value);
-        }
-      });
+    const storage = globalThis.localStorage;
+    if (!storage) {
+      return;
     }
+
+    const preservedEntries = [];
+
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+
+      if (
+        key &&
+        (LOCAL_STORAGE_KEYS_TO_PRESERVE_ON_LOGOUT.includes(key) ||
+          LOCAL_STORAGE_PREFIXES_TO_PRESERVE_ON_LOGOUT.some((prefix) =>
+            key.startsWith(prefix)
+          ))
+      ) {
+        preservedEntries.push([key, storage.getItem(key)]);
+      }
+    }
+
+    storage.clear();
+
+    preservedEntries.forEach(([key, value]) => {
+      if (value !== null) {
+        storage.setItem(key, value);
+      }
+    });
   } catch (error) {
     console.warn('[setupAuth] Failed to clear localStorage on logout:', error);
   }
@@ -115,7 +122,7 @@ export function setupAuth(options = {}) {
         'messagingController.closeAllConversations',
       );
       runSafe(() => messagesUI?.reset?.(), 'messagesUI.reset');
-      // NOTE: Local storage is cleared on log out.
+      // NOTE: Local storage is cleared on log out, while selected keys are preserved.
       clearLocalStorageOnLogout();
     };
 

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => {
         return () => handlers.delete(eventName);
       }),
     },
+    closeAllConversations: vi.fn(),
+    resetMessagesUI: vi.fn(),
     renderContactsList: vi.fn(() => Promise.resolve()),
     removeAllIncomingListeners: vi.fn(),
     startListeningForSavedRooms: vi.fn(() => Promise.resolve()),
@@ -40,6 +42,18 @@ vi.mock('../../features/call/room-listeners.js', () => ({
   startListeningForSavedRooms: mocks.startListeningForSavedRooms,
 }));
 
+vi.mock('../../features/messaging/messaging-controller.js', () => ({
+  messagingController: {
+    closeAllConversations: mocks.closeAllConversations,
+  },
+}));
+
+vi.mock('../../features/messaging/components/messages-ui.js', () => ({
+  messagesUI: {
+    reset: mocks.resetMessagesUI,
+  },
+}));
+
 vi.mock('../../features/contacts/index.js', () => ({
   cleanupInviteListeners: mocks.cleanupInviteListeners,
   setupInviteListener: mocks.setupInviteListener,
@@ -56,10 +70,17 @@ vi.mock('../../features/notifications/index.js', () => ({
 }));
 
 describe('setupAuth', () => {
+  let localStorageClearSpy;
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.handlers.clear();
+    localStorageClearSpy = vi.spyOn(Storage.prototype, 'clear');
+  });
+
+  afterEach(() => {
+    localStorageClearSpy?.mockRestore();
   });
 
   it('renders contacts when auth becomes ready', async () => {
@@ -111,6 +132,9 @@ describe('setupAuth', () => {
     expect(mocks.renderContactsList).toHaveBeenCalledWith(lobbyElement);
     expect(mocks.removeAllIncomingListeners).toHaveBeenCalled();
     expect(mocks.cleanupInviteListeners).toHaveBeenCalled();
+    expect(mocks.closeAllConversations).toHaveBeenCalled();
+    expect(mocks.resetMessagesUI).toHaveBeenCalled();
+    expect(localStorageClearSpy).toHaveBeenCalled();
 
     teardown();
   });

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   const handlers = new Map();

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -88,8 +88,7 @@ describe('setupAuth', () => {
         localStorageData.has(String(key))
           ? localStorageData.get(String(key))
           : null,
-      setItem: (key, value) =>
-        localStorageData.set(String(key), String(value)),
+      setItem: (key, value) => localStorageData.set(String(key), String(value)),
       removeItem: (key) => localStorageData.delete(String(key)),
       clear: () => localStorageData.clear(),
     };
@@ -163,7 +162,6 @@ describe('setupAuth', () => {
     const { setupAuth } = await import('../setupAuth.js');
     const lobbyElement = { id: 'lobby' };
 
-    globalThis.localStorage.setItem('referredBy', 'ref-123');
     globalThis.localStorage.setItem('locale', 'is');
     globalThis.localStorage.setItem('volatileKey', 'drop-me');
 
@@ -171,7 +169,6 @@ describe('setupAuth', () => {
 
     await mocks.handlers.get('evt:auth:session:logout')({});
 
-    expect(globalThis.localStorage.getItem('referredBy')).toBe('ref-123');
     expect(globalThis.localStorage.getItem('locale')).toBe('is');
     expect(globalThis.localStorage.getItem('volatileKey')).toBeNull();
 

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -138,4 +138,28 @@ describe('setupAuth', () => {
 
     teardown();
   });
+
+  it('continues logout cleanup when conversation close throws', async () => {
+    const { setupAuth } = await import('../setupAuth.js');
+    const lobbyElement = { id: 'lobby' };
+
+    mocks.closeAllConversations.mockImplementationOnce(() => {
+      throw new Error('close failed');
+    });
+
+    const teardown = await setupAuth({ lobbyElement });
+
+    await expect(
+      mocks.handlers.get('evt:auth:session:logout')({}),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.renderContactsList).toHaveBeenCalledWith(lobbyElement);
+    expect(mocks.removeAllIncomingListeners).toHaveBeenCalled();
+    expect(mocks.cleanupInviteListeners).toHaveBeenCalled();
+    expect(mocks.closeAllConversations).toHaveBeenCalled();
+    expect(mocks.resetMessagesUI).toHaveBeenCalled();
+    expect(localStorageClearSpy).toHaveBeenCalled();
+
+    teardown();
+  });
 });

--- a/src/setup/tests/setupAuth.test.js
+++ b/src/setup/tests/setupAuth.test.js
@@ -71,16 +71,36 @@ vi.mock('../../features/notifications/index.js', () => ({
 
 describe('setupAuth', () => {
   let localStorageClearSpy;
+  let localStorageRef;
+  let localStorageData;
 
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.handlers.clear();
-    localStorageClearSpy = vi.spyOn(Storage.prototype, 'clear');
+    localStorageData = new Map();
+    localStorageRef = {
+      get length() {
+        return localStorageData.size;
+      },
+      key: (index) => Array.from(localStorageData.keys())[index] ?? null,
+      getItem: (key) =>
+        localStorageData.has(String(key))
+          ? localStorageData.get(String(key))
+          : null,
+      setItem: (key, value) =>
+        localStorageData.set(String(key), String(value)),
+      removeItem: (key) => localStorageData.delete(String(key)),
+      clear: () => localStorageData.clear(),
+    };
+
+    vi.stubGlobal('localStorage', localStorageRef);
+    localStorageClearSpy = vi.spyOn(globalThis.localStorage, 'clear');
   });
 
   afterEach(() => {
     localStorageClearSpy?.mockRestore();
+    vi.unstubAllGlobals();
   });
 
   it('renders contacts when auth becomes ready', async () => {
@@ -135,6 +155,25 @@ describe('setupAuth', () => {
     expect(mocks.closeAllConversations).toHaveBeenCalled();
     expect(mocks.resetMessagesUI).toHaveBeenCalled();
     expect(localStorageClearSpy).toHaveBeenCalled();
+
+    teardown();
+  });
+
+  it('preserves selected localStorage keys on logout', async () => {
+    const { setupAuth } = await import('../setupAuth.js');
+    const lobbyElement = { id: 'lobby' };
+
+    globalThis.localStorage.setItem('referredBy', 'ref-123');
+    globalThis.localStorage.setItem('locale', 'is');
+    globalThis.localStorage.setItem('volatileKey', 'drop-me');
+
+    const teardown = await setupAuth({ lobbyElement });
+
+    await mocks.handlers.get('evt:auth:session:logout')({});
+
+    expect(globalThis.localStorage.getItem('referredBy')).toBe('ref-123');
+    expect(globalThis.localStorage.getItem('locale')).toBe('is');
+    expect(globalThis.localStorage.getItem('volatileKey')).toBeNull();
 
     teardown();
   });


### PR DESCRIPTION
## Summary\n- add explicit main logout cleanup path in auth setup\n- close all messaging conversations and reset messages UI on logout\n- clear localStorage on logout with explicit in-code note\n- extend setupAuth logout tests to assert messaging cleanup and localStorage clear\n\n## Validation\n- /Users/kristinnroachgunnarsson/Desktop/Dev/HangVidU/node_modules/.bin/vitest --run src/setup/tests/setupAuth.test.js\n- Test Files: 1 passed\n- Tests: 3 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now reliably closes active conversations, resets the messaging view, and clears local session data while preserving important settings (locale, recent calls, referral/debug keys); cleanup continues even if individual steps fail to avoid stuck sessions.

* **Tests**
  * Added tests covering the expanded logout cleanup and a failure scenario to ensure remaining cleanup still runs and resolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->