### PR TITLE
Add TTL-based cleanup for RTDB messages

### DIFF
--- a/src/features/messaging/storage/rtdb-message-store.js
+++ b/src/features/messaging/storage/rtdb-message-store.js
@@ -28,6 +28,7 @@ import { rtdb } from '../../../shared/storage/fb-rtdb/rtdb.js';
 import { getUserId } from '../../../auth/index.js';
 
 const MAX_MESSAGES = 100;
+const MESSAGE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days (set to null to disable TTL-based cleanup)
 
 /**
  * Normalize reactions from RTDB format { emoji: { uid: true } } to { emoji: [uid] }
@@ -266,17 +267,32 @@ export class RTDBMessageStore extends MessageStore {
     if (!snapshot.exists()) return;
 
     const messages = snapshot.val();
-    const keys = Object.keys(messages);
-    if (keys.length <= MAX_MESSAGES) return;
-
-    const sorted = Object.entries(messages).sort(
-      (a, b) => (a[1].sentAt || 0) - (b[1].sentAt || 0),
-    );
+    const now = Date.now();
     const updates = {};
-    for (let i = 0; i < keys.length - MAX_MESSAGES; i++) {
-      updates[`conversations/${conversationId}/messages/${sorted[i][0]}`] =
-        null;
+    const survivors = [];
+
+    for (const [id, msg] of Object.entries(messages)) {
+      if (
+        MESSAGE_TTL_MS != null &&
+        typeof msg.sentAt === 'number' &&
+        now - msg.sentAt > MESSAGE_TTL_MS
+      ) {
+        updates[`conversations/${conversationId}/messages/${id}`] = null;
+      } else {
+        survivors.push([id, msg]);
+      }
     }
-    await update(ref(rtdb), updates);
+
+    if (survivors.length > MAX_MESSAGES) {
+      survivors.sort((a, b) => (a[1].sentAt || 0) - (b[1].sentAt || 0));
+      for (let i = 0; i < survivors.length - MAX_MESSAGES; i++) {
+        updates[`conversations/${conversationId}/messages/${survivors[i][0]}`] =
+          null;
+      }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await update(ref(rtdb), updates);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Extend `RTDBMessageStore._cleanup()` to prune messages older than `MESSAGE_TTL_MS` (30 days) in addition to the existing `MAX_MESSAGES` count cap.
- Single batched `update()` handles both TTL and count-based deletions.
- Set `MESSAGE_TTL_MS = null` to disable TTL cleanup (count cap still applies).

## Why
Images are stored as inline base64 in message docs at `conversations/{id}/messages/{msgId}`. Prior cleanup was count-only, so infrequent conversations could hoard large image payloads indefinitely. TTL bounds storage growth by time as well as count.

## Test plan
- [ ] Send messages with images in a conversation; verify normal send/receive still works
- [ ] Seed a message with `sentAt` older than `MESSAGE_TTL_MS`; confirm next `write()` prunes it
- [ ] Temporarily set `MESSAGE_TTL_MS = null`; confirm only count cap runs
- [ ] Verify messages lacking a numeric `sentAt` (pre-resolve server timestamp, legacy data) are not deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now automatically expire and delete after 30 days.

* **Performance**
  * Improved message storage cleanup and optimization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->