### PR TITLE
Render image attachments in messaging-next

### DIFF
--- a/src/components/base-legacy/imagePreview.js
+++ b/src/components/base-legacy/imagePreview.js
@@ -26,9 +26,10 @@ export function showImagePreview(src, fileName, downloadLabel = null) {
   downloadBtn.setAttribute('aria-label', `Download`);
   downloadBtn.setAttribute('title', `Download`);
 
-  const downloadIcon = document.createElement('i');
-  downloadIcon.setAttribute('data-lucide', 'download');
-  downloadBtn.appendChild(downloadIcon);
+  // const downloadIcon = document.createElement('i');
+  // downloadIcon.setAttribute('data-lucide', 'download');
+  // downloadBtn.appendChild(downloadIcon);
+
   if (typeof downloadLabel === 'string' && downloadLabel.trim() !== '') {
     const labelSpan = document.createElement('span');
     labelSpan.textContent = ' ' + downloadLabel;
@@ -39,12 +40,11 @@ export function showImagePreview(src, fileName, downloadLabel = null) {
   closeBtn.className = 'image-preview-close';
   closeBtn.setAttribute('aria-label', 'Close');
   closeBtn.setAttribute('title', 'Close Image Preview');
+  closeBtn.addEventListener('click', () => dialog.close());
 
-  const closeIcon = document.createElement('button');
-  // closeIcon.textContent = '×';
+  // const closeIcon = document.createElement('i');
   // closeIcon.setAttribute('data-lucide', 'x');
   // closeBtn.appendChild(closeIcon);
-  closeBtn.addEventListener('click', () => dialog.close());
 
   dialog.appendChild(img);
   dialog.appendChild(downloadBtn);

--- a/src/components/base-legacy/imagePreview.js
+++ b/src/components/base-legacy/imagePreview.js
@@ -40,9 +40,10 @@ export function showImagePreview(src, fileName, downloadLabel = null) {
   closeBtn.setAttribute('aria-label', 'Close');
   closeBtn.setAttribute('title', 'Close Image Preview');
 
-  const closeIcon = document.createElement('i');
-  closeIcon.setAttribute('data-lucide', 'x');
-  closeBtn.appendChild(closeIcon);
+  const closeIcon = document.createElement('button');
+  // closeIcon.textContent = '×';
+  // closeIcon.setAttribute('data-lucide', 'x');
+  // closeBtn.appendChild(closeIcon);
   closeBtn.addEventListener('click', () => dialog.close());
 
   dialog.appendChild(img);

--- a/src/components/base-legacy/imagePreview.js
+++ b/src/components/base-legacy/imagePreview.js
@@ -26,10 +26,6 @@ export function showImagePreview(src, fileName, downloadLabel = null) {
   downloadBtn.setAttribute('aria-label', `Download`);
   downloadBtn.setAttribute('title', `Download`);
 
-  // const downloadIcon = document.createElement('i');
-  // downloadIcon.setAttribute('data-lucide', 'download');
-  // downloadBtn.appendChild(downloadIcon);
-
   if (typeof downloadLabel === 'string' && downloadLabel.trim() !== '') {
     const labelSpan = document.createElement('span');
     labelSpan.textContent = ' ' + downloadLabel;
@@ -41,10 +37,6 @@ export function showImagePreview(src, fileName, downloadLabel = null) {
   closeBtn.setAttribute('aria-label', 'Close');
   closeBtn.setAttribute('title', 'Close Image Preview');
   closeBtn.addEventListener('click', () => dialog.close());
-
-  // const closeIcon = document.createElement('i');
-  // closeIcon.setAttribute('data-lucide', 'x');
-  // closeBtn.appendChild(closeIcon);
 
   dialog.appendChild(img);
   dialog.appendChild(downloadBtn);

--- a/src/features/messaging-next/ConversationPanel.module.css
+++ b/src/features/messaging-next/ConversationPanel.module.css
@@ -82,11 +82,9 @@
 }
 
 .msg:has(.filePreviewImg) {
-.msg:has(.filePreviewImg) {
   background: transparent;
   padding: 0;
   margin-bottom: 0.75rem;
-}
 }
 
 .filePreviewImg {

--- a/src/features/messaging-next/ConversationPanel.module.css
+++ b/src/features/messaging-next/ConversationPanel.module.css
@@ -82,10 +82,11 @@
 }
 
 .msg:has(.filePreviewImg) {
+.msg:has(.filePreviewImg) {
   background: transparent;
-
   padding: 0;
   margin-bottom: 0.75rem;
+}
 }
 
 .filePreviewImg {

--- a/src/features/messaging-next/ConversationPanel.module.css
+++ b/src/features/messaging-next/ConversationPanel.module.css
@@ -81,6 +81,44 @@
   text-wrap: pretty;
 }
 
+.msg:has(.filePreviewImg) {
+  background: transparent;
+
+  padding: 0;
+  margin-bottom: 0.75rem;
+}
+
+.filePreviewImg {
+  display: block;
+  max-width: 100%;
+  max-height: 400px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 0.45rem;
+  cursor: pointer;
+}
+
+.fileMessageMeta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  min-width: 0;
+  font-size: 0.9em;
+}
+
+.fileMessageName {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: inherit;
+  text-decoration: underline;
+}
+
+.fileMessageSize {
+  flex: 0 0 auto;
+  opacity: 0.75;
+}
+
 .msgSystem {
   background-color: transparent;
   color: #888;
@@ -102,6 +140,16 @@
 
 .msgText {
   word-break: break-word;
+}
+
+.fileMessage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.msgText:not(:empty) + .fileMessage {
+  margin-top: 0.4rem;
 }
 
 .msgStatus {

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -269,12 +269,20 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                                     class={styles.filePreviewImg}
                                     src={file.data}
                                     alt={file.fileName}
+                                    role='button'
+                                    tabIndex={0}
                                     onClick={() =>
                                       showImagePreview(
                                         file.data,
                                         file.fileName,
                                       )
                                     }
+                                    onKeyDown={(e) => {
+                                      if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        showImagePreview(file.data, file.fileName);
+                                      }
+                                    }}
                                   />
                                 </Show>
                                 <span class={styles.fileMessageMeta}>

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -261,6 +261,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                             const safeDataUrl = isSafeDataUrl(file.data);
                             const canPreview =
                               safeDataUrl && isImageAttachment(file);
+                            const canDownload =
+                              safeDataUrl ||
+                              file.data.startsWith('blob:') ||
+                              file.data.startsWith('https://') ||
+                              file.data.startsWith('http://');
 
                             return (
                               <span class={styles.fileMessage}>
@@ -269,25 +274,14 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                                     class={styles.filePreviewImg}
                                     src={file.data}
                                     alt={file.fileName}
-                                    role='button'
-                                    tabIndex={0}
                                     onClick={() =>
-                                      showImagePreview(
-                                        file.data,
-                                        file.fileName,
-                                      )
+                                      showImagePreview(file.data, file.fileName)
                                     }
-                                    onKeyDown={(e) => {
-                                      if (e.key === 'Enter' || e.key === ' ') {
-                                        e.preventDefault();
-                                        showImagePreview(file.data, file.fileName);
-                                      }
-                                    }}
                                   />
                                 </Show>
                                 <span class={styles.fileMessageMeta}>
                                   <Show
-                                    when={safeDataUrl}
+                                    when={canDownload}
                                     fallback={
                                       <span class={styles.fileMessageName}>
                                         {file.fileName}

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -33,8 +33,21 @@ import styles from './ConversationPanel.module.css';
 const runtime = createMessagingRuntime();
 const DRAFT_SAVE_DELAY_MS = 250;
 
-function isSafeDataUrl(url: string) {
-  return url.startsWith('data:');
+function dataUrlMimeType(url: string) {
+  const match = /^data:([^;,]+)[;,]/i.exec(url);
+  return match?.[1]?.toLowerCase() ?? 'text/plain';
+}
+
+function hasAllowedDataUrl(attachment: MessageAttachment) {
+  if (!attachment.data.startsWith('data:')) return false;
+
+  const declaredMimeType = attachment.mimeType.trim().toLowerCase();
+  const actualMimeType = dataUrlMimeType(attachment.data);
+  return (
+    actualMimeType === declaredMimeType &&
+    actualMimeType !== 'text/html' &&
+    actualMimeType !== 'image/svg+xml'
+  );
 }
 
 function isImageAttachment(attachment: MessageAttachment) {
@@ -258,14 +271,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                         <Show when={msg.attachment}>
                           {(attachment) => {
                             const file = attachment();
-                            const safeDataUrl = isSafeDataUrl(file.data);
+                            const allowedDataUrl = hasAllowedDataUrl(file);
                             const canPreview =
-                              safeDataUrl && isImageAttachment(file);
+                              allowedDataUrl && isImageAttachment(file);
                             const canDownload =
-                              safeDataUrl ||
-                              file.data.startsWith('blob:') ||
-                              file.data.startsWith('https://') ||
-                              file.data.startsWith('http://');
+                              allowedDataUrl || file.data.startsWith('blob:');
 
                             return (
                               <span class={styles.fileMessage}>

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -274,9 +274,19 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                                     class={styles.filePreviewImg}
                                     src={file.data}
                                     alt={file.fileName}
+                                    role='button'
+                                    tabIndex={0}
+                                    aria-label={`Open preview for ${file.fileName}`}
                                     onClick={() =>
                                       showImagePreview(file.data, file.fileName)
                                     }
+                                    onKeyDown={(e) => {
+                                      if (e.key !== 'Enter' && e.key !== ' ') {
+                                        return;
+                                      }
+                                      e.preventDefault();
+                                      showImagePreview(file.data, file.fileName);
+                                    }}
                                   />
                                 </Show>
                                 <span class={styles.fileMessageMeta}>

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -51,7 +51,7 @@ function hasAllowedDataUrl(attachment: MessageAttachment) {
 }
 
 function isImageAttachment(attachment: MessageAttachment) {
-  return attachment.mimeType.startsWith('image/');
+  return attachment.mimeType.trim().toLowerCase().startsWith('image/');
 }
 
 function formatFileSize(bytes: number) {

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -14,6 +14,7 @@ import { getUserName } from '../../auth/index.js';
 
 import { useI18n } from '../../shared/i18n';
 import { LoadBoundary } from '../../components/app/LoadBoundary';
+import { showImagePreview } from '../../components/base-legacy/imagePreview.js';
 
 import { createMessagingRuntime } from './messaging-runtime.js';
 
@@ -25,12 +26,26 @@ import {
 } from './use-conversation.js';
 import { clearLocalDraft, saveLocalDraft } from './local-drafts.js';
 import type { ConversationId, UserId } from './types.js';
-import type { ConversationSelection } from './interfaces.js';
+import type { ConversationSelection, MessageAttachment } from './interfaces.js';
 
 import styles from './ConversationPanel.module.css';
 
 const runtime = createMessagingRuntime();
 const DRAFT_SAVE_DELAY_MS = 250;
+
+function isSafeDataUrl(url: string) {
+  return url.startsWith('data:');
+}
+
+function isImageAttachment(attachment: MessageAttachment) {
+  return attachment.mimeType.startsWith('image/');
+}
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 function MessageHistorySkeleton() {
   return (
@@ -240,6 +255,53 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                         }}
                       >
                         <span class={styles.msgText}>{msg.text}</span>
+                        <Show when={msg.attachment}>
+                          {(attachment) => {
+                            const file = attachment();
+                            const safeDataUrl = isSafeDataUrl(file.data);
+                            const canPreview =
+                              safeDataUrl && isImageAttachment(file);
+
+                            return (
+                              <span class={styles.fileMessage}>
+                                <Show when={canPreview}>
+                                  <img
+                                    class={styles.filePreviewImg}
+                                    src={file.data}
+                                    alt={file.fileName}
+                                    onClick={() =>
+                                      showImagePreview(
+                                        file.data,
+                                        file.fileName,
+                                      )
+                                    }
+                                  />
+                                </Show>
+                                <span class={styles.fileMessageMeta}>
+                                  <Show
+                                    when={safeDataUrl}
+                                    fallback={
+                                      <span class={styles.fileMessageName}>
+                                        {file.fileName}
+                                      </span>
+                                    }
+                                  >
+                                    <a
+                                      href={file.data}
+                                      download={file.fileName}
+                                      class={styles.fileMessageName}
+                                    >
+                                      {file.fileName}
+                                    </a>
+                                  </Show>
+                                  <span class={styles.fileMessageSize}>
+                                    ({formatFileSize(file.fileSize)})
+                                  </span>
+                                </span>
+                              </span>
+                            );
+                          }}
+                        </Show>
                         <Show when={msg.status === 'sending'}>
                           <span class={styles.msgStatus}>…</span>
                         </Show>

--- a/src/features/messaging-next/adapters/rtdb.test.js
+++ b/src/features/messaging-next/adapters/rtdb.test.js
@@ -56,6 +56,45 @@ describe('messaging-next RTDB adapter', () => {
     );
   });
 
+  it('loads legacy file message rows for read-side rendering', async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      forEach: (visit) => {
+        visit({
+          key: 'file-1',
+          val: () => ({
+            from: 'user-a',
+            fromName: 'User A',
+            type: 'file',
+            fileName: 'demo.png',
+            mimeType: 'image/png',
+            fileSize: 123,
+            data: 'data:image/png;base64,abc',
+            sentAt: 10,
+            read: false,
+          }),
+        });
+      },
+    });
+
+    const repository = createRTDBMessageRepository();
+    const messages = await repository.loadMessages('user-a_user-b');
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        messageId: 'file-1',
+        payload: {
+          type: 'file',
+          fileName: 'demo.png',
+          mimeType: 'image/png',
+          fileSize: 123,
+          data: 'data:image/png;base64,abc',
+          text: undefined,
+        },
+      }),
+    ]);
+  });
+
   it('loads shared conversation metadata without draft state', async () => {
     vi.mocked(get).mockResolvedValue({
       exists: () => true,

--- a/src/features/messaging-next/adapters/rtdb.ts
+++ b/src/features/messaging-next/adapters/rtdb.ts
@@ -48,15 +48,45 @@ function toIncoming(
   key: string,
   conversationId: ConversationId,
 ): IncomingMessage | null {
-  if (!raw || typeof raw.text !== 'string' || !raw.from) return null;
-  return {
+  if (!raw || !raw.from) return null;
+
+  const base = {
     messageId: key,
     conversationId,
     senderId: raw.from as UserId,
     senderName: typeof raw.fromName === 'string' ? raw.fromName : undefined,
     // sentAt is a server timestamp (number on read, null briefly after write)
     sentAt: typeof raw.sentAt === 'number' ? raw.sentAt : Date.now(),
-    delivery: 'persistent',
+    delivery: 'persistent' as const,
+  };
+
+  if (raw.type === 'file') {
+    if (
+      typeof raw.fileName !== 'string' ||
+      typeof raw.mimeType !== 'string' ||
+      typeof raw.fileSize !== 'number' ||
+      typeof raw.data !== 'string'
+    ) {
+      return null;
+    }
+
+    return {
+      ...base,
+      payload: {
+        type: 'file',
+        fileName: raw.fileName,
+        mimeType: raw.mimeType,
+        fileSize: raw.fileSize,
+        data: raw.data,
+        text: typeof raw.text === 'string' ? raw.text : undefined,
+      },
+    };
+  }
+
+  if (typeof raw.text !== 'string') return null;
+
+  return {
+    ...base,
     payload: {
       type: 'text',
       text: raw.text,

--- a/src/features/messaging-next/interfaces.ts
+++ b/src/features/messaging-next/interfaces.ts
@@ -175,6 +175,14 @@ export type TransportMode = 'persisted' | 'private';
 
 export type MessageAction = { label: string; onClick: () => void };
 
+export type MessageAttachment = {
+  type: 'file';
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+  data: string;
+};
+
 export type ConversationSelection = {
   conversationId: ConversationId;
   remoteParticipantIds?: UserId[];
@@ -186,6 +194,7 @@ export type ChatMessage = {
   id: string;
   conversationId: ConversationId;
   text: string;
+  attachment?: MessageAttachment;
   senderId: UserId;
   sentAt: number;
   status: MessageStatus;

--- a/src/features/messaging-next/schema.ts
+++ b/src/features/messaging-next/schema.ts
@@ -61,6 +61,15 @@ export const TextMessagePayloadSchema = z.object({
   text: z.string().min(1),
 });
 
+export const FileMessagePayloadSchema = z.object({
+  type: z.literal('file'),
+  fileName: z.string().trim().min(1),
+  mimeType: z.string().trim().min(1),
+  fileSize: z.number().int().nonnegative(),
+  data: z.string().min(1),
+  text: z.string().optional(),
+});
+
 export const EventMessagePayloadSchema = z.object({
   type: z.literal('event'),
   eventType: z.literal('evt:call:session:unanswered'),
@@ -79,6 +88,7 @@ export const SystemMessagePayloadSchema = z.object({
 
 export const MessagePayloadSchema = z.discriminatedUnion('type', [
   TextMessagePayloadSchema,
+  FileMessagePayloadSchema,
   EventMessagePayloadSchema,
   SystemMessagePayloadSchema,
 ]);

--- a/src/features/messaging-next/tests/schema.test.js
+++ b/src/features/messaging-next/tests/schema.test.js
@@ -71,19 +71,22 @@ describe('messaging-next schema', () => {
     expect(payload.details?.callId).toBe('room-123');
   });
 
-  it('rejects file payloads until the file-message contract is designed', () => {
-    expect(() =>
-      MessageEnvelopeSchema.parse({
-        messageId: 'msg-1',
-        conversationId: 'user-a_user-b',
-        senderId: 'user-a',
-        sentAt: 10,
-        delivery: 'persistent',
-        payload: {
-          type: 'file',
-          fileName: 'demo.png',
-        },
-      }),
-    ).toThrow();
+  it('accepts legacy file payloads for read-side rendering', () => {
+    const message = MessageEnvelopeSchema.parse({
+      messageId: 'msg-1',
+      conversationId: 'user-a_user-b',
+      senderId: 'user-a',
+      sentAt: 10,
+      delivery: 'persistent',
+      payload: {
+        type: 'file',
+        fileName: 'demo.png',
+        mimeType: 'image/png',
+        fileSize: 123,
+        data: 'data:image/png;base64,abc',
+      },
+    });
+
+    expect(message.payload.type).toBe('file');
   });
 });

--- a/src/features/messaging-next/tests/use-conversation.test.js
+++ b/src/features/messaging-next/tests/use-conversation.test.js
@@ -37,6 +37,36 @@ describe('messaging-next useConversation', () => {
     expect(loaded.map((msg) => msg.id)).toEqual(['msg-1', 'msg-2', 'msg-3']);
   });
 
+  it('maps legacy file envelopes into chat attachments', async () => {
+    const repository = {
+      loadMessages: () => [
+        envelope({
+          payload: {
+            type: 'file',
+            fileName: 'demo.png',
+            mimeType: 'image/png',
+            fileSize: 123,
+            data: 'data:image/png;base64,abc',
+          },
+        }),
+      ],
+    };
+
+    const loaded = await loadConversationHistory(repository, 'conversation-1');
+
+    expect(loaded[0]).toMatchObject({
+      id: 'msg-1',
+      text: '',
+      attachment: {
+        type: 'file',
+        fileName: 'demo.png',
+        mimeType: 'image/png',
+        fileSize: 123,
+        data: 'data:image/png;base64,abc',
+      },
+    });
+  });
+
   it('starts live subscriptions only after history is ready', async () => {
     const store = createConversationState();
     const actions = createConversationActions(store);

--- a/src/features/messaging-next/types.ts
+++ b/src/features/messaging-next/types.ts
@@ -7,6 +7,7 @@ import type {
   DeliveryPolicySchema,
   DirectConversationIdSchema,
   EventMessagePayloadSchema,
+  FileMessagePayloadSchema,
   GroupConversationIdSchema,
   MessageEnvelopeSchema,
   MessagePayloadSchema,
@@ -29,6 +30,7 @@ export type ConversationRecord = z.infer<typeof ConversationRecordSchema>;
 export type ConversationNode = z.infer<typeof ConversationNodeSchema>;
 
 export type TextMessagePayload = z.infer<typeof TextMessagePayloadSchema>;
+export type FileMessagePayload = z.infer<typeof FileMessagePayloadSchema>;
 export type EventMessagePayload = z.infer<typeof EventMessagePayloadSchema>;
 export type SystemMessagePayload = z.infer<typeof SystemMessagePayloadSchema>;
 export type MessagePayload = z.infer<typeof MessagePayloadSchema>;

--- a/src/features/messaging-next/use-conversation.ts
+++ b/src/features/messaging-next/use-conversation.ts
@@ -32,15 +32,31 @@ export function envelopeToChatMessage(
   message: MessageEnvelope,
   source: ChatMessage['source'],
 ): ChatMessage | null {
-  if (message.payload.type !== 'text') {
+  if (message.payload.type === 'system' || message.payload.type === 'event') {
     return null;
   }
+
+  const text =
+    message.payload.type === 'text'
+      ? message.payload.text
+      : (message.payload.text ?? '');
+  const attachment =
+    message.payload.type === 'file'
+      ? {
+          type: 'file' as const,
+          fileName: message.payload.fileName,
+          mimeType: message.payload.mimeType,
+          fileSize: message.payload.fileSize,
+          data: message.payload.data,
+        }
+      : undefined;
 
   return {
     id: message.messageId,
     conversationId: message.conversationId,
     senderId: message.senderId,
-    text: message.payload.text,
+    text,
+    attachment,
     sentAt: message.sentAt,
     delivery: message.delivery,
     source,

--- a/src/styles/components/dialog/image-preview-dialog.css
+++ b/src/styles/components/dialog/image-preview-dialog.css
@@ -38,7 +38,6 @@
   cursor: pointer;
   overflow: hidden;
   font-size: 28px;
-
   transition: color 0.2s ease;
 }
 

--- a/src/styles/components/dialog/image-preview-dialog.css
+++ b/src/styles/components/dialog/image-preview-dialog.css
@@ -24,8 +24,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-
-  /* mix-blend-mode: lighten; */
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   border-radius: 50%;

--- a/src/styles/components/dialog/image-preview-dialog.css
+++ b/src/styles/components/dialog/image-preview-dialog.css
@@ -21,32 +21,49 @@
 
 .image-preview-close,
 .image-preview-download {
-  mix-blend-mode: lighten;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* mix-blend-mode: lighten; */
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   border-radius: 50%;
-  padding: var(--spacing-xs);
-
-  background-color: rgba(255 255 255 / 0.05);
   border: none;
-  color: var(--text-secondary);
+  width: 36px;
+  height: 36px;
+  background-color: rgba(131 131 131 / 0.639);
+  color: var(--text-primary);
+  text-shadow: 0 0 4px rgba(0 0 0 / 0.5);
+  cursor: pointer;
+  overflow: hidden;
+  font-size: 28px;
 
   transition: color 0.2s ease;
 }
 
 .image-preview-close:hover,
 .image-preview-download:hover {
-  background: rgba(255 255 255 / 0.1);
+  background: rgb(0 0 0 / 0.8);
   color: var(--text-primary);
 }
 
 .image-preview-download {
   position: absolute;
   top: var(--spacing-sm);
-  right: var(--spacing-sm);
+  left: var(--spacing-sm);
 }
 
 .image-preview-close {
   position: absolute;
   top: var(--spacing-sm);
-  left: var(--spacing-sm);
+  right: var(--spacing-sm);
+}
+
+.image-preview-close::before {
+  content: '×';
+}
+
+.image-preview-download::before {
+  content: '⤓';
 }


### PR DESCRIPTION
## Summary
- Add file/image message payload to the Zod schema, RTDB adapter, and conversation state in `messaging-next`.
- Render image previews inline in the message bubble with click-to-expand via the existing `imagePreview` dialog.
- Fix bubble collapse where images intermittently rendered at zero height. Root cause: `max-height` + `overflow` was applied to the bubble (`.msg`), which forced 0-height layout before the data-URL image had resolved intrinsic size. Constraints now live on the `<img>` itself.
- Drop `loading=\"lazy\"` on chat images. It is pointless for `data:` URLs and the IntersectionObserver was leaving placeholders in place whenever the bubble briefly had zero height or was off-screen during auto-scroll.

## Test plan
- [ ] Send an image; preview renders at correct size, click opens full preview.
- [ ] Receive an image; same behaviour.
- [ ] Send several images in a row; none stay as placeholders, auto-scroll lands correctly.
- [ ] Non-image attachment still renders filename + size with a working download link.
- [ ] Existing text/system/event messages unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages can include file attachments; images show inline previews and other files provide download links.

* **Improvements**
  * Safer attachment handling: some unsafe types are blocked from previewing and will render as plain names or safe downloads.
  * Updated preview and file-message styling, layout, metadata, and button placement.

* **Bug Fixes**
  * Preview dialog close/download buttons may currently lack their prior icons; visual fix to follow.

* **Tests**
  * Added/updated tests to cover legacy file-message handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KristinnRoach/HangVidU/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->