### PR TITLE
Potential fix for code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/src/features/contacts/components/add-contact-modal.js
+++ b/src/features/contacts/components/add-contact-modal.js
@@ -65,7 +65,7 @@ function openEmailComposeFallback(contacts) {
   if (!opened) {
     const mailtoLink =
       contacts.length === 1
-        ? `mailto:${contacts[0].email}?subject=${subject}&body=${body}`
+        ? `mailto:${encodeURIComponent(contacts[0].email)}?subject=${subject}&body=${body}`
         : `mailto:?bcc=${rawTo}&subject=${subject}&body=${body}`;
     window.location.href = mailtoLink;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/KristinnRoach/HangVidU/security/code-scanning/24](https://github.com/KristinnRoach/HangVidU/security/code-scanning/24)

The safest fix is to **URI-encode recipient emails before interpolating into the `mailto:` URL in all branches**, including the single-recipient fallback path currently using raw input.

In `src/features/contacts/components/add-contact-modal.js`, update `openEmailComposeFallback(contacts)` so the single-contact `mailto:` branch uses the already-defined `encodedTo` (or a per-contact `encodeURIComponent`) instead of raw `contacts[0].email`. This preserves current behavior while ensuring tainted input is not reinterpreted unsafely in a navigation URL.

No new methods or external dependencies are required. Existing imports remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
