### PR TITLE
feat(call): audio-only call button + audioOnly flag E2E

### DIFF
--- a/src/features/call/CALL_E2E_FLOW_TRACE.md
+++ b/src/features/call/CALL_E2E_FLOW_TRACE.md
@@ -1,0 +1,127 @@
+# Call E2E Flow Trace
+
+Reference snapshot of the current call code path, captured while threading the `audioOnly` flag end-to-end. Intended as input to the upcoming refactor that simplifies/decouples this trace via the new `src/events/` shared API.
+
+Both paths are listed in execution order. Each step links a function with its file and the line where the function definition starts.
+
+---
+
+## A. Initiator Path (outgoing call)
+
+User taps the call button in the message top bar. The flow ends with the initiator waiting for an SDP answer.
+
+1. **Click handler — `setCallHandler` / `setAudioCallHandler`** — `src/features/messaging/components/messages-ui.js:177`
+   Builds the call payload from the current conversation state and dispatches `cmd:call:outgoing:initiate` on the app bus (audio button adds `audioOnly: true`).
+
+2. **`handleCommand('cmd:call:outgoing:initiate')`** — `src/setup/setupMainAppBusListeners.js:152`
+   Resolves the contact nickname, optionally selects the conversation in messaging controller, then forwards to `callContact(contactId, name, roomId, { audioOnly })`.
+
+3. **`callContact(contactId, contactNickName, roomId, { audioOnly })`** — `src/features/call/WIP-start-call-refactor.js:153`
+   Computes a deterministic room id when none is provided, lazy-imports the calling UI bundle, attaches an incoming listener for the room, then calls `joinOrCreateRoomWithId(roomId, { forceInitiator: true, audioOnly })`.
+
+4. **`listenForIncomingOnRoom(roomId)`** — `src/features/call/room-listeners.js:458`
+   Attaches RTDB listeners for member joins, cancellations, and member leaves on the room (used here to receive the joiner's eventual response).
+
+5. **`joinOrCreateRoomWithId(roomId, { forceInitiator, audioOnly })`** — `src/features/call/WIP-start-call-refactor.js:58`
+   Initializes local media, then (because `forceInitiator` is true) skips the room-status probe and goes straight to creating the call.
+
+6. **`initLocalStreamAndMedia({ audioOnly })`** — `src/shared/media/WIP-init-local-media.js:19`
+   Idempotent setup of the local media stream and media-control buttons; passes `audioOnly` down to `setUpLocalStream`.
+
+7. **`setUpLocalStream(localVideoEl, { audioOnly })`** — `src/shared/media/stream.js:65`
+   Acquires the local stream and (for video calls) wires a video-only preview into the local video element. Skips the preview wiring entirely when `audioOnly` is true.
+
+8. **`createLocalStream({ audioOnly })`** — `src/shared/media/stream.js:26`
+   Calls `getUserMedia` with `{ video: false, audio }` when `audioOnly`, otherwise both. Reuses an existing stream if one is already set.
+
+9. **`getCallOptions(roomId, { audioOnly })`** — `src/features/call/WIP-start-call-refactor.js:28`
+   Bundles the local stream + UI element refs + helpers (`setupRemoteStream`, `setupWatchSync`) + `audioOnly` into the options object passed to `CallController.createCall`.
+
+10. **`CallController.createCall(options)`** — `src/features/call/call-controller.js:438`
+    Thin wrapper that delegates to `createCallFlow` and emits lifecycle events on success/failure.
+
+11. **`createCall({ ..., audioOnly })`** — `src/features/call/call-flow.js:55`
+    Constructs the `RTCPeerConnection`, adds local tracks, sets up remote stream + ICE + connection-state handlers, creates the SDP offer, persists it to RTDB, and starts watch-sync.
+
+12. **`addLocalTracks(pc, localStream, { audioOnly })`** — `src/features/call/webrtc-utils.js:76`
+    Adds tracks to the peer connection. When `audioOnly`, filters to `getAudioTracks()` only so video isn't sent even if an existing video-capable stream is being reused.
+
+13. **`createOffer(pc)`** — `src/features/call/webrtc-utils.js:107`
+    Calls `pc.createOffer()` and `setLocalDescription`. Resulting SDP carries only audio m-lines when no video tracks were added.
+
+14. **`RoomService.createNewRoom(offer, userId, roomId, { audioOnly })`** — `src/features/call/room.js:23`
+    Writes `{ offer, createdAt, createdBy, audioOnly }` to `rooms/{roomId}` in RTDB so the joiner can read the call mode before negotiating.
+
+15. **Initiator-side post-success — `callContact`** — `src/features/call/WIP-start-call-refactor.js:153`
+    After `joinOrCreateRoomWithId` resolves true, updates `lastInteractionAt` on the contact, shows the outgoing call UI (with cancel/timeout handlers), and fires `getPushNotifications().sendIncomingCall(...)` so the joiner receives an OS-level call notification.
+
+---
+
+## B. Joiner Path (incoming call)
+
+The joiner has previously called `listenForIncomingOnRoom(roomId)` (either from a saved-contact bootstrap or from receiving a push notification). When the initiator joins the room, the member-join listener fires.
+
+1. **`listenForIncomingOnRoom(roomId)`** — `src/features/call/room-listeners.js:458`
+   Already attached. Internally registers `RoomService.onMemberJoined(roomId, ...)` whose async callback drives the rest of the joiner flow.
+
+2. **`onMemberJoined` callback** — inside `listenForIncomingOnRoom` at `src/features/call/room-listeners.js:498`
+   Filters out self-joins, then runs preconditions, decides notification strategy, plays ringtone, shows the incoming-call UI, and awaits the user's accept/reject.
+
+3. **`evaluateIncomingCallPreconditions({ roomId, joinedContactId, currentUserId, memberData })`** — `src/features/call/room-listeners.js:103`
+   Checks call freshness (`joinedAt` and `roomCreatedAt`), reads room data via `RoomService.getRoomData`, ensures `offer` exists and is not yet answered, and reports back `{ canProceed, freshnessResult, audioOnly: !!roomData.audioOnly }`.
+
+4. **`decideIncomingNotificationStrategy(...)`** — `src/features/call/room-listeners.js:280`
+   Chooses whether the in-app UI continues alongside a background push notification.
+
+5. **`ringtoneManager.playIncoming()` + `callIndicators.startCallIndicators(callerName)`** — invoked from `room-listeners.js:564`
+   Audible + visual ringing.
+
+6. **`showIncomingCallUI({ roomId, from }, onAccept, onReject)`** — `src/features/call/components/incoming-call.js`
+   Renders the accept/reject UI and resolves a promise based on user input or external events (`onCallCancelled`, `onAnswerAdded`).
+
+7. **`handleIncomingCallAccepted({ roomId, joinedContactId, audioOnly })`** — `src/features/call/room-listeners.js:309`
+   Publishes `evt:call:incoming:accepted`, removes the room's incoming listeners, dismisses push notifications, updates contact `lastInteractionAt`, then calls `joinOrCreateRoomWithId(roomId, { audioOnly })`.
+
+8. **`joinOrCreateRoomWithId(roomId, { audioOnly })`** — `src/features/call/WIP-start-call-refactor.js:58`
+   With no `forceInitiator`, runs `RoomService.checkRoomStatus`, sees the room exists with members (the initiator), and chooses the answer branch.
+
+9. **`initLocalStreamAndMedia({ audioOnly })`** — `src/shared/media/WIP-init-local-media.js:19`
+   Same media bootstrap as the initiator path. `audioOnly` propagates to `setUpLocalStream` → `createLocalStream` so the joiner only requests microphone permission when joining an audio-only call.
+
+10. **`getCallOptions(null, { audioOnly })`** — `src/features/call/WIP-start-call-refactor.js:28`
+    Bundles the same options for the answer branch.
+
+11. **`CallController.answerCall({ roomId, ...callOptions })`** — `src/features/call/call-controller.js:535`
+    Wrapper that delegates to `answerCallFlow` and emits lifecycle events.
+
+12. **`answerCall({ roomId, ..., audioOnly })`** — `src/features/call/call-flow.js:171`
+    Re-validates the room, fetches the offer, builds the joiner peer connection, adds local tracks, sets the remote offer, creates and writes the SDP answer, joins the room as a member, and starts watch-sync.
+
+13. **`addLocalTracks(pc, localStream, { audioOnly })`** — `src/features/call/webrtc-utils.js:76`
+    Same filtering rule as the initiator side — answer-side only sends audio when `audioOnly`.
+
+14. **`createAnswer(pc)`** — `src/features/call/webrtc-utils.js:118`
+    Calls `pc.createAnswer()` + `setLocalDescription`. Negotiation completes with audio-only m-lines on both sides.
+
+15. **`RoomService.joinRoom(roomId, userId)`** — `src/features/call/room.js`
+    Adds the joiner to `rooms/{roomId}/members` with `joinedAt`, which the initiator's `onMemberJoined` listener uses to start the active call setup.
+
+---
+
+## Footnotes — Refactor Hooks
+
+These are observations made while threading `audioOnly`. They are pre-decisional — flag for discussion before acting.
+
+1. **Two parallel orchestrators.** `src/features/call/call-flow.js:329` exports its own `joinOrCreateRoom` while `src/features/call/WIP-start-call-refactor.js:58` exports `joinOrCreateRoomWithId`. They overlap. Consolidating to one entry point (and renaming the WIP file) would remove a class of "which path is canonical?" questions.
+
+2. **Options-bag drift.** `getCallOptions` (`WIP-start-call-refactor.js:28`) and the `createCall` / `answerCall` parameter lists (`call-flow.js:55`, `call-flow.js:171`) duplicate the same shape. Threading `audioOnly` required edits in 4 call sites just to forward one flag. A single typed `CallOptions` object passed through unchanged would collapse this.
+
+3. **Receiver mode discovery is implicit.** The joiner only learns `audioOnly` by reading `rooms/{roomId}` *after* the member-join listener fires, inside `evaluateIncomingCallPreconditions` (`room-listeners.js:103`). For push-initiated cold starts the push payload could also carry `audioOnly`, so the OS notification can label "Audio call" vs "Video call" before any RTDB read.
+
+4. **`callContact` does too much.** `src/features/call/WIP-start-call-refactor.js:153` orchestrates: room id derivation, listener attach, media init, peer connection, contact bookkeeping, calling UI, and push notification. Each of these is a candidate `cmd:` / `evt:` boundary in the `src/events/` API — splitting them would shrink the trace dramatically.
+
+5. **Circular import noted by existing TODO.** `room-listeners.js` ↔ `WIP-start-call-refactor.js`. Routing `joinOrCreateRoomWithId` invocations through the app bus (e.g. `cmd:call:join-or-create`) would break this without a runtime change.
+
+6. **Local stream reuse semantics.** `createLocalStream` (`stream.js:26`) reuses an existing stream regardless of mode. After this PR, an audio-only call that follows a video call will inherit the video-bearing stream; the audio-only behavior is preserved only because `addLocalTracks` filters tracks. A clearer model: track-set reconciliation per call mode at the media layer, so downstream code never has to know about it.
+
+7. **UI is unchanged for audio-only.** The video panes still mount with empty video tracks. Acceptable for the MVP; the proper solution (avatar + audio-only top bar) belongs to the call-UI refactor.

--- a/src/features/call/CALL_E2E_FLOW_TRACE.md
+++ b/src/features/call/CALL_E2E_FLOW_TRACE.md
@@ -1,6 +1,6 @@
 # Call E2E Flow Trace
 
-Reference snapshot of the current call code path, captured while threading the `audioOnly` flag end-to-end. Intended as input to the upcoming refactor that simplifies/decouples this trace via the new `src/events/` shared API.
+Reference snapshot of the current call code path, captured while threading the `audioOnly` flag end-to-end. Intended as input to the upcoming refactor that simplifies/decouples this trace via the planned `src/events/` shared API (today located at `src/shared/events/`).
 
 Both paths are listed in execution order. Each step links a function with its file and the line where the function definition starts.
 
@@ -76,7 +76,7 @@ The joiner has previously called `listenForIncomingOnRoom(roomId)` (either from 
 5. **`ringtoneManager.playIncoming()` + `callIndicators.startCallIndicators(callerName)`** — invoked from `room-listeners.js:564`
    Audible + visual ringing.
 
-6. **`showIncomingCallUI({ roomId, from }, onAccept, onReject)`** — `src/features/call/components/incoming-call.js`
+6. **`showIncomingCallUI({ roomId, from }, onAccept, onReject)`** — `src/features/call/components/incoming-call.js:6`
    Renders the accept/reject UI and resolves a promise based on user input or external events (`onCallCancelled`, `onAnswerAdded`).
 
 7. **`handleIncomingCallAccepted({ roomId, joinedContactId, audioOnly })`** — `src/features/call/room-listeners.js:309`

--- a/src/features/call/DEFERRED_FROM_AUDIO_CALL_POC.md
+++ b/src/features/call/DEFERRED_FROM_AUDIO_CALL_POC.md
@@ -1,0 +1,17 @@
+# Deferred from Audio Call POC (PR #471)
+
+Items raised in PR #471 review (Copilot + CodeRabbit) that were intentionally not addressed in the POC merge to keep the footprint minimal. Most are expected to be touched by the upcoming call-module refactor.
+
+## Behavior / Correctness
+
+- **Stop local video tracks during audio-only mode** — `src/features/call/webrtc-utils.js:76` `addLocalTracks` currently filters `getAudioTracks()` when `audioOnly` is true, but does not call `track.stop()` / `removeTrack()` on existing video tracks. If a video stream is reused (`createLocalStream` reuses via `hasLocalStream()`), the camera capture continues even though no video is sent. Fix: stop and remove video tracks from the reused stream before adding to the peer connection.
+
+- **Joiner mode drift** — `src/features/call/call-flow.js:171` `answerCall` reads the `audioOnly` flag from its options bag, not from the room state it already fetches at line 209. If an upstream caller forgets to thread the flag, joiner can negotiate video while initiator is audio-only. Fix: derive an `effectiveAudioOnly = roomData.audioOnly === true || audioOnly === true` after `getRoomData` and use it for `addLocalTracks`.
+
+## UI / Styling
+
+- **CSS for the new audio-call button** — `.messages-topbar-audio-call` does not match the existing top-bar button styling, which targets `.messages-topbar-call` in `src/shared/styles/components/messages.css`. Layout/hover styling will diverge. Fix: add the new selector to the existing rules, or have the button reuse the same class.
+
+## Tests
+
+- **Audio-only branch coverage** — `src/setup/tests/setupMainAppBusListeners.test.js` only asserts the default `{ audioOnly: false }` branch when dispatching `cmd:call:outgoing:initiate`. Add a sibling test that emits the command with `audioOnly: true` and asserts `callContact(..., { audioOnly: true })`.

--- a/src/features/call/WIP-start-call-refactor.js
+++ b/src/features/call/WIP-start-call-refactor.js
@@ -25,7 +25,7 @@ import {
 //   showCopyLinkModal (UI), showCallingUI (UI) — all cross-domain orchestration.
 // - This file is a candidate for renaming to call-orchestration.js once stable.
 
-export function getCallOptions(targetRoomId = null) {
+export function getCallOptions(targetRoomId = null, { audioOnly = false } = {}) {
   const { localVideoEl, remoteVideoEl, mutePartnerBtn } = getElements();
   return {
     localStream: getLocalStream(),
@@ -35,6 +35,7 @@ export function getCallOptions(targetRoomId = null) {
     setupRemoteStream,
     setupWatchSync,
     targetRoomId,
+    audioOnly,
   };
 }
 
@@ -56,10 +57,10 @@ export function applyCallResult(result, showLinkModal = false) {
 
 export async function joinOrCreateRoomWithId(
   customRoomId,
-  { forceInitiator = false, allowCreate = forceInitiator } = {},
+  { forceInitiator = false, allowCreate = forceInitiator, audioOnly = false } = {},
 ) {
   try {
-    await initLocalStreamAndMedia();
+    await initLocalStreamAndMedia({ audioOnly });
   } catch (error) {
     console.error('Failed to initialize local media stream:', error);
     handleMediaPermissionError(error);
@@ -84,7 +85,7 @@ export async function joinOrCreateRoomWithId(
     );
 
     const result = await CallController.createCall(
-      getCallOptions(customRoomId),
+      getCallOptions(customRoomId, { audioOnly }),
     );
 
     return applyCallResult(result, false);
@@ -129,7 +130,7 @@ export async function joinOrCreateRoomWithId(
     );
 
     const result = await CallController.createCall(
-      getCallOptions(customRoomId),
+      getCallOptions(customRoomId, { audioOnly }),
     );
 
     return applyCallResult(result, true);
@@ -144,12 +145,17 @@ export async function joinOrCreateRoomWithId(
 
   const result = await CallController.answerCall({
     roomId: customRoomId,
-    ...getCallOptions(),
+    ...getCallOptions(null, { audioOnly }),
   });
   return applyCallResult(result, false);
 }
 
-export async function callContact(contactId, contactNickName, roomId = null) {
+export async function callContact(
+  contactId,
+  contactNickName,
+  roomId = null,
+  { audioOnly = false } = {},
+) {
   const myUserId = getUserId();
   if (contactId && myUserId === contactId) {
     console.warn('[CALL] Cannot call yourself');
@@ -182,6 +188,7 @@ export async function callContact(contactId, contactNickName, roomId = null) {
 
   const success = await joinOrCreateRoomWithId(roomId, {
     forceInitiator: true,
+    audioOnly,
   }).catch((e) => {
     console.warn('[CALL] Failed to join or create room:', e);
     return false;

--- a/src/features/call/WIP-start-call-refactor.js
+++ b/src/features/call/WIP-start-call-refactor.js
@@ -25,7 +25,10 @@ import {
 //   showCopyLinkModal (UI), showCallingUI (UI) — all cross-domain orchestration.
 // - This file is a candidate for renaming to call-orchestration.js once stable.
 
-export function getCallOptions(targetRoomId = null, { audioOnly = false } = {}) {
+export function getCallOptions(
+  targetRoomId = null,
+  { audioOnly = false } = {},
+) {
   const { localVideoEl, remoteVideoEl, mutePartnerBtn } = getElements();
   return {
     localStream: getLocalStream(),
@@ -57,7 +60,11 @@ export function applyCallResult(result, showLinkModal = false) {
 
 export async function joinOrCreateRoomWithId(
   customRoomId,
-  { forceInitiator = false, allowCreate = forceInitiator, audioOnly = false } = {},
+  {
+    forceInitiator = false,
+    allowCreate = forceInitiator,
+    audioOnly = false,
+  } = {},
 ) {
   try {
     await initLocalStreamAndMedia({ audioOnly });
@@ -215,6 +222,7 @@ export async function callContact(
     try {
       onCallingStarted();
       await showOutgoingCallUI(roomId, contactNickName, {
+        audioOnly,
         onCancel: (reason) => {
           CallController.hangUp({ reason }).catch((e) => {
             console.warn('[CALL] hangUp after cancel/timeout failed:', e);

--- a/src/features/call/call-flow.js
+++ b/src/features/call/call-flow.js
@@ -59,6 +59,7 @@ export async function createCall({
   setupRemoteStream,
   setupWatchSync,
   targetRoomId = null,
+  audioOnly = false,
 }) {
   // ─────────────────────────────────────────────────────────────────────────
   // 1. VALIDATE PREREQUISITES
@@ -81,7 +82,7 @@ export async function createCall({
   // ─────────────────────────────────────────────────────────────────────────
 
   // 3a. Add local media tracks
-  const trackHealth = addLocalTracks(pc, localStream);
+  const trackHealth = addLocalTracks(pc, localStream, { audioOnly });
   if (trackHealth.unhealthyKinds.includes('audio')) {
     showErrorToast(t('media.audio_disconnected'));
   }
@@ -109,7 +110,7 @@ export async function createCall({
   // 4. CREATE AND SAVE OFFER
   // ─────────────────────────────────────────────────────────────────────────
   const offer = await createOffer(pc);
-  await RoomService.createNewRoom(offer, userId, roomId);
+  await RoomService.createNewRoom(offer, userId, roomId, { audioOnly });
 
   devDebug('Peer connection created as initiator', { roomId, userId });
 
@@ -174,6 +175,7 @@ export async function answerCall({
   mutePartnerBtn,
   setupRemoteStream,
   setupWatchSync,
+  audioOnly = false,
 }) {
   // ─────────────────────────────────────────────────────────────────────────
   // 1. VALIDATE PREREQUISITES
@@ -229,7 +231,7 @@ export async function answerCall({
   // ─────────────────────────────────────────────────────────────────────────
 
   // 3a. Add local media tracks
-  const trackHealth = addLocalTracks(pc, localStream);
+  const trackHealth = addLocalTracks(pc, localStream, { audioOnly });
   if (trackHealth.unhealthyKinds.includes('audio')) {
     showErrorToast(t('media.audio_disconnected'));
   }

--- a/src/features/call/components/outgoing-call.js
+++ b/src/features/call/components/outgoing-call.js
@@ -23,7 +23,7 @@ let storedOnHide = null;
 export async function showOutgoingCallUI(
   roomId,
   contactNickName,
-  { onCancel, onHide } = {},
+  { onCancel, onHide, audioOnly } = {},
 ) {
   const diag = getDiagnosticLogger();
   const showTime = Date.now();
@@ -139,7 +139,7 @@ export async function showOutgoingCallUI(
   activeCallingUI = overlay;
 
   // Start outgoing call ringtone
-  ringtoneManager.playOutgoing();
+  ringtoneManager.playOutgoing({ audioOnly });
 
   // Auto-timeout after 30 seconds
   timeoutId = setTimeout(async () => {

--- a/src/features/call/room-listeners.js
+++ b/src/features/call/room-listeners.js
@@ -273,6 +273,7 @@ async function evaluateIncomingCallPreconditions({
   return {
     canProceed: true,
     freshnessResult,
+    audioOnly: !!roomData.audioOnly,
   };
 }
 
@@ -305,7 +306,7 @@ function decideIncomingNotificationStrategy({
   }
 }
 
-async function handleIncomingCallAccepted({ roomId, joinedContactId }) {
+async function handleIncomingCallAccepted({ roomId, joinedContactId, audioOnly = false }) {
   publish('evt:call:incoming:accepted', {
     roomId,
     contactId: joinedContactId,
@@ -345,7 +346,7 @@ async function handleIncomingCallAccepted({ roomId, joinedContactId }) {
     })
     .catch(() => {});
 
-  const success = await joinOrCreateRoomWithId(roomId).catch((e) => {
+  const success = await joinOrCreateRoomWithId(roomId, { audioOnly }).catch((e) => {
     console.warn('Failed to answer incoming call:', e);
     getDiagnosticLogger().logFirebaseOperation(
       'join_room_on_accept',
@@ -616,6 +617,7 @@ export function listenForIncomingOnRoom(roomId) {
         await handleIncomingCallAccepted({
           roomId,
           joinedContactId,
+          audioOnly: preconditions.audioOnly,
         });
       } else if (accept === 'caller_cancelled') {
         devDebug('Incoming call cancelled by caller');

--- a/src/features/call/room.js
+++ b/src/features/call/room.js
@@ -20,7 +20,7 @@ class RoomService {
   /**
    * Create a new room with an offer
    */
-  async createNewRoom(offer, userId, roomId = null) {
+  async createNewRoom(offer, userId, roomId = null, { audioOnly = false } = {}) {
     const startTime = Date.now();
     if (!roomId) roomId = Math.random().toString(36).substring(2, 15);
 
@@ -28,6 +28,7 @@ class RoomService {
       roomId,
       userId,
       hasOffer: !!offer,
+      audioOnly,
       timestamp: startTime,
     });
 
@@ -41,6 +42,7 @@ class RoomService {
         },
         createdAt: Date.now(),
         createdBy: userId,
+        audioOnly,
       });
 
       getDiagnosticLogger().logFirebaseOperation('create_room', true, null, {

--- a/src/features/call/webrtc-utils.js
+++ b/src/features/call/webrtc-utils.js
@@ -73,10 +73,14 @@ export function isValidSignalingState(pc, expectedType) {
  * @returns {boolean} .allHealthy - True if all tracks are live and added, false if any were skipped
  * @returns {string[]} .unhealthyKinds - Array of track kinds that were dead/skipped (e.g. ['audio'])
  */
-export function addLocalTracks(pc, localStream) {
+export function addLocalTracks(pc, localStream, { audioOnly = false } = {}) {
   const unhealthyKinds = [];
 
-  localStream.getTracks().forEach((track) => {
+  const tracks = audioOnly
+    ? localStream.getAudioTracks()
+    : localStream.getTracks();
+
+  tracks.forEach((track) => {
     if (track.readyState !== 'live') {
       console.warn(
         `[WebRTC] ${track.kind} track is not live at addLocalTracks:`,

--- a/src/features/messaging/components/createMessageTopBar.js
+++ b/src/features/messaging/components/createMessageTopBar.js
@@ -13,10 +13,10 @@ export function createMessageTopBar() {
       <span class="avatar" aria-hidden="true"></span>
       <span class="messages-topbar-name"></span>
     </div>
-    <button type="button" class="messages-topbar-audio-call" aria-label="${t('message.call')}">
+    <button type="button" class="messages-topbar-audio-call" aria-label="${t('message.audioCall')}">
       <i data-lucide="phone" aria-hidden="true"></i>
     </button>
-    <button type="button" class="messages-topbar-call" aria-label="${t('message.call')}">
+    <button type="button" class="messages-topbar-call" aria-label="${t('message.videoCall')}">
       <i data-lucide="video" aria-hidden="true"></i>
     </button>
   `;

--- a/src/features/messaging/components/createMessageTopBar.js
+++ b/src/features/messaging/components/createMessageTopBar.js
@@ -13,13 +13,17 @@ export function createMessageTopBar() {
       <span class="avatar" aria-hidden="true"></span>
       <span class="messages-topbar-name"></span>
     </div>
-    <button type="button" class="messages-topbar-call" aria-label="${t('message.call')}">
+    <button type="button" class="messages-topbar-audio-call" aria-label="${t('message.call')}">
       <i data-lucide="phone" aria-hidden="true"></i>
+    </button>
+    <button type="button" class="messages-topbar-call" aria-label="${t('message.call')}">
+      <i data-lucide="video" aria-hidden="true"></i>
     </button>
   `;
 
   const backBtn = root.querySelector('.messages-topbar-back');
   const callBtn = root.querySelector('.messages-topbar-call');
+  const audioCallBtn = root.querySelector('.messages-topbar-audio-call');
   const avatarSpan = root.querySelector('.avatar');
   const nameEl = root.querySelector('.messages-topbar-name');
 
@@ -36,12 +40,24 @@ export function createMessageTopBar() {
     callBtn.onclick = fn || null;
   };
 
+  const setAudioCallHandler = (fn) => {
+    audioCallBtn.onclick = fn || null;
+  };
+
   const cleanup = () => {
     backBtn.onclick = null;
     callBtn.onclick = null;
+    audioCallBtn.onclick = null;
     root.remove();
   };
 
   initIcons(root);
-  return { element: root, setContact, setBackHandler, setCallHandler, cleanup };
+  return {
+    element: root,
+    setContact,
+    setBackHandler,
+    setCallHandler,
+    setAudioCallHandler,
+    cleanup,
+  };
 }

--- a/src/features/messaging/components/createMessageTopBar.js
+++ b/src/features/messaging/components/createMessageTopBar.js
@@ -2,6 +2,10 @@ import { renderAvatar } from '../../../shared/components/ui/utils/avatar.js';
 import { t } from '../../../shared/i18n/index.js';
 import { initIcons } from '../../../shared/components/ui/icons.js';
 
+// TEMP BLOCK AUDIO ONLY CALL FEATURE:
+const AUDIO_ONLY_CALL_ENABLED = false;
+const AUDIO_CALL_DISPLAY = AUDIO_ONLY_CALL_ENABLED ? 'block' : 'none';
+
 export function createMessageTopBar() {
   const root = document.createElement('div');
   root.className = 'messages-top-bar';
@@ -13,7 +17,7 @@ export function createMessageTopBar() {
       <span class="avatar" aria-hidden="true"></span>
       <span class="messages-topbar-name"></span>
     </div>
-    <button type="button" class="messages-topbar-audio-call" aria-label="${t('message.audioCall')}">
+    <button type="button" style="display: ${AUDIO_CALL_DISPLAY}" class="messages-topbar-audio-call" aria-label="${t('message.audioCall')}">
       <i data-lucide="phone" aria-hidden="true"></i>
     </button>
     <button type="button" class="messages-topbar-call" aria-label="${t('message.videoCall')}">
@@ -41,7 +45,7 @@ export function createMessageTopBar() {
   };
 
   const setAudioCallHandler = (fn) => {
-    audioCallBtn.onclick = fn || null;
+    if (audioCallBtn) audioCallBtn.onclick = fn || null;
   };
 
   const cleanup = () => {

--- a/src/features/messaging/components/messages-ui.js
+++ b/src/features/messaging/components/messages-ui.js
@@ -164,25 +164,36 @@ export function initMessagesUI() {
 
     messageTopBar.setBackHandler(() => closeMessagesUI());
 
+    const buildCallPayload = () => {
+      const state = messagingController.getSelectedConversationState();
+      const conversationId = state?.conversationId;
+      const contactId = state?.remoteParticipantIds?.[0] ?? null;
+      const roomId = state?.roomId ?? null;
+      const contactNickName =
+        messagingController.getConversationDisplayName(conversationId) || null;
+      return { contactId, contactNickName, conversationId, roomId };
+    };
+
     messageTopBar.setCallHandler(() => {
       try {
-        const state = messagingController.getSelectedConversationState();
-        const conversationId = state?.conversationId;
-        const contactId = state?.remoteParticipantIds?.[0] ?? null;
-        const roomId = state?.roomId ?? null;
-        const contactNickName =
-          messagingController.getConversationDisplayName(conversationId) ||
-          null;
-
-        dispatchCommand('cmd:call:outgoing:initiate', {
-          contactId,
-          contactNickName,
-          conversationId,
-          roomId,
-        });
+        dispatchCommand('cmd:call:outgoing:initiate', buildCallPayload());
       } catch (err) {
         console.warn(
           'Failed to emit cmd:call:outgoing:initiate in temp msg-ui code',
+          err,
+        );
+      }
+    });
+
+    messageTopBar.setAudioCallHandler(() => {
+      try {
+        dispatchCommand('cmd:call:outgoing:initiate', {
+          ...buildCallPayload(),
+          audioOnly: true,
+        });
+      } catch (err) {
+        console.warn(
+          'Failed to emit cmd:call:outgoing:initiate (audioOnly) in temp msg-ui code',
           err,
         );
       }

--- a/src/setup/setupMainAppBusListeners.js
+++ b/src/setup/setupMainAppBusListeners.js
@@ -151,7 +151,13 @@ export function setupMainAppBusListeners() {
 
       handleCommand(
         'cmd:call:outgoing:initiate',
-        async ({ contactId, contactNickName, conversationId, roomId }) => {
+        async ({
+          contactId,
+          contactNickName,
+          conversationId,
+          roomId,
+          audioOnly = false,
+        }) => {
           const resolvedContactNickName =
             typeof contactNickName === 'string' && contactNickName.trim()
               ? contactNickName.trim()
@@ -165,6 +171,7 @@ export function setupMainAppBusListeners() {
                 contactNickName: resolvedContactNickName,
                 conversationId,
                 roomId,
+                audioOnly,
               },
             );
 
@@ -196,7 +203,7 @@ export function setupMainAppBusListeners() {
             }
           }
 
-          callContact(contactId, resolvedContactNickName, roomId);
+          callContact(contactId, resolvedContactNickName, roomId, { audioOnly });
         },
         { signal: ac.signal },
       );

--- a/src/setup/tests/setupMainAppBusListeners.test.js
+++ b/src/setup/tests/setupMainAppBusListeners.test.js
@@ -97,6 +97,7 @@ describe('setupMainAppBusListeners', () => {
       null,
       'Unknown Caller',
       'room-123',
+      { audioOnly: false },
     );
   });
 

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -120,6 +120,8 @@
   "message.downloaded_label": "Downloaded:",
   "message.sign_in_required": "Please sign in to send messages",
   "message.call": "Call",
+  "message.audioCall": "Audio call",
+  "message.videoCall": "Video call",
 
   "message.watch.synced": "Video synced - Ready to watch together",
   "message.watch.failed_load": "Failed to load video",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -120,6 +120,8 @@
   "message.downloaded_label": "Sótt:",
   "message.sign_in_required": "Skráðu þig inn til að senda skilaboð",
   "message.call": "Hringja",
+  "message.audioCall": "Símtal",
+  "message.videoCall": "Myndsímtal",
 
   "message.watch.synced": "Myndband samstillt - tilbúið að horfa",
   "message.watch.failed_load": "Tókst ekki að hlaða myndbandi",

--- a/src/shared/media/WIP-init-local-media.js
+++ b/src/shared/media/WIP-init-local-media.js
@@ -16,7 +16,7 @@ import { t } from '../i18n/index.js';
 // TODO: This is a temp WIP extraction - decoupling considerations:
 // imports CallController for getPeerConnection(), media/ → call/ dependency.
 
-export async function initLocalStreamAndMedia() {
+export async function initLocalStreamAndMedia({ audioOnly = false } = {}) {
   if (hasInitializedLocalStreamAndMedia()) return;
   markLocalStreamAndMediaInitialized();
 
@@ -32,7 +32,7 @@ export async function initLocalStreamAndMedia() {
     remotePipBtn,
   } = getElements();
 
-  await setUpLocalStream(localVideoEl);
+  await setUpLocalStream(localVideoEl, { audioOnly });
 
   initializeMediaControls({
     getLocalStream,

--- a/src/shared/media/audio/ringtone-manager.js
+++ b/src/shared/media/audio/ringtone-manager.js
@@ -18,6 +18,7 @@ class RingtoneManager {
     this.defaultVolume = volume ?? 0.4; // 0.0 to 1.0;
     this.currentPlayer = null;
     this.currentType = null; // 'incoming', 'outgoing', or null
+    this.previousAudioSessionType = null;
   }
 
   /**
@@ -69,8 +70,47 @@ class RingtoneManager {
    * Play outgoing call ringtone (looped)
    * @returns {Promise<boolean>} True if playback started successfully
    */
-  async playOutgoing() {
-    return this._play('outgoing', this.outgoingSrc);
+  async playOutgoing({ audioOnly } = {}) {
+    return this._play('outgoing', this.outgoingSrc, {
+      beforePlayback: () => this._setOutgoingAudioSession({ audioOnly }),
+    });
+  }
+
+  /**
+   * Prefer the handset/voice-call audio route for audio-only outgoing ringing
+   * when the browser exposes Audio Session controls.
+   */
+  _setOutgoingAudioSession({ audioOnly } = {}) {
+    const audioSession = globalThis.navigator?.audioSession;
+    if (!audioSession || !audioOnly) {
+      this.previousAudioSessionType = null;
+      return;
+    }
+
+    this.previousAudioSessionType = audioSession.type ?? null;
+
+    try {
+      audioSession.type = 'play-and-record';
+    } catch (err) {
+      console.warn('[Ringtone] Failed to set audio session for audio-only call', err);
+      this.previousAudioSessionType = null;
+    }
+  }
+
+  _restoreAudioSession() {
+    const audioSession = globalThis.navigator?.audioSession;
+    if (!audioSession || this.previousAudioSessionType == null) {
+      this.previousAudioSessionType = null;
+      return;
+    }
+
+    try {
+      audioSession.type = this.previousAudioSessionType;
+    } catch (err) {
+      console.warn('[Ringtone] Failed to restore audio session type', err);
+    } finally {
+      this.previousAudioSessionType = null;
+    }
   }
 
   /**
@@ -80,9 +120,10 @@ class RingtoneManager {
    * @param {string} src - Path to audio file
    * @returns {Promise<boolean>}
    */
-  async _play(type, src) {
+  async _play(type, src, { beforePlayback } = {}) {
     // Stop any currently playing ringtone first
     this.stop();
+    beforePlayback?.();
 
     try {
       // Create new player with looping enabled
@@ -122,6 +163,8 @@ class RingtoneManager {
    * Stop the currently playing ringtone
    */
   stop() {
+    this._restoreAudioSession();
+
     if (this.currentPlayer) {
       console.log(`[Ringtone] Stopping ${this.currentType} ringtone`);
       this.currentPlayer.stop();

--- a/src/shared/media/audio/ringtone-manager.test.js
+++ b/src/shared/media/audio/ringtone-manager.test.js
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./audio-player.js', () => ({
+  AudioPlayer: class {
+    play = vi.fn().mockResolvedValue(true);
+    stop = vi.fn();
+    dispose = vi.fn();
+    isPlaying = false;
+  },
+}));
+
+describe('ringtoneManager', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('switches to play-and-record for audio-only outgoing ringtones when supported', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {
+        audioSession: {
+          type: 'auto',
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const { ringtoneManager } = await import('./ringtone-manager.js');
+
+    await ringtoneManager.playOutgoing({ audioOnly: true });
+    expect(globalThis.navigator.audioSession.type).toBe('play-and-record');
+
+    ringtoneManager.stop();
+    expect(globalThis.navigator.audioSession.type).toBe('auto');
+  });
+
+  it('leaves the audio session untouched for non-audio-only outgoing ringtones', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {
+        audioSession: {
+          type: 'auto',
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const { ringtoneManager } = await import('./ringtone-manager.js');
+
+    await ringtoneManager.playOutgoing({ audioOnly: false });
+    expect(globalThis.navigator.audioSession.type).toBe('auto');
+  });
+});

--- a/src/shared/media/stream.js
+++ b/src/shared/media/stream.js
@@ -23,13 +23,13 @@ export function attachAudioMonitor(stream) {
   attachAudioInputRecovery(stream);
 }
 
-export const createLocalStream = async () => {
+export const createLocalStream = async ({ audioOnly = false } = {}) => {
   if (hasLocalStream()) {
     console.debug('Reusing existing local MediaStream.');
     return getLocalStream();
   }
 
-  const videoConstraints = getVideoConstraints('user');
+  const videoConstraints = audioOnly ? false : getVideoConstraints('user');
   const audioConstraints = getAudioConstraints();
 
   try {
@@ -51,7 +51,7 @@ export const createLocalStream = async () => {
       // Fallback to absolute minimum (avoid Over Constrained error)
       const fallbackAudioConstraints = getFallbackAudioConstraints();
       const basicStream = await navigator.mediaDevices.getUserMedia({
-        video: true,
+        video: audioOnly ? false : true,
         audio: fallbackAudioConstraints,
       });
       setLocalStream(basicStream);
@@ -62,8 +62,12 @@ export const createLocalStream = async () => {
   }
 };
 
-export async function setUpLocalStream(localVideoEl) {
-  const localStream = await createLocalStream();
+export async function setUpLocalStream(localVideoEl, { audioOnly = false } = {}) {
+  const localStream = await createLocalStream({ audioOnly });
+
+  if (audioOnly) {
+    return true;
+  }
 
   // Workaround for mobile browser echo (don't respect "videoEl.volume"):
   // Create a new stream with only the video track for local preview

--- a/src/shared/styles/components/messages.css
+++ b/src/shared/styles/components/messages.css
@@ -181,17 +181,20 @@
   }
 
   & .messages-topbar-back,
-  & .messages-topbar-call {
+  & .messages-topbar-call,
+  & .messages-topbar-audio-call {
     padding: 0 var(--spacing-xs);
     width: 32px;
   }
 
-  & .messages-topbar-call {
+  & .messages-topbar-call,
+  & .messages-topbar-audio-call {
     color: rgba(25, 204, 46, 0.855);
   }
 
   & .messages-topbar-back:hover,
-  & .messages-topbar-call:hover {
+  & .messages-topbar-call:hover,
+  & .messages-topbar-audio-call:hover {
     opacity: 0.85;
     background: rgba(255, 255, 255, 0.1);
   }


### PR DESCRIPTION
## Summary

- New phone button in the message top bar (video icon now marks the existing video call button) that dispatches `cmd:call:outgoing:initiate` with `audioOnly: true`.
- `audioOnly` threaded end-to-end through `callContact` → `joinOrCreateRoomWithId` → media bootstrap → peer connection setup. `getUserMedia` requests mic-only on both sides; `addLocalTracks` filters to audio tracks even if an existing video stream is reused.
- Initiator persists `audioOnly` into `rooms/{roomId}` RTDB. Joiner reads it in `evaluateIncomingCallPreconditions` and threads it into `joinOrCreateRoomWithId` so both peers negotiate audio-only SDP.
- Adds `src/features/call/CALL_E2E_FLOW_TRACE.md` documenting the initiator and joiner paths (one-line per step, file:line). Reference for the upcoming `src/events/` refactor; includes 7 footnote ideas for simplification.

Minimum-footprint approach: single boolean threaded through the existing path, no new event names, no new orchestrators, no UI changes. Call UI is reused as-is for now.

## Test plan

- [x] Manually verified end-to-end (initiator and joiner exchange audio-only call)
- [ ] Verify existing video call path is unchanged
- [ ] Verify mic-only permission prompt on both sides for audio call
- [ ] Verify `audioOnly: false` is the default everywhere (`grep audioOnly`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio-only calling: separate audio and video call buttons and explicit audio-only initiation.
* **Behavior / Bug Fixes**
  * Audio-only preference is persisted and propagated so joiners use the correct mode.
* **UI**
  * Outgoing call UI and ringtone behavior adapt to audio-only mode.
* **Documentation**
  * Added end-to-end call flow reference and deferred POC notes.
* **Localization**
  * Added English and Icelandic labels for "Audio call" and "Video call".
* **Tests**
  * Added tests for ringtone/audio-session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->