### PR TITLE
Retry getUserMedia on dismissed prompt; offer reload on denial

### DIFF
--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -202,7 +202,7 @@
   "status.push_enabled": "Push notifications enabled! You'll now receive notifications for incoming calls.",
   "status.push_already": "Push notifications are already enabled!",
 
-  "error.media.permission": "Camera/microphone access is required for video calls. Please click \"Allow\" when prompted, or check your browser settings.",
+  "error.media.permission": "Camera/microphone access is required. Please click \"Allow\" when prompted, or check your browser settings.\n\nReload the page to try again?",
   "error.call_failed": "Unable to call. Please try again.",
   "error.clipboard.no_link": "No valid room link found in clipboard.",
   "error.clipboard.denied": "Clipboard access denied. Please allow clipboard access or paste the link manually.",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -202,7 +202,7 @@
   "status.push_enabled": "Push tilkynningar virkjaðar! Þú færð nú tilkynningar um símtöl.",
   "status.push_already": "Push tilkynningar eru nú þegar virkjaðar!",
 
-  "error.media.permission": "Aðgangur að myndavél/hljóðnema er nauðsynlegur fyrir myndsímtöl. Smelltu á \"Leyfa\" þegar beðið er um það, eða athugaðu vafrastillingar.",
+  "error.media.permission": "Aðgangur að myndavél/hljóðnema er nauðsynlegur. Smelltu á \"Leyfa\" þegar beðið er um það, eða athugaðu vafrastillingar.\n\nEndurhlaða síðunni og reyna aftur?",
   "error.call_failed": "Ekki hægt að hringja. Reyndu aftur.",
   "error.clipboard.no_link": "Enginn gildur herbergistengill fundust í klippispjaldi.",
   "error.clipboard.denied": "Aðgangur að klippispjaldi hafnaður. Leyfaðu aðgang að klippispjaldi eða límdu tengilinn inn handvirkt.",

--- a/src/shared/media/WIP-init-local-media.js
+++ b/src/shared/media/WIP-init-local-media.js
@@ -68,7 +68,10 @@ export function handleMediaPermissionError(error) {
     error?.name === 'NotAllowedError' ||
     error?.name === 'PermissionDeniedError'
   ) {
-    alert(t('error.media.permission'));
+    // confirm() so PWA users (no easy reload) can recover in one tap.
+    if (confirm(t('error.media.permission'))) {
+      window.location.reload();
+    }
   }
   resetLocalStreamInitFlag();
 }

--- a/src/shared/media/stream.js
+++ b/src/shared/media/stream.js
@@ -23,6 +23,27 @@ export function attachAudioMonitor(stream) {
   attachAudioInputRecovery(stream);
 }
 
+// Retry once on NotAllowedError if the browser still considers permission
+// grantable. Covers the case where the prompt was dismissed by accident or
+// not properly visible (focus/PWA quirks). User just clicked "call" — try
+// one more time before failing.
+async function getUserMediaWithRetry(constraints) {
+  try {
+    return await navigator.mediaDevices.getUserMedia(constraints);
+  } catch (err) {
+    if (err?.name !== 'NotAllowedError' && err?.name !== 'PermissionDeniedError') throw err;
+    let promptable = true;
+    try {
+      const probeName = constraints?.audio ? 'microphone' : 'camera';
+      const s = await navigator.permissions?.query?.({ name: probeName });
+      promptable = !s || s.state === 'prompt';
+    } catch {}
+    if (!promptable) throw err;
+    await new Promise((r) => setTimeout(r, 250));
+    return navigator.mediaDevices.getUserMedia(constraints);
+  }
+}
+
 export const createLocalStream = async ({ audioOnly = false } = {}) => {
   if (hasLocalStream()) {
     console.debug('Reusing existing local MediaStream.');
@@ -33,7 +54,7 @@ export const createLocalStream = async ({ audioOnly = false } = {}) => {
   const audioConstraints = getAudioConstraints();
 
   try {
-    const newStream = await navigator.mediaDevices.getUserMedia({
+    const newStream = await getUserMediaWithRetry({
       video: videoConstraints,
       audio: audioConstraints,
     });
@@ -50,7 +71,7 @@ export const createLocalStream = async ({ audioOnly = false } = {}) => {
       devDebug('Full error:', error);
       // Fallback to absolute minimum (avoid Over Constrained error)
       const fallbackAudioConstraints = getFallbackAudioConstraints();
-      const basicStream = await navigator.mediaDevices.getUserMedia({
+      const basicStream = await getUserMediaWithRetry({
         video: audioOnly ? false : true,
         audio: fallbackAudioConstraints,
       });

--- a/src/shared/media/stream.js
+++ b/src/shared/media/stream.js
@@ -34,9 +34,21 @@ async function getUserMediaWithRetry(constraints) {
     if (err?.name !== 'NotAllowedError' && err?.name !== 'PermissionDeniedError') throw err;
     let promptable = true;
     try {
-      const probeName = constraints?.audio ? 'microphone' : 'camera';
-      const s = await navigator.permissions?.query?.({ name: probeName });
-      promptable = !s || s.state === 'prompt';
+      const probeNames = [];
+      if (constraints?.audio) probeNames.push('microphone');
+      if (constraints?.video) probeNames.push('camera');
+
+      const states = await Promise.all(
+        probeNames.map(async (name) => {
+          try {
+            return await navigator.permissions?.query?.({ name });
+          } catch {
+            return undefined;
+          }
+        }),
+      );
+
+      promptable = states.some((s) => !s || s.state === 'prompt');
     } catch {}
     if (!promptable) throw err;
     await new Promise((r) => setTimeout(r, 250));


### PR DESCRIPTION
## Summary
- Wrap `getUserMedia` in `createLocalStream` with one silent retry on `NotAllowedError` when `navigator.permissions.query` reports `prompt` (or the API isn't available, e.g. iOS Safari). Covers accidentally dismissed prompts and focus/PWA quirks where the prompt never properly appeared.
- Replace `alert()` in `handleMediaPermissionError` with `confirm()` that offers a page reload. On iOS Safari getUserMedia permission is per-page-load, so reload re-prompts; in a PWA shell there's no easy way to reload manually.
- Drop "for video calls" from the permission message — the path is now mode-agnostic (audio-only call button uses the same flow).

## Why
Reported on iOS production: clicking the audio-call button intermittently surfaced the permission alert without any prompt appearing. Most likely a dismissed/non-visible prompt or a known WebKit quirk where PWAs lose mic/camera permission on hash/route changes. The retry covers the recoverable case; the reload offer covers the iOS path where reload genuinely fixes it.

## Test plan
- [ ] Desktop: deny prompt once → silent retry re-prompts (Chrome/Firefox where state goes `prompt` after dismiss).
- [ ] Desktop: click "Block" → confirm dialog appears, OK reloads page (won't fix block on desktop, but no regression).
- [ ] iOS Safari: deny prompt once → confirm dialog appears, OK reloads → re-prompts cleanly.
- [ ] Non-permission `getUserMedia` errors (`OverconstrainedError`, etc.) still flow through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated media permission messages (English and Icelandic) with clearer guidance and a prompt to reload the page.
  * Added a single automatic retry for media access after a short delay, gated by a permission probe to avoid spurious retries.
  * Replaced blocking alerts with a user confirmation dialog that can reload the page to recover from permission errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->