### PR TITLE
Add Peer class + address deferred PR #491 review items

### DIFF
--- a/src/lib/webrtc/DEFERRED_ISSUES.md
+++ b/src/lib/webrtc/DEFERRED_ISSUES.md
@@ -1,0 +1,36 @@
+# Deferred Issues — `src/lib/webrtc/`
+
+Known issues flagged during review but intentionally deferred. Revisit before publishing externally.
+
+---
+
+## `sdp.js` — dedup cache mutated before apply
+
+**Flagged:** 2026-04-20 (CodeRabbit, PR [#491](https://github.com/KristinnRoach/HangVidU/pull/491))
+**Deferred:** 2026-04-21 (PR [#492](https://github.com/KristinnRoach/HangVidU/pull/492))
+**File:** `src/lib/webrtc/sdp.js`
+**Severity:** Latent bug (bites on retry-after-failure, not happy-path)
+
+### Symptom
+`isDuplicateSdp(pc, sdp)` writes the SDP into its cache at check time, *before* the subsequent `setRemoteDescription` is attempted. If that apply fails (thrown error) or is short-circuited (signaling-state check returns false), the SDP is still marked "seen" — so a legitimate retry with the same SDP will be silently dropped as a duplicate.
+
+### Correct shape
+Split check from mark:
+
+```js
+// Check-only; no mutation
+export function isDuplicateSdp(pc, sdp) { ... }
+
+// Call only after a successful setLocalDescription / setRemoteDescription
+export function markSdpApplied(pc, sdp) { ... }
+```
+
+Update both callsites so they call `markSdpApplied` *after* the native WebRTC call succeeds, not before.
+
+### Why deferred
+1. Pre-existing — identical shape existed in the pre-extraction `webrtc-utils.js`. Not a regression from PR #491.
+2. Non-trivial blast radius — the dedup guards the RTDB "own write echoes via onValue listener" path; splitting check/mark needs careful review of every SDP entry point to make sure nothing re-enters between the two calls.
+3. Not currently breaking — happy path never retries, so the pre-emptive write ends up semantically correct.
+
+### When to fix
+Before publishing `lib/webrtc/` as an external package, or the first time we see a retry-after-failure bug in the field. Needs a targeted regression test for the retry path.

--- a/src/lib/webrtc/WIP_NOTES.md
+++ b/src/lib/webrtc/WIP_NOTES.md
@@ -1,0 +1,36 @@
+# `src/lib/webrtc/` — WIP Notes
+
+Context for the next person (or future-you) picking up the extraction work.
+
+---
+
+## Where we are
+
+- **PR [#491](https://github.com/KristinnRoach/HangVidU/pull/491)** (merged) — Phase 1: extracted webrtc primitives (sdp, ice, tracks, data-channel, rtt, config, logger) from `src/features/call/` into this dependency-free module. Signaling plugged via `IceTransport` / `DataSignalingChannel` contracts; Firebase adapters live in `src/features/call/signaling/`.
+- **PR [#492](https://github.com/KristinnRoach/HangVidU/pull/492)** (open) — Phase 1.5: added the `Peer` class. **Not yet wired into `call-controller`/`call-flow`.**
+
+## Next concrete step — Phase 1.6
+
+Refactor `src/features/call/call-flow.js` and `src/features/call/call-controller.js` to use the `Peer` class. Expect meaningful LoC reduction in the controller: the `createCall`/`answerCall` paths currently hand-roll PC construction + `setupIceCandidates` + SDP + track plumbing that the `Peer` class now encapsulates.
+
+Suggested order:
+1. Build a thin Firebase adapter that satisfies the full `SignalingChannel` contract for the *main call* (offer/answer/ice on `offer`/`answer`/`offerCandidates`/`answerCandidates` buckets). The existing `createFirebaseIceTransport` covers the ICE half.
+2. Swap `createCall` over to `new Peer({ role: 'initiator', signaling, localStream })` and wire its events to what the controller currently emits (`evt:call:session:*`). Keep the call-flow return shape unchanged.
+3. Do the same for `answerCall`.
+4. Delete the now-dead hand-rolled PC setup.
+5. If the single-purpose `createDataChannel`/`joinDataChannel` helpers become redundant against `Peer({ dataChannel: true })`, collapse them — but verify file-transfer flows still work end-to-end first.
+
+## Design decisions worth preserving
+
+- **`Peer` extends native `EventTarget`** (not the project's `EventEmitter` class) so `lib/webrtc` stays zero-deps and publishable. `on`/`off`/`once` are sugar on top of `addEventListener`.
+- **Pluggable logger** (`setLogger`) — the lib must be silent by default. `data-channel.js` still has `console.warn` in two catch blocks and `console.error` in `closeDataConnection`; these are acceptable for internal use but should route through `log` before external publishing.
+- **Input validation scope** — `tracks.js` now has boundary-style `TypeError` checks because we expect this lib to become an independent package. Other primitives (`sdp`, `ice`) don't yet; add them if/when we publish.
+
+## Phase 2 (external package) — open questions
+
+Before publishing to npm:
+- Resolve `DEFERRED_ISSUES.md`.
+- Decide: bundle signaling adapters (Firebase) as an optional subpath export, or keep them as separate packages? Current structure (adapters in `src/features/call/signaling/`) already treats them as separate.
+- Add input validation to remaining primitives consistent with `tracks.js`.
+- Publish `Peer` as the primary entry point, with sdp/ice/tracks helpers available for power users who want to orchestrate manually.
+- TypeScript types — currently JSDoc-typed. Probably worth an actual `.d.ts` pass before publishing.

--- a/src/lib/webrtc/data-channel.js
+++ b/src/lib/webrtc/data-channel.js
@@ -117,13 +117,16 @@ export function joinDataChannel(signaling, options = {}) {
       };
     });
 
-    dataChannelTimer = setTimeout(() => {
-      rejectDataChannel(
-        new Error(
-          `DataChannel: ondatachannel did not fire within ${dataChannelTimeoutMs}ms`,
-        ),
-      );
-    }, dataChannelTimeoutMs);
+    const armDataChannelTimeout = () => {
+      if (dataChannelTimer || dataChannelSettled) return;
+      dataChannelTimer = setTimeout(() => {
+        rejectDataChannel(
+          new Error(
+            `DataChannel: ondatachannel did not fire within ${dataChannelTimeoutMs}ms`,
+          ),
+        );
+      }, dataChannelTimeoutMs);
+    };
 
     pc.ondatachannel = (event) => {
       log('[DataChannel] DataChannel received (joiner)', {
@@ -148,6 +151,7 @@ export function joinDataChannel(signaling, options = {}) {
         await signaling.sendAnswer({ type: answer.type, sdp: answer.sdp });
         log('[DataChannel] Joined (joiner)');
 
+        armDataChannelTimeout();
         const dataChannel = await dataChannelReady;
 
         if (monitorRtt) {

--- a/src/lib/webrtc/data-channel.js
+++ b/src/lib/webrtc/data-channel.js
@@ -16,6 +16,7 @@ import { log } from './logger.js';
 
 const DEFAULT_LABEL = 'data';
 const DEFAULT_RTT_CHECK_DELAY_MS = 1000;
+const DEFAULT_DATA_CHANNEL_READY_TIMEOUT_MS = 10000;
 
 /**
  * Initiator side: create a data-only PeerConnection and DataChannel, send
@@ -44,9 +45,6 @@ export async function createDataChannel(signaling, options = {}) {
 
   setupIceCandidates(pc, signaling);
 
-  const offer = await createOffer(pc);
-  await signaling.sendOffer({ type: offer.type, sdp: offer.sdp });
-
   signaling.onAnswer(async (answer) => {
     if (!answer) return;
     try {
@@ -67,6 +65,9 @@ export async function createDataChannel(signaling, options = {}) {
     }
   });
 
+  const offer = await createOffer(pc);
+  await signaling.sendOffer({ type: offer.type, sdp: offer.sdp });
+
   log('[DataChannel] Created (initiator)');
   return { pc, dataChannel };
 }
@@ -77,6 +78,9 @@ export async function createDataChannel(signaling, options = {}) {
  *
  * @param {DataSignalingChannel} signaling
  * @param {Object} [options] - See {@link createDataChannel}.
+ * @param {number} [options.dataChannelTimeoutMs=10000] - Reject if
+ *   `ondatachannel` has not fired within this many ms after the answer is
+ *   sent (prevents the promise from hanging indefinitely).
  * @returns {Promise<{ pc: RTCPeerConnection, dataChannel: RTCDataChannel }>}
  */
 export function joinDataChannel(signaling, options = {}) {
@@ -84,6 +88,7 @@ export function joinDataChannel(signaling, options = {}) {
     rtcConfig = defaultRtcConfig,
     monitorRtt = true,
     rttLabel = 'Data Connection',
+    dataChannelTimeoutMs = DEFAULT_DATA_CHANNEL_READY_TIMEOUT_MS,
   } = options;
 
   assertSignaling(signaling);
@@ -93,9 +98,32 @@ export function joinDataChannel(signaling, options = {}) {
     let resolved = false;
 
     let resolveDataChannel;
-    const dataChannelReady = new Promise((r) => {
-      resolveDataChannel = r;
+    let rejectDataChannel;
+    let dataChannelTimer = null;
+    let dataChannelSettled = false;
+
+    const dataChannelReady = new Promise((res, rej) => {
+      resolveDataChannel = (channel) => {
+        if (dataChannelSettled) return;
+        dataChannelSettled = true;
+        clearTimeout(dataChannelTimer);
+        res(channel);
+      };
+      rejectDataChannel = (err) => {
+        if (dataChannelSettled) return;
+        dataChannelSettled = true;
+        clearTimeout(dataChannelTimer);
+        rej(err);
+      };
     });
+
+    dataChannelTimer = setTimeout(() => {
+      rejectDataChannel(
+        new Error(
+          `DataChannel: ondatachannel did not fire within ${dataChannelTimeoutMs}ms`,
+        ),
+      );
+    }, dataChannelTimeoutMs);
 
     pc.ondatachannel = (event) => {
       log('[DataChannel] DataChannel received (joiner)', {
@@ -133,6 +161,7 @@ export function joinDataChannel(signaling, options = {}) {
         resolve({ pc, dataChannel });
       } catch (err) {
         console.warn('[DataChannel] Failed to complete data join:', err);
+        rejectDataChannel(err);
         try {
           pc.close();
         } catch (_) {}

--- a/src/lib/webrtc/index.js
+++ b/src/lib/webrtc/index.js
@@ -33,3 +33,5 @@ export {
 } from './data-channel.js';
 
 export { getRTT, checkAndWarnRTT } from './rtt.js';
+
+export { Peer, PEER_STATES } from './peer.js';

--- a/src/lib/webrtc/peer.js
+++ b/src/lib/webrtc/peer.js
@@ -1,0 +1,364 @@
+// src/lib/webrtc/peer.js
+//
+// High-level Peer abstraction over RTCPeerConnection. Wraps the sdp/ice/
+// tracks primitives with a single cohesive lifecycle and an EventTarget-
+// based event surface.
+//
+// Signaling-agnostic: callers inject a SignalingChannel implementation
+// (see signaling-transport.js). Works for both initiator and joiner roles
+// and optionally carries a data channel alongside media tracks.
+
+import { rtcConfig as defaultRtcConfig } from './config.js';
+import { createOffer, createAnswer, setRemoteDescription } from './sdp.js';
+import { setupIceCandidates, drainIceCandidateQueue } from './ice.js';
+import { addLocalTracks } from './tracks.js';
+import { log } from './logger.js';
+
+/** @typedef {import('./signaling-transport.js').DataSignalingChannel} SignalingChannel */
+
+const PEER_STATES = Object.freeze({
+  IDLE: 'idle',
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  DISCONNECTED: 'disconnected',
+  FAILED: 'failed',
+  CLOSED: 'closed',
+});
+
+/**
+ * Events dispatched on Peer (via EventTarget):
+ *   - 'statechange'   → detail: { state: PeerState, previous: PeerState }
+ *   - 'connected'     → fired once when pc.connectionState becomes 'connected'
+ *   - 'disconnected'  → fired when connection drops ('disconnected' | 'failed')
+ *   - 'track'         → detail: { track, streams } (native RTCTrackEvent fields)
+ *   - 'datachannel'   → detail: { channel } (initiator: on create; joiner: on ondatachannel)
+ *   - 'open'          → data channel opened
+ *   - 'message'       → detail: { data } (data channel message)
+ *   - 'close'         → data channel closed
+ *   - 'error'         → detail: { error, phase }
+ *
+ * Sugar `on/off/once` methods exist alongside the standard
+ * `addEventListener/removeEventListener` API.
+ */
+export class Peer extends EventTarget {
+  /**
+   * @param {Object} options
+   * @param {'initiator'|'joiner'} options.role
+   * @param {SignalingChannel} options.signaling
+   * @param {MediaStream}  [options.localStream]
+   * @param {boolean}      [options.audioOnly=false]
+   * @param {boolean}      [options.dataChannel=false]
+   *   Initiator: create a data channel up-front. Joiner: forward the remote
+   *   channel when it arrives.
+   * @param {string}       [options.dataChannelLabel='data']
+   * @param {RTCConfiguration} [options.rtcConfig]
+   */
+  constructor(options) {
+    super();
+    const {
+      role,
+      signaling,
+      localStream = null,
+      audioOnly = false,
+      dataChannel = false,
+      dataChannelLabel = 'data',
+      rtcConfig = defaultRtcConfig,
+    } = options ?? {};
+
+    if (role !== 'initiator' && role !== 'joiner') {
+      throw new Error(`Peer: invalid role "${role}"`);
+    }
+    assertSignaling(signaling);
+
+    this._role = role;
+    this._signaling = signaling;
+    this._localStream = localStream;
+    this._audioOnly = audioOnly;
+    this._wantsDataChannel = dataChannel;
+    this._dataChannelLabel = dataChannelLabel;
+    this._rtcConfig = rtcConfig;
+
+    this._pc = null;
+    this._dataChannel = null;
+    this._state = PEER_STATES.IDLE;
+    this._started = false;
+    this._startPromise = null;
+    this._closed = false;
+  }
+
+  // ─── Public API ───────────────────────────────────────────────────────
+
+  get role() {
+    return this._role;
+  }
+  get state() {
+    return this._state;
+  }
+  get pc() {
+    return this._pc;
+  }
+  get dataChannel() {
+    return this._dataChannel;
+  }
+
+  /**
+   * Kick off the connection. Idempotent: repeat calls return the same promise.
+   * Resolves after SDP + local signaling complete (peers may still be
+   * negotiating ICE; listen for 'connected' to know when media is flowing).
+   */
+  start() {
+    if (this._started) return this._startPromise;
+    this._started = true;
+    this._setState(PEER_STATES.CONNECTING);
+
+    this._startPromise =
+      this._role === 'initiator' ? this._startInitiator() : this._startJoiner();
+
+    // Don't leak rejections — caller can still await start() to see them.
+    this._startPromise.catch((error) => {
+      this._emit('error', { error, phase: 'start' });
+      this._setState(PEER_STATES.FAILED);
+    });
+
+    return this._startPromise;
+  }
+
+  /**
+   * Send data through the data channel. Throws if no channel or not open.
+   * @param {string|Blob|ArrayBuffer|ArrayBufferView} data
+   */
+  send(data) {
+    if (!this._dataChannel) {
+      throw new Error('Peer.send: no data channel');
+    }
+    if (this._dataChannel.readyState !== 'open') {
+      throw new Error(
+        `Peer.send: data channel not open (state=${this._dataChannel.readyState})`,
+      );
+    }
+    this._dataChannel.send(data);
+  }
+
+  /**
+   * Close the peer connection and any associated data channel.
+   * Safe to call multiple times.
+   */
+  close() {
+    if (this._closed) return;
+    this._closed = true;
+
+    try {
+      this._dataChannel?.close();
+    } catch (_) {}
+
+    try {
+      this._pc?.close();
+    } catch (err) {
+      console.error('[Peer] Error closing peer connection:', err);
+    }
+
+    this._setState(PEER_STATES.CLOSED);
+  }
+
+  // ─── on/off/once sugar (thin wrappers over EventTarget) ───────────────
+
+  /**
+   * Subscribe to an event. Returns an unsubscribe function.
+   * @param {string} type
+   * @param {(detail: any, event: CustomEvent) => void} callback
+   */
+  on(type, callback) {
+    const handler = (event) => callback(event.detail, event);
+    this.addEventListener(type, handler);
+    return () => this.removeEventListener(type, handler);
+  }
+
+  /**
+   * Subscribe once; auto-unsubscribes after first fire.
+   * @param {string} type
+   * @param {(detail: any, event: CustomEvent) => void} callback
+   */
+  once(type, callback) {
+    const handler = (event) => {
+      this.removeEventListener(type, handler);
+      callback(event.detail, event);
+    };
+    this.addEventListener(type, handler);
+    return () => this.removeEventListener(type, handler);
+  }
+
+  /**
+   * Remove a previously-registered listener. Callers using `on`/`once` should
+   * prefer the returned unsubscribe function; this is here for parity with
+   * other emitter APIs.
+   * @param {string} type
+   * @param {Function} callback
+   */
+  off(type, callback) {
+    this.removeEventListener(type, callback);
+  }
+
+  // ─── Private: role-specific flows ─────────────────────────────────────
+
+  async _startInitiator() {
+    this._initPc();
+
+    if (this._wantsDataChannel) {
+      const channel = this._pc.createDataChannel(this._dataChannelLabel);
+      this._bindDataChannel(channel);
+    }
+
+    this._signaling.onAnswer(async (answer) => {
+      if (!answer || this._closed) return;
+      try {
+        const applied = await setRemoteDescription(
+          this._pc,
+          answer,
+          drainIceCandidateQueue,
+        );
+        if (!applied) return;
+        log('[Peer] Remote answer applied');
+      } catch (err) {
+        this._emit('error', { error: err, phase: 'answer' });
+      }
+    });
+
+    const offer = await createOffer(this._pc);
+    await this._signaling.sendOffer({ type: offer.type, sdp: offer.sdp });
+    log('[Peer] Offer sent (initiator)');
+  }
+
+  async _startJoiner() {
+    this._initPc();
+
+    let offerHandled = false;
+    await new Promise((resolve, reject) => {
+      this._signaling.onOffer(async (offer) => {
+        if (offerHandled || !offer || this._closed) return;
+        try {
+          const applied = await setRemoteDescription(
+            this._pc,
+            offer,
+            drainIceCandidateQueue,
+          );
+          if (!applied) return;
+
+          const answer = await createAnswer(this._pc);
+          await this._signaling.sendAnswer({
+            type: answer.type,
+            sdp: answer.sdp,
+          });
+          log('[Peer] Answer sent (joiner)');
+          offerHandled = true;
+          resolve();
+        } catch (err) {
+          this._emit('error', { error: err, phase: 'offer' });
+          reject(err);
+        }
+      });
+    });
+  }
+
+  // ─── Private: PC setup + event wiring ─────────────────────────────────
+
+  _initPc() {
+    const pc = new RTCPeerConnection(this._rtcConfig);
+    this._pc = pc;
+
+    if (this._localStream) {
+      const health = addLocalTracks(pc, this._localStream, {
+        audioOnly: this._audioOnly,
+      });
+      if (!health.allHealthy) {
+        this._emit('error', {
+          error: new Error(
+            `Unhealthy local tracks: ${health.unhealthyKinds.join(', ')}`,
+          ),
+          phase: 'tracks',
+        });
+      }
+    }
+
+    setupIceCandidates(pc, this._signaling);
+
+    pc.addEventListener('track', (event) => {
+      this._emit('track', { track: event.track, streams: event.streams });
+    });
+
+    pc.addEventListener('connectionstatechange', () => {
+      const connState = pc.connectionState;
+      log(`[Peer] connectionState → ${connState}`);
+      if (connState === 'connected') {
+        this._setState(PEER_STATES.CONNECTED);
+        this._emit('connected', {});
+      } else if (connState === 'disconnected') {
+        this._setState(PEER_STATES.DISCONNECTED);
+        this._emit('disconnected', { reason: 'disconnected' });
+      } else if (connState === 'failed') {
+        this._setState(PEER_STATES.FAILED);
+        this._emit('disconnected', { reason: 'failed' });
+      } else if (connState === 'closed') {
+        this._setState(PEER_STATES.CLOSED);
+      }
+    });
+
+    pc.addEventListener('datachannel', (event) => {
+      // Joiner path: remote created the channel.
+      if (this._wantsDataChannel || this._role === 'joiner') {
+        this._bindDataChannel(event.channel);
+      }
+    });
+  }
+
+  _bindDataChannel(channel) {
+    this._dataChannel = channel;
+    this._emit('datachannel', { channel });
+
+    channel.addEventListener('open', () => {
+      this._emit('open', {});
+    });
+    channel.addEventListener('message', (event) => {
+      this._emit('message', { data: event.data });
+    });
+    channel.addEventListener('close', () => {
+      this._emit('close', {});
+    });
+    channel.addEventListener('error', (event) => {
+      this._emit('error', { error: event.error, phase: 'datachannel' });
+    });
+  }
+
+  // ─── Private: emit + state helpers ────────────────────────────────────
+
+  _setState(next) {
+    if (this._state === next) return;
+    const previous = this._state;
+    this._state = next;
+    this._emit('statechange', { state: next, previous });
+  }
+
+  _emit(type, detail) {
+    this.dispatchEvent(new CustomEvent(type, { detail }));
+  }
+}
+
+export { PEER_STATES };
+
+function assertSignaling(signaling) {
+  if (!signaling) {
+    throw new Error('Peer: signaling channel is required');
+  }
+  const required = [
+    'sendOffer',
+    'sendAnswer',
+    'onOffer',
+    'onAnswer',
+    'sendCandidate',
+    'onRemoteCandidate',
+  ];
+  for (const name of required) {
+    if (typeof signaling[name] !== 'function') {
+      throw new Error(`Peer: signaling channel missing method "${name}"`);
+    }
+  }
+}

--- a/src/lib/webrtc/peer.js
+++ b/src/lib/webrtc/peer.js
@@ -84,6 +84,7 @@ export class Peer extends EventTarget {
     this._started = false;
     this._startPromise = null;
     this._closed = false;
+    this._listenerMap = new Map();
   }
 
   // ─── Public API ───────────────────────────────────────────────────────
@@ -157,7 +158,7 @@ export class Peer extends EventTarget {
     try {
       this._pc?.close();
     } catch (err) {
-      console.error('[Peer] Error closing peer connection:', err);
+      log('[Peer] Error closing peer connection:', err);
     }
 
     this._setState(PEER_STATES.CLOSED);
@@ -172,8 +173,23 @@ export class Peer extends EventTarget {
    */
   on(type, callback) {
     const handler = (event) => callback(event.detail, event);
+    if (!this._listenerMap.has(type)) {
+      this._listenerMap.set(type, new Map());
+    }
+    const callbacks = this._listenerMap.get(type);
+    if (!callbacks.has(callback)) {
+      callbacks.set(callback, new Set());
+    }
+    callbacks.get(callback).add(handler);
     this.addEventListener(type, handler);
-    return () => this.removeEventListener(type, handler);
+    return () => {
+      this.removeEventListener(type, handler);
+      const handlers = this._listenerMap.get(type)?.get(callback);
+      handlers?.delete(handler);
+      if (handlers?.size === 0) {
+        this._listenerMap.get(type)?.delete(callback);
+      }
+    };
   }
 
   /**
@@ -198,6 +214,14 @@ export class Peer extends EventTarget {
    * @param {Function} callback
    */
   off(type, callback) {
+    const handlers = this._listenerMap.get(type)?.get(callback);
+    if (handlers) {
+      for (const handler of handlers) {
+        this.removeEventListener(type, handler);
+      }
+      this._listenerMap.get(type)?.delete(callback);
+      return;
+    }
     this.removeEventListener(type, callback);
   }
 

--- a/src/lib/webrtc/peer.js
+++ b/src/lib/webrtc/peer.js
@@ -107,6 +107,7 @@ export class Peer extends EventTarget {
    * negotiating ICE; listen for 'connected' to know when media is flowing).
    */
   start() {
+    if (this._state === PEER_STATES.CLOSED) return Promise.resolve();
     if (this._started) return this._startPromise;
     this._started = true;
     this._setState(PEER_STATES.CONNECTING);
@@ -117,7 +118,9 @@ export class Peer extends EventTarget {
     // Don't leak rejections — caller can still await start() to see them.
     this._startPromise.catch((error) => {
       this._emit('error', { error, phase: 'start' });
-      this._setState(PEER_STATES.FAILED);
+      if (this._state !== PEER_STATES.CLOSED) {
+        this._setState(PEER_STATES.FAILED);
+      }
     });
 
     return this._startPromise;

--- a/src/lib/webrtc/peer.js
+++ b/src/lib/webrtc/peer.js
@@ -84,6 +84,7 @@ export class Peer extends EventTarget {
     this._started = false;
     this._startPromise = null;
     this._closed = false;
+    this._pendingStartReject = null;
     this._listenerMap = new Map();
   }
 
@@ -162,6 +163,12 @@ export class Peer extends EventTarget {
     }
 
     this._setState(PEER_STATES.CLOSED);
+
+    if (this._pendingStartReject) {
+      const reject = this._pendingStartReject;
+      this._pendingStartReject = null;
+      reject(new Error('Peer: closed before start completed'));
+    }
   }
 
   // ─── on/off/once sugar (thin wrappers over EventTarget) ───────────────
@@ -198,12 +205,31 @@ export class Peer extends EventTarget {
    * @param {(detail: any, event: CustomEvent) => void} callback
    */
   once(type, callback) {
+    if (!this._listenerMap.has(type)) {
+      this._listenerMap.set(type, new Map());
+    }
+    const callbacks = this._listenerMap.get(type);
+    if (!callbacks.has(callback)) {
+      callbacks.set(callback, new Set());
+    }
+    const handlers = callbacks.get(callback);
+
+    const forget = () => {
+      handlers.delete(handler);
+      if (handlers.size === 0) callbacks.delete(callback);
+    };
     const handler = (event) => {
       this.removeEventListener(type, handler);
+      forget();
       callback(event.detail, event);
     };
+    handlers.add(handler);
     this.addEventListener(type, handler);
-    return () => this.removeEventListener(type, handler);
+
+    return () => {
+      this.removeEventListener(type, handler);
+      forget();
+    };
   }
 
   /**
@@ -258,8 +284,19 @@ export class Peer extends EventTarget {
   async _startJoiner() {
     this._initPc();
 
+    if (this._closed) {
+      throw new Error('Peer: closed before start completed');
+    }
+
     let offerHandled = false;
     await new Promise((resolve, reject) => {
+      this._pendingStartReject = reject;
+      const settle = (fn, value) => {
+        if (this._pendingStartReject === reject) {
+          this._pendingStartReject = null;
+        }
+        fn(value);
+      };
       this._signaling.onOffer(async (offer) => {
         if (offerHandled || !offer || this._closed) return;
         try {
@@ -277,10 +314,10 @@ export class Peer extends EventTarget {
           });
           log('[Peer] Answer sent (joiner)');
           offerHandled = true;
-          resolve();
+          settle(resolve);
         } catch (err) {
           this._emit('error', { error: err, phase: 'offer' });
-          reject(err);
+          settle(reject, err);
         }
       });
     });

--- a/src/lib/webrtc/peer.js
+++ b/src/lib/webrtc/peer.js
@@ -24,6 +24,7 @@ const PEER_STATES = Object.freeze({
   FAILED: 'failed',
   CLOSED: 'closed',
 });
+const START_CLOSED_ERROR = 'Peer: closed before start completed';
 
 /**
  * Events dispatched on Peer (via EventTarget):
@@ -112,10 +113,30 @@ export class Peer extends EventTarget {
     if (this._state === PEER_STATES.CLOSED) return Promise.resolve();
     if (this._started) return this._startPromise;
     this._started = true;
-    this._setState(PEER_STATES.CONNECTING);
 
-    this._startPromise =
-      this._role === 'initiator' ? this._startInitiator() : this._startJoiner();
+    this._startPromise = new Promise((resolve, reject) => {
+      this._pendingStartReject = reject;
+      const rejectStart = reject;
+      const settle = (fn, value) => {
+        if (this._pendingStartReject === rejectStart) {
+          this._pendingStartReject = null;
+        }
+        fn(value);
+      };
+
+      (async () => {
+        this._setState(PEER_STATES.CONNECTING);
+        this._throwIfClosedDuringStart();
+        if (this._role === 'initiator') {
+          await this._startInitiator();
+        } else {
+          await this._startJoiner();
+        }
+      })().then(
+        (value) => settle(resolve, value),
+        (error) => settle(reject, error),
+      );
+    });
 
     // Don't leak rejections — caller can still await start() to see them.
     this._startPromise.catch((error) => {
@@ -167,7 +188,7 @@ export class Peer extends EventTarget {
     if (this._pendingStartReject) {
       const reject = this._pendingStartReject;
       this._pendingStartReject = null;
-      reject(new Error('Peer: closed before start completed'));
+      reject(new Error(START_CLOSED_ERROR));
     }
   }
 
@@ -255,11 +276,13 @@ export class Peer extends EventTarget {
 
   async _startInitiator() {
     this._initPc();
+    this._throwIfClosedDuringStart();
 
     if (this._wantsDataChannel) {
       const channel = this._pc.createDataChannel(this._dataChannelLabel);
       this._bindDataChannel(channel);
     }
+    this._throwIfClosedDuringStart();
 
     this._signaling.onAnswer(async (answer) => {
       if (!answer || this._closed) return;
@@ -277,28 +300,25 @@ export class Peer extends EventTarget {
     });
 
     const offer = await createOffer(this._pc);
+    this._throwIfClosedDuringStart();
     await this._signaling.sendOffer({ type: offer.type, sdp: offer.sdp });
+    this._throwIfClosedDuringStart();
     log('[Peer] Offer sent (initiator)');
   }
 
   async _startJoiner() {
     this._initPc();
 
-    if (this._closed) {
-      throw new Error('Peer: closed before start completed');
-    }
+    this._throwIfClosedDuringStart();
 
     let offerHandled = false;
     await new Promise((resolve, reject) => {
-      this._pendingStartReject = reject;
       const settle = (fn, value) => {
-        if (this._pendingStartReject === reject) {
-          this._pendingStartReject = null;
-        }
         fn(value);
       };
       this._signaling.onOffer(async (offer) => {
         if (offerHandled || !offer || this._closed) return;
+        offerHandled = true;
         try {
           const applied = await setRemoteDescription(
             this._pc,
@@ -313,7 +333,6 @@ export class Peer extends EventTarget {
             sdp: answer.sdp,
           });
           log('[Peer] Answer sent (joiner)');
-          offerHandled = true;
           settle(resolve);
         } catch (err) {
           this._emit('error', { error: err, phase: 'offer' });
@@ -321,6 +340,12 @@ export class Peer extends EventTarget {
         }
       });
     });
+  }
+
+  _throwIfClosedDuringStart() {
+    if (this._closed || this._state === PEER_STATES.CLOSED) {
+      throw new Error(START_CLOSED_ERROR);
+    }
   }
 
   // ─── Private: PC setup + event wiring ─────────────────────────────────

--- a/src/lib/webrtc/rtt.js
+++ b/src/lib/webrtc/rtt.js
@@ -2,6 +2,8 @@
 //
 // Round-trip-time diagnostics for WebRTC peer connections.
 
+import { log } from './logger.js';
+
 const RTT_WARNING_THRESHOLD_MS = 250;
 
 /**
@@ -20,7 +22,7 @@ export async function getRTT(pc) {
       }
     }
   } catch (e) {
-    console.warn('[RTTMonitor] Failed to get RTT:', e.message);
+    log('[RTTMonitor] Failed to get RTT:', e.message);
   }
   return null;
 }
@@ -41,11 +43,11 @@ export async function checkAndWarnRTT(
   if (rtt === null) return null;
 
   if (rtt > thresholdMs) {
-    console.warn(
+    log(
       `[RTTMonitor] ⚠️ ${label} has high latency. WebRTC peerConnection round trip time (RTT): ${rtt}ms. File transfers may be slow.`,
     );
   } else {
-    console.info(
+    log(
       `[RTTMonitor] ${label} WebRTC peerConnection round trip time (RTT): ${rtt}ms (OK)`,
     );
   }

--- a/src/lib/webrtc/rtt.js
+++ b/src/lib/webrtc/rtt.js
@@ -22,7 +22,11 @@ export async function getRTT(pc) {
       }
     }
   } catch (e) {
-    log('[RTTMonitor] Failed to get RTT:', e.message);
+    log(
+      '[RTTMonitor] Failed to get RTT:',
+      e instanceof Error ? e.message : String(e),
+      e,
+    );
   }
   return null;
 }

--- a/src/lib/webrtc/tests/peer.browser.test.js
+++ b/src/lib/webrtc/tests/peer.browser.test.js
@@ -176,6 +176,52 @@ describe('Peer', () => {
       const p2 = peer.start();
       expect(p1).toBe(p2);
     });
+
+    it('start() resolves without starting after close()', async () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      peers = [peer];
+      peer._startInitiator = vi.fn();
+
+      peer.close();
+      await expect(peer.start()).resolves.toBeUndefined();
+
+      expect(peer._startInitiator).not.toHaveBeenCalled();
+      expect(peer.state).toBe(PEER_STATES.CLOSED);
+    });
+
+    it('keeps closed state when start() fails after close()', async () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      peers = [peer];
+      const startError = new Error('start failed');
+      const onError = vi.fn();
+      peer._startInitiator = vi.fn(
+        () =>
+          new Promise((_, reject) => {
+            setTimeout(() => reject(startError), 0);
+          }),
+      );
+      peer.on('error', onError);
+
+      const startPromise = peer.start();
+      peer.close();
+      await expect(startPromise).rejects.toThrow(startError);
+
+      expect(onError).toHaveBeenCalledWith(
+        { error: startError, phase: 'start' },
+        expect.any(CustomEvent),
+      );
+      expect(peer.state).toBe(PEER_STATES.CLOSED);
+    });
   });
 
   describe('send()', () => {

--- a/src/lib/webrtc/tests/peer.browser.test.js
+++ b/src/lib/webrtc/tests/peer.browser.test.js
@@ -1,0 +1,250 @@
+// src/lib/webrtc/tests/peer.browser.test.js
+//
+// Browser-mode tests for the Peer class. Uses real RTCPeerConnection APIs.
+// Two Peer instances are wired through an in-memory loopback signaling
+// channel so offers/answers/ICE candidates flow between them end-to-end.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Peer, PEER_STATES } from '../peer.js';
+
+/**
+ * Build a pair of loopback SignalingChannels that wire two Peers together.
+ * Whatever side A sends, side B receives, and vice-versa.
+ */
+function createLoopbackPair() {
+  const offerListeners = { a: null, b: null };
+  const answerListeners = { a: null, b: null };
+  const candidateListeners = { a: [], b: [] };
+
+  const makeSide = (self, other) => ({
+    sendOffer: async (offer) => offerListeners[other]?.(offer),
+    sendAnswer: async (answer) => answerListeners[other]?.(answer),
+    onOffer: (cb) => {
+      offerListeners[self] = cb;
+    },
+    onAnswer: (cb) => {
+      answerListeners[self] = cb;
+    },
+    sendCandidate: async (candidate) => {
+      for (const cb of candidateListeners[other]) cb(candidate);
+    },
+    onRemoteCandidate: (cb) => {
+      candidateListeners[self].push(cb);
+    },
+  });
+
+  return { a: makeSide('a', 'b'), b: makeSide('b', 'a') };
+}
+
+describe('Peer', () => {
+  let peers;
+
+  afterEach(() => {
+    peers?.forEach((p) => {
+      try {
+        p.close();
+      } catch (_) {}
+    });
+    peers = null;
+  });
+
+  describe('construction', () => {
+    it('throws on invalid role', () => {
+      const { a } = createLoopbackPair();
+      expect(() => new Peer({ role: 'observer', signaling: a })).toThrow(
+        /invalid role/,
+      );
+    });
+
+    it('throws when signaling is missing', () => {
+      expect(() => new Peer({ role: 'initiator' })).toThrow(
+        /signaling channel is required/,
+      );
+    });
+
+    it('throws when signaling is incomplete', () => {
+      expect(
+        () =>
+          new Peer({
+            role: 'initiator',
+            signaling: { sendOffer: () => {} },
+          }),
+      ).toThrow(/missing method/);
+    });
+
+    it('starts in idle state', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+      expect(peer.state).toBe(PEER_STATES.IDLE);
+      expect(peer.role).toBe('initiator');
+      peer.close();
+    });
+  });
+
+  describe('data-only peer negotiation', () => {
+    it('exchanges offer/answer and opens a data channel', async () => {
+      const { a, b } = createLoopbackPair();
+
+      const initiator = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      const joiner = new Peer({ role: 'joiner', signaling: b });
+      peers = [initiator, joiner];
+
+      const joinerChannel = new Promise((resolve) => {
+        joiner.once('datachannel', ({ channel }) => resolve(channel));
+      });
+      const initiatorOpen = new Promise((resolve) => {
+        initiator.once('open', () => resolve());
+      });
+
+      await Promise.all([initiator.start(), joiner.start()]);
+
+      const channel = await joinerChannel;
+      expect(channel).toBeDefined();
+      expect(channel.label).toBe('data');
+
+      await initiatorOpen;
+      expect(initiator.dataChannel).toBeDefined();
+      expect(initiator.dataChannel.readyState).toBe('open');
+    });
+
+    it('delivers messages from initiator to joiner', async () => {
+      const { a, b } = createLoopbackPair();
+
+      const initiator = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      const joiner = new Peer({ role: 'joiner', signaling: b });
+      peers = [initiator, joiner];
+
+      const received = new Promise((resolve) => {
+        joiner.once('message', ({ data }) => resolve(data));
+      });
+      const initiatorOpen = new Promise((resolve) => {
+        initiator.once('open', () => resolve());
+      });
+
+      await Promise.all([initiator.start(), joiner.start()]);
+      await initiatorOpen;
+
+      initiator.send('hello from initiator');
+
+      expect(await received).toBe('hello from initiator');
+    });
+
+    it('emits statechange and connected events', async () => {
+      const { a, b } = createLoopbackPair();
+
+      const initiator = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      const joiner = new Peer({ role: 'joiner', signaling: b });
+      peers = [initiator, joiner];
+
+      const stateChanges = [];
+      initiator.on('statechange', ({ state }) => stateChanges.push(state));
+
+      const connected = new Promise((resolve) => {
+        initiator.once('connected', () => resolve());
+      });
+
+      await Promise.all([initiator.start(), joiner.start()]);
+      await connected;
+
+      expect(stateChanges).toContain(PEER_STATES.CONNECTING);
+      expect(stateChanges).toContain(PEER_STATES.CONNECTED);
+      expect(initiator.state).toBe(PEER_STATES.CONNECTED);
+    });
+
+    it('start() is idempotent — returns the same promise on repeat calls', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      peers = [peer];
+
+      const p1 = peer.start();
+      const p2 = peer.start();
+      expect(p1).toBe(p2);
+    });
+  });
+
+  describe('send()', () => {
+    it('throws if no data channel was configured', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+      peers = [peer];
+      expect(() => peer.send('nope')).toThrow(/no data channel/);
+    });
+
+    it('throws if channel is not open yet', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      peers = [peer];
+      // Data channel is created synchronously in start(); invoke lifecycle
+      // so _dataChannel is bound but still 'connecting'.
+      peer.start();
+      expect(() => peer.send('early')).toThrow(/not open/);
+    });
+  });
+
+  describe('close()', () => {
+    it('transitions to closed state and is safe to call twice', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+
+      peer.close();
+      expect(peer.state).toBe(PEER_STATES.CLOSED);
+
+      // Second call is a no-op
+      peer.close();
+      expect(peer.state).toBe(PEER_STATES.CLOSED);
+    });
+  });
+
+  describe('on/once sugar', () => {
+    it('on() returns an unsubscribe function', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+      peers = [peer];
+
+      const handler = vi.fn();
+      const off = peer.on('statechange', handler);
+
+      peer.close();
+      expect(handler).toHaveBeenCalled();
+
+      handler.mockClear();
+      off();
+      peer.dispatchEvent(new CustomEvent('statechange', { detail: {} }));
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('once() auto-unsubscribes after the first fire', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+      peers = [peer];
+
+      const handler = vi.fn();
+      peer.once('statechange', handler);
+
+      peer.dispatchEvent(new CustomEvent('statechange', { detail: {} }));
+      peer.dispatchEvent(new CustomEvent('statechange', { detail: {} }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lib/webrtc/tests/peer.browser.test.js
+++ b/src/lib/webrtc/tests/peer.browser.test.js
@@ -305,5 +305,34 @@ describe('Peer', () => {
 
       expect(handler).toHaveBeenCalledTimes(1);
     });
+
+    it('off() removes a listener added with once() before it fires', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+      peers = [peer];
+
+      const handler = vi.fn();
+      peer.once('statechange', handler);
+      peer.off('statechange', handler);
+
+      peer.dispatchEvent(new CustomEvent('statechange', { detail: {} }));
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('joiner lifecycle', () => {
+    it('rejects start() when close() happens before the offer arrives', async () => {
+      const { b } = createLoopbackPair();
+      const joiner = new Peer({ role: 'joiner', signaling: b });
+      peers = [joiner];
+
+      const startPromise = joiner.start();
+      // Let _startJoiner install the onOffer listener + _pendingStartReject.
+      await Promise.resolve();
+      joiner.close();
+
+      await expect(startPromise).rejects.toThrow(/closed before start/);
+      expect(joiner.state).toBe(PEER_STATES.CLOSED);
+    });
   });
 });

--- a/src/lib/webrtc/tests/peer.browser.test.js
+++ b/src/lib/webrtc/tests/peer.browser.test.js
@@ -279,6 +279,19 @@ describe('Peer', () => {
       expect(handler).not.toHaveBeenCalled();
     });
 
+    it('off() removes a listener added with on()', () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({ role: 'initiator', signaling: a });
+      peers = [peer];
+
+      const handler = vi.fn();
+      peer.on('statechange', handler);
+      peer.off('statechange', handler);
+
+      peer.dispatchEvent(new CustomEvent('statechange', { detail: {} }));
+      expect(handler).not.toHaveBeenCalled();
+    });
+
     it('once() auto-unsubscribes after the first fire', () => {
       const { a } = createLoopbackPair();
       const peer = new Peer({ role: 'initiator', signaling: a });

--- a/src/lib/webrtc/tests/peer.browser.test.js
+++ b/src/lib/webrtc/tests/peer.browser.test.js
@@ -214,12 +214,37 @@ describe('Peer', () => {
 
       const startPromise = peer.start();
       peer.close();
-      await expect(startPromise).rejects.toThrow(startError);
+      await expect(startPromise).rejects.toThrow(/closed before start/);
 
       expect(onError).toHaveBeenCalledWith(
-        { error: startError, phase: 'start' },
+        { error: expect.any(Error), phase: 'start' },
         expect.any(CustomEvent),
       );
+      expect(onError.mock.calls[0][0].error.message).toMatch(
+        /closed before start/,
+      );
+      expect(peer.state).toBe(PEER_STATES.CLOSED);
+    });
+
+    it('rejects and skips startup when close() runs during connecting statechange', async () => {
+      const { a } = createLoopbackPair();
+      const peer = new Peer({
+        role: 'initiator',
+        signaling: a,
+        dataChannel: true,
+      });
+      peers = [peer];
+      peer._startInitiator = vi.fn();
+      peer.on('statechange', ({ state }) => {
+        if (state === PEER_STATES.CONNECTING) {
+          peer.close();
+        }
+      });
+
+      await expect(peer.start()).rejects.toThrow(/closed before start/);
+
+      expect(peer._startInitiator).not.toHaveBeenCalled();
+      expect(peer._pendingStartReject).toBeNull();
       expect(peer.state).toBe(PEER_STATES.CLOSED);
     });
   });
@@ -333,6 +358,91 @@ describe('Peer', () => {
 
       await expect(startPromise).rejects.toThrow(/closed before start/);
       expect(joiner.state).toBe(PEER_STATES.CLOSED);
+    });
+
+    it('latches the first incoming offer before async answer work finishes', async () => {
+      const OriginalRTCPeerConnection = globalThis.RTCPeerConnection;
+      const OriginalRTCSessionDescription = globalThis.RTCSessionDescription;
+      const remoteDescriptionResolvers = [];
+      let remoteDescriptionCount = 0;
+      let offerHandler;
+
+      class FakePeerConnection extends EventTarget {
+        constructor() {
+          super();
+          this.signalingState = 'stable';
+          this.remoteDescription = null;
+          this.localDescription = null;
+        }
+
+        setRemoteDescription(description) {
+          remoteDescriptionCount += 1;
+          return new Promise((resolve) => {
+            remoteDescriptionResolvers.push(() => {
+              this.remoteDescription = description;
+              this.signalingState = 'have-remote-offer';
+              resolve();
+            });
+          });
+        }
+
+        createAnswer() {
+          return Promise.resolve({ type: 'answer', sdp: 'answer-sdp' });
+        }
+
+        setLocalDescription(description) {
+          this.localDescription = description;
+          this.signalingState = 'stable';
+          return Promise.resolve();
+        }
+
+        addIceCandidate() {
+          return Promise.resolve();
+        }
+
+        close() {
+          this.signalingState = 'closed';
+        }
+      }
+
+      globalThis.RTCPeerConnection = FakePeerConnection;
+      globalThis.RTCSessionDescription = function RTCSessionDescription(init) {
+        return init;
+      };
+
+      try {
+        const sendAnswer = vi.fn(() => Promise.resolve());
+        const joiner = new Peer({
+          role: 'joiner',
+          signaling: {
+            sendOffer: vi.fn(),
+            sendAnswer,
+            onOffer: (callback) => {
+              offerHandler = callback;
+            },
+            onAnswer: vi.fn(),
+            sendCandidate: vi.fn(),
+            onRemoteCandidate: vi.fn(),
+          },
+        });
+        peers = [joiner];
+
+        const startPromise = joiner.start();
+        await Promise.resolve();
+
+        offerHandler({ type: 'offer', sdp: 'first-offer' });
+        offerHandler({ type: 'offer', sdp: 'second-offer' });
+        await Promise.resolve();
+
+        expect(remoteDescriptionCount).toBe(1);
+
+        remoteDescriptionResolvers[0]();
+        await expect(startPromise).resolves.toBeUndefined();
+        expect(sendAnswer).toHaveBeenCalledTimes(1);
+      } finally {
+        globalThis.RTCPeerConnection = OriginalRTCPeerConnection;
+        globalThis.RTCSessionDescription = OriginalRTCSessionDescription;
+      }
     });
   });
 });

--- a/src/lib/webrtc/tracks.js
+++ b/src/lib/webrtc/tracks.js
@@ -11,6 +11,21 @@
  * @returns {{ allHealthy: boolean, unhealthyKinds: string[] }}
  */
 export function addLocalTracks(pc, localStream, { audioOnly = false } = {}) {
+  if (!pc || typeof pc.addTrack !== 'function') {
+    throw new TypeError(
+      'addLocalTracks: pc must be an RTCPeerConnection-like object with addTrack()',
+    );
+  }
+  if (
+    !localStream ||
+    typeof localStream.getTracks !== 'function' ||
+    typeof localStream.getAudioTracks !== 'function'
+  ) {
+    throw new TypeError(
+      'addLocalTracks: localStream must be a MediaStream-like object with getTracks() and getAudioTracks()',
+    );
+  }
+
   const unhealthyKinds = [];
 
   const tracks = audioOnly

--- a/src/lib/webrtc/tracks.js
+++ b/src/lib/webrtc/tracks.js
@@ -16,13 +16,20 @@ export function addLocalTracks(pc, localStream, { audioOnly = false } = {}) {
       'addLocalTracks: pc must be an RTCPeerConnection-like object with addTrack()',
     );
   }
-  if (
-    !localStream ||
-    typeof localStream.getTracks !== 'function' ||
-    typeof localStream.getAudioTracks !== 'function'
-  ) {
+  if (!localStream) {
     throw new TypeError(
-      'addLocalTracks: localStream must be a MediaStream-like object with getTracks() and getAudioTracks()',
+      'addLocalTracks: localStream must be a MediaStream-like object',
+    );
+  }
+  if (audioOnly) {
+    if (typeof localStream.getAudioTracks !== 'function') {
+      throw new TypeError(
+        'addLocalTracks: localStream must implement getAudioTracks() when audioOnly=true',
+      );
+    }
+  } else if (typeof localStream.getTracks !== 'function') {
+    throw new TypeError(
+      'addLocalTracks: localStream must implement getTracks()',
     );
   }
 

--- a/src/lib/webrtc/utils.js
+++ b/src/lib/webrtc/utils.js
@@ -9,11 +9,19 @@ const ROOM_ID_LENGTH = 7;
  * @returns {string} 7-char lowercase base36 ID.
  */
 export function generateRoomId() {
-  const bytes = new Uint8Array(ROOM_ID_LENGTH);
-  globalThis.crypto.getRandomValues(bytes);
   let out = '';
-  for (let i = 0; i < ROOM_ID_LENGTH; i++) {
-    out += ROOM_ID_ALPHABET[bytes[i] % ROOM_ID_ALPHABET.length];
+  const alphabetLen = ROOM_ID_ALPHABET.length;
+  const maxUnbiased = Math.floor(256 / alphabetLen) * alphabetLen;
+  const bytes = new Uint8Array(ROOM_ID_LENGTH * 2);
+
+  while (out.length < ROOM_ID_LENGTH) {
+    globalThis.crypto.getRandomValues(bytes);
+    for (let i = 0; i < bytes.length && out.length < ROOM_ID_LENGTH; i++) {
+      const byte = bytes[i];
+      if (byte < maxUnbiased) {
+        out += ROOM_ID_ALPHABET[byte % alphabetLen];
+      }
+    }
   }
   return out;
 }

--- a/src/lib/webrtc/utils.js
+++ b/src/lib/webrtc/utils.js
@@ -1,9 +1,19 @@
 // src/lib/webrtc/utils.js
 
+const ROOM_ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+const ROOM_ID_LENGTH = 7;
+
 /**
  * Generate a short random room ID suitable for use as a signaling key.
- * @returns {string}
+ * Uses the Web Crypto API so invite codes are unpredictable.
+ * @returns {string} 7-char lowercase base36 ID.
  */
 export function generateRoomId() {
-  return Math.random().toString(36).substring(2, 9);
+  const bytes = new Uint8Array(ROOM_ID_LENGTH);
+  globalThis.crypto.getRandomValues(bytes);
+  let out = '';
+  for (let i = 0; i < ROOM_ID_LENGTH; i++) {
+    out += ROOM_ID_ALPHABET[bytes[i] % ROOM_ID_ALPHABET.length];
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary
- Phase 1.5 of the WebRTC extraction: adds a high-level `Peer` class in `src/lib/webrtc/peer.js` that wraps `RTCPeerConnection` with sdp/ice/tracks/data-channel primitives and an `EventTarget`-based event surface. Signaling-agnostic; works for both initiator and joiner; optional media stream and optional data channel.
- Addresses 4 review items deferred from PR #491:
  1. `data-channel.js` joiner: `dataChannelReady` now times out after 10s (configurable) so callers cannot hang indefinitely if `ondatachannel` never fires.
  2. `data-channel.js` initiator: register `onAnswer` **before** `sendOffer` to eliminate the (theoretical) fast-answer race.
  3. `rtt.js`: route `console.warn/info` through the pluggable `log()` so the lib is silent-by-default per the `setLogger` contract.
  4. `utils.js`: `generateRoomId` now uses `crypto.getRandomValues` instead of `Math.random` (format unchanged: 7-char base36).

## Peer class highlights
- Lifecycle states: `idle → connecting → connected → disconnected/failed/closed`
- Events: `statechange`, `connected`, `disconnected`, `track`, `datachannel`, `open`, `message`, `close`, `error`
- API: `start()`, `send()`, `close()`, plus `on/off/once` sugar returning unsubscribe closures
- Zero new dependencies — native `EventTarget` only
- **Not yet wired into `call-controller`/`call-flow`**. Existing `createDataChannel`/`joinDataChannel` flows are untouched. The controller refactor is a follow-up.

## Tests
- 13 new browser-mode tests for `Peer` using real `RTCPeerConnection` with an in-memory loopback signaling pair
- Full suite: 362 node tests + 71 browser tests pass; lint + boundaries + build all green

## Test plan
- [ ] CI green (lint, boundaries, CodeQL, node tests, browser tests, build)
- [ ] Manual smoke: create a call + join a call still work (existing flows unchanged)
- [ ] Optional: manual verification that a new invite link format still parses (`?room=<7 lowercase base36 chars>`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Peer abstraction with public states/methods and exported it from the main WebRTC entrypoint.
  * Configurable data-channel ready timeout (default 10s).

* **Bug Fixes**
  * Prevents data-channel joins from hanging by timing out and rejecting stalled attempts.
  * Room IDs now use cryptographic randomness to produce fixed 7‑char lowercase IDs.
  * Improved RTT logging and stricter validation when adding local tracks.

* **Tests**
  * Added browser-mode tests for Peer lifecycle, data-channel negotiation, messaging, and events.

* **Documentation**
  * Added deferred issues and WIP notes capturing next steps and design decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->