### PR TITLE
Fix stale saved-contact call rooms

### DIFF
--- a/src/features/call/room.js
+++ b/src/features/call/room.js
@@ -70,7 +70,10 @@ class RoomService {
   ) {
     const joinedAt = Date.now();
     const result = await runTransaction(roomRef, (currentRoom) => {
-      if (currentRoom !== null) return;
+      const existingMembers = currentRoom?.members || {};
+      const hasExistingMembers = Object.keys(existingMembers).length > 0;
+      // BANDAID: saved-contact calls reuse stable room IDs, so reclaim stale empty room nodes left with cancellation/signaling data.
+      if (currentRoom !== null && hasExistingMembers) return;
 
       return {
         ...roomData,

--- a/src/features/call/tests/room-creation.test.js
+++ b/src/features/call/tests/room-creation.test.js
@@ -75,4 +75,54 @@ describe('Room creation', () => {
       },
     });
   });
+
+  it('reclaims stale empty room nodes when creating metadata', async () => {
+    runTransaction.mockImplementationOnce(async (_fbRef, updateFn) => {
+      const value = updateFn({
+        cancellation: { by: 'creator-user', reason: 'auto_timeout' },
+        answer: { type: 'answer', sdp: 'stale' },
+      });
+      return {
+        committed: value !== undefined,
+        snapshot: {
+          val: () => value,
+        },
+      };
+    });
+
+    await RoomService.createRoomMetadata('creator-user', 'metadata-room');
+
+    const [, updateFn] = runTransaction.mock.calls[0];
+    expect(updateFn({ cancellation: { reason: 'stale' } })).toMatchObject({
+      createdBy: 'creator-user',
+      members: {
+        'creator-user': {
+          userName: 'Guest User',
+        },
+      },
+    });
+  });
+
+  it('still rejects metadata creation when the room has active members', async () => {
+    runTransaction.mockImplementationOnce(async (_fbRef, updateFn) => {
+      const value = updateFn({
+        members: {
+          'other-user': {
+            userName: 'Other User',
+            joinedAt: 123,
+          },
+        },
+      });
+      return {
+        committed: value !== undefined,
+        snapshot: {
+          val: () => value,
+        },
+      };
+    });
+
+    await expect(
+      RoomService.createRoomMetadata('creator-user', 'metadata-room'),
+    ).rejects.toThrow('Room already exists');
+  });
 });


### PR DESCRIPTION
Quick fix for PROD - Proper solution saved for larger refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room creation logic to allow reclaiming empty room nodes, enabling users to rejoin rooms that exist but contain no active members.

* **Tests**
  * Added test coverage for room recovery scenarios and validation of member-based room creation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->