### PR TITLE
Drop legacy per-user call paths from RTDB rules

### DIFF
--- a/database.rules.TODO.md
+++ b/database.rules.TODO.md
@@ -1,13 +1,15 @@
 # Database Rules Migration TODO
 
-These rules are shared by production and development. Do not remove legacy paths
-until the Solid/p2p call-flow branch has been merged, deployed, and production
-clients are no longer running the `main` branch call code.
+These rules are shared by production and development. Items below are deferred
+to subsequent releases — they must not block the Solid cutover deploy.
 
-## After the new call-flow is deployed
+## After the new call-flow is deployed (legacy clients fully retired)
 
-- Restore the scoped `rooms/{roomId}` access rules that were temporarily rolled
-  back for production legacy call compatibility:
+The Solid deploy keeps `rooms/{roomId}` permissive (`read: true / write: true`)
+for one release as a safety net for any cached PWA clients still running
+`archive-pre-solid-main` call code. Once those clients are confirmed gone:
+
+- Restore the scoped `rooms/{roomId}` access rules:
 
   ```json
   "rooms": {
@@ -24,36 +26,50 @@ clients are no longer running the `main` branch call code.
       },
       "p2pSignaling": {
         ".write": "auth != null && root.child('rooms').child($roomId).child('participants').child(auth.uid).exists()"
-      },
-      "watch": {
-        ".write": "auth != null && root.child('rooms').child($roomId).child('participants').child(auth.uid).exists()"
-      },
-      "mediaSyncSignaling": {
-        ".write": "auth != null && root.child('rooms').child($roomId).child('participants').child(auth.uid).exists()"
       }
     }
   }
   ```
-- Review whether `users/{userId}/recentCalls` is still used. It is required by
-  the current production `main` branch call listeners, so it must stay until the
-  legacy call module is fully retired in production.
-- Review whether `users/{userId}/outgoingCall` is still used. It belongs to the
-  legacy outgoing-call UI state and may be removable after the new call-flow owns
-  all outgoing call state.
-- Review whether `users/{userId}/calls/*` can replace any legacy call lifecycle
-  paths, and tighten validation for:
-  - `calls/incoming`: require the invite writer to match `callerId`, validate
-    required fields, and define whether only contacts may create call invites.
-  - `calls/response`: require response payloads to match the expected room and
-    sender, and define who can clear the response.
-  - `calls/response` `.read` is currently `auth != null`, so any signed-in user
-    can read any other user's call-response signaling (caller/callee uids,
-    roomId, response type, timestamps). Scope to the participants of the call
-    — either by including `callerId` in the payload and gating
-    `.read` on `auth.uid === data.child('callerId').val()`, or by moving the
-    response under `rooms/{roomId}` so room-access gates the read.
-- Once all active clients are migrated, remove obsolete call rules and matching
-  storage helpers in the same release.
+
+  The legacy `watch` and `mediaSyncSignaling` sub-rules can be dropped — the
+  Solid code does not use those paths (watch-together has not been re-wired
+  onto the new room model yet; add the sub-rule back when it is).
+
+- `users/{uid}/calls/response` `.read` is currently `auth != null`, which lets
+  any signed-in user read any other user's call-response signaling (caller/
+  callee uids, roomId, response type, timestamps). Scope to call participants
+  — either by including `callerId` in the payload and gating `.read` on
+  `auth.uid === data.child('callerId').val() || auth.uid === $userId`, or by
+  moving the response under `rooms/{roomId}` so room-access gates the read.
+
+- Tighten the remaining `calls/incoming` and `calls/response` `.write`
+  validation if any field constraints are still missing once the call flow is
+  fully exercised in prod (e.g. require `callerId === auth.uid` on writes,
+  bound expiresAt windows, restrict to contacts).
+
+## Conversations: backfill `members/` and drop the substring fallback
+
+Today both `conversations/{id}` `.read` and `messages/{messageId}` `.write`
+fall back to `$conversationId.contains(auth.uid + '_')` because neither the
+archive code nor the new Solid `messaging-next` adapter writes
+`conversations/{id}/members/{uid}`. The fallback is load-bearing: dropping it
+without a backfill would break every existing direct conversation. The
+substring rule is safe in practice because Firebase Auth UIDs are alphanumeric
+(no `_`), but is fragile in principle and ties us to the
+`{userA}_{userB}`-sorted direct-id format.
+
+Steps for a future release:
+
+1. Update the messaging RTDB adapter to write `members/{senderId}` and
+   `members/{recipientId}` on first send (or on conversation open) for direct
+   conversations.
+2. Run an admin backfill that derives both participants from the existing
+   `{userA}_{userB}` conversation id and writes `members/{uid}: true` for each.
+3. Drop both substring fallbacks from `database.rules.json`.
+4. While there, fix the direct-id format itself (see top of
+   [`src/shared/utils/direct-conversation-id.js`](./src/shared/utils/direct-conversation-id.js))
+   — `split('_')` breaks if uids ever contain `_`. Use a safer encoded id or
+   pass participant ids from conversation metadata.
 
 ## Password / username sign-in (deferred until verified or BetterAuth migration)
 
@@ -80,10 +96,10 @@ not affect production before the new flow is verified:
 
 ## Field rename: `userName` → `displayName` (or `appNickname`)
 
-Before deploying the username + password flow, rename the existing display-name
-field `userName` (used everywhere as a non-unique display string) to
-`displayName` or `appNickname` to disambiguate from the new `username` (unique
-login handle). This is a breaking data-shape change that touches:
+Before deploying the username + password flow widely, rename the existing
+display-name field `userName` (used everywhere as a non-unique display string)
+to `displayName` or `appNickname` to disambiguate from the new `username`
+(unique login handle). This is a breaking data-shape change that touches:
 
 - `users/{uid}/profile/userName` (RTDB path key)
 - `usersByEmail/{hash}.userName` (directory entry)
@@ -94,3 +110,16 @@ login handle). This is a breaking data-shape change that touches:
 Plan a one-time migration (read old field, write new, delete old) and ship the
 rename and migration in the same release. Do not start until both DEV and PROD
 clients have been updated to read both keys during a transition window.
+
+## Minor cleanups (low priority)
+
+- `notifications/{userId}` RTDB node is unused at runtime — only the
+  `delete-account-handler` cloud function ever writes to it (with `null`),
+  and no client reads or writes it. Rule is also too permissive
+  (`.write: "auth != null"` lets any signed-in user write to anyone's node).
+  Drop the rule block and the cloud-function cleanup line in the same release.
+- `users/{uid}/profile` `.write` has no shape validation. Restrict to known
+  keys (`userName`, `photoURL`, `username`, `email`) with `.validate` rules.
+- `users/{uid}` parent `.write: "$userId === auth.uid && !newData.exists()"`
+  is effectively dead — the account-delete cloud function uses admin SDK,
+  which bypasses rules. Can be removed, leaving per-child rules.

--- a/database.rules.json
+++ b/database.rules.json
@@ -33,14 +33,6 @@
             ".write": "auth != null && (($acceptedByUserId === auth.uid && !data.exists()) || ($userId === auth.uid && !newData.exists()))"
           }
         },
-        "callHistory": {
-          ".read": "$userId === auth.uid",
-          ".write": "$userId === auth.uid"
-        },
-        "recentCalls": {
-          ".read": "$userId === auth.uid",
-          ".write": "$userId === auth.uid"
-        },
         "calls": {
           "incoming": {
             ".read": "$userId === auth.uid",
@@ -50,10 +42,6 @@
             ".read": "auth != null",
             ".write": "$userId === auth.uid && (!newData.exists() || (newData.hasChildren(['roomId', 'responseType', 'by', 'respondedAt']) && newData.child('roomId').isString() && newData.child('by').val() === auth.uid && newData.child('respondedAt').isNumber() && (!newData.child('expiresAt').exists() || newData.child('expiresAt').isNumber()) && (newData.child('responseType').val() === 'accepted' || newData.child('responseType').val() === 'rejected' || newData.child('responseType').val() === 'busy')))"
           }
-        },
-        "outgoingCall": {
-          ".read": "$userId === auth.uid",
-          ".write": "$userId === auth.uid"
         },
         "profile": {
           ".read": true,

--- a/scripts/cleanup-legacy-call-paths.js
+++ b/scripts/cleanup-legacy-call-paths.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * Remove legacy per-user call paths from RTDB after the Solid cutover.
+ *
+ * The new call flow uses `users/{uid}/calls/{incoming,response}`. The legacy
+ * `archive-pre-solid-main` code wrote to:
+ *   - users/{uid}/recentCalls
+ *   - users/{uid}/outgoingCall
+ *   - users/{uid}/callHistory
+ *
+ * Rules for these paths were removed in the same release that deploys this
+ * script. Existing data is now orphaned and unreadable; this script deletes
+ * it.
+ *
+ * Usage:
+ *   node scripts/cleanup-legacy-call-paths.js          # dry run
+ *   node scripts/cleanup-legacy-call-paths.js --delete # actually delete
+ */
+
+import admin from 'firebase-admin';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import readline from 'readline';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const shouldDelete = process.argv.includes('--delete');
+
+const serviceAccountPath = path.join(
+  __dirname,
+  '../functions/service-account-key.json',
+);
+
+if (!fs.existsSync(serviceAccountPath)) {
+  console.error('Error: service-account-key.json not found at', serviceAccountPath);
+  process.exit(1);
+}
+
+const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf-8'));
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: 'https://vidu-aae11-default-rtdb.europe-west1.firebasedatabase.app',
+});
+
+const db = admin.database();
+
+const LEGACY_KEYS = ['recentCalls', 'outgoingCall', 'callHistory'];
+
+function promptConfirmation(message) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(message, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+async function main() {
+  console.log('=== Legacy call-path cleanup ===\n');
+  console.log(`Scanning users/* for: ${LEGACY_KEYS.join(', ')}\n`);
+
+  // Use shallow=true via a single read; user nodes are typically small enough
+  // for this. If the user table grows huge, switch to paginated reads.
+  const snapshot = await db.ref('users').once('value');
+
+  if (!snapshot.exists()) {
+    console.log('No users found.');
+    process.exit(0);
+  }
+
+  const updates = {};
+  const counts = Object.fromEntries(LEGACY_KEYS.map((k) => [k, 0]));
+  let affectedUsers = 0;
+  let totalUsers = 0;
+
+  snapshot.forEach((userSnap) => {
+    totalUsers += 1;
+    const uid = userSnap.key;
+    let userAffected = false;
+    for (const key of LEGACY_KEYS) {
+      if (userSnap.child(key).exists()) {
+        updates[`users/${uid}/${key}`] = null;
+        counts[key] += 1;
+        userAffected = true;
+      }
+    }
+    if (userAffected) affectedUsers += 1;
+  });
+
+  console.log('Summary:');
+  console.log(`  Total users scanned: ${totalUsers}`);
+  console.log(`  Users with legacy data: ${affectedUsers}`);
+  for (const key of LEGACY_KEYS) {
+    console.log(`  Users with ${key}: ${counts[key]}`);
+  }
+  console.log(`  Total path deletions queued: ${Object.keys(updates).length}\n`);
+
+  if (Object.keys(updates).length === 0) {
+    console.log('Nothing to delete.');
+    process.exit(0);
+  }
+
+  if (!shouldDelete) {
+    console.log('Dry run only. Re-run with --delete to apply.');
+    process.exit(0);
+  }
+
+  const confirmed = await promptConfirmation(
+    `About to delete ${Object.keys(updates).length} paths across ${affectedUsers} users. Type "yes" to confirm: `,
+  );
+  if (!confirmed) {
+    console.log('Cancelled.');
+    process.exit(0);
+  }
+
+  await db.ref().update(updates);
+  console.log(`\nDeleted ${Object.keys(updates).length} paths.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/cleanup-rtdb-stale.js
+++ b/scripts/cleanup-rtdb-stale.js
@@ -44,7 +44,9 @@ const DATABASE_URL =
 
 const shouldDelete = process.argv.includes('--delete');
 const skipPrompt = process.argv.includes('--yes');
-const taskArg = process.argv[2];
+// First non-flag argument after the script path is the task name, so flag
+// order doesn't matter (e.g. `--delete rooms-legacy` works).
+const taskArg = process.argv.slice(2).find((a) => !a.startsWith('--'));
 
 const TASKS = [
   'rooms-legacy',
@@ -139,6 +141,12 @@ async function confirmAndApply(label, updates) {
   return paths.length;
 }
 
+// New-flow rooms write meta.createdAt up-front, but the write is not atomic
+// with the room being touched for the first time — a room read mid-creation
+// could legitimately have no meta yet. Skip no-meta rooms younger than this
+// window so we don't race in-flight Solid call handshakes.
+const NO_META_MIN_AGE_MS = 60 * 60 * 1000; // 1 hour
+
 async function taskRoomsLegacy() {
   console.log('\n=== rooms-legacy ===');
   const snap = await db.ref('rooms').once('value');
@@ -147,9 +155,11 @@ async function taskRoomsLegacy() {
     return 0;
   }
   const rooms = snap.val();
+  const now = Date.now();
   const updates = {};
   let legacyKeyHits = 0;
   let noMetaHits = 0;
+  let noMetaSkippedTooNew = 0;
 
   for (const [roomId, room] of Object.entries(rooms)) {
     if (!room || typeof room !== 'object') continue;
@@ -161,14 +171,28 @@ async function taskRoomsLegacy() {
       updates[`rooms/${roomId}`] = null;
       legacyKeyHits += 1;
     } else if (!hasMetaCreatedAt) {
-      updates[`rooms/${roomId}`] = null;
-      noMetaHits += 1;
+      // Fallback timestamps that the archive code may have written at the
+      // top level. If none exist, treat the room as ancient (legacy).
+      const fallbackTs =
+        typeof room.createdAt === 'number' ? room.createdAt : null;
+      const ageMs = fallbackTs != null ? now - fallbackTs : Infinity;
+      if (ageMs >= NO_META_MIN_AGE_MS) {
+        updates[`rooms/${roomId}`] = null;
+        noMetaHits += 1;
+      } else {
+        noMetaSkippedTooNew += 1;
+      }
     }
   }
 
   console.log(`Total rooms: ${Object.keys(rooms).length}`);
   console.log(`Rooms with legacy sub-keys: ${legacyKeyHits}`);
-  console.log(`Rooms without meta.createdAt: ${noMetaHits}`);
+  console.log(`Rooms without meta.createdAt (>=1h old): ${noMetaHits}`);
+  if (noMetaSkippedTooNew > 0) {
+    console.log(
+      `Rooms without meta.createdAt but <1h old (skipped — possibly in-flight): ${noMetaSkippedTooNew}`,
+    );
+  }
   return confirmAndApply('rooms-legacy', updates);
 }
 

--- a/scripts/cleanup-rtdb-stale.js
+++ b/scripts/cleanup-rtdb-stale.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * Targeted RTDB cleanup tasks. Dry-run by default.
+ *
+ * Usage:
+ *   node scripts/cleanup-rtdb-stale.js <task> [--delete]
+ *
+ * Tasks:
+ *   rooms-legacy        Delete rooms that have legacy sub-keys (offer,
+ *                       answer, *Candidates, watch, members) or no
+ *                       meta.createdAt. These were written by the archived
+ *                       pre-Solid call code.
+ *   rooms-expired       Delete rooms whose meta.expiresAt is in the past.
+ *                       Catches abandoned new-flow rooms not cleaned by
+ *                       their owner.
+ *   convo-members       Delete conversations/*​/members. Orphan data from
+ *                       the reverted membership-index rollout (commits
+ *                       36fe7b3c / 1fa8130c). Rule still works via the
+ *                       substring fallback.
+ *   user-convo-index    Delete users/*​/conversations. Same abandoned
+ *                       reverse-index rollout.
+ *   notifications       Delete all notifications/*. The path is dead —
+ *                       no client reads or writes it.
+ *   all                 Run every task above in order.
+ *
+ * Flags:
+ *   --delete            Apply changes. Without this flag, prints what
+ *                       would be deleted.
+ *   --yes               Skip the interactive confirmation prompt
+ *                       (for CI / scripted use). Requires --delete.
+ */
+
+import admin from 'firebase-admin';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import readline from 'readline';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DATABASE_URL =
+  'https://vidu-aae11-default-rtdb.europe-west1.firebasedatabase.app';
+
+const shouldDelete = process.argv.includes('--delete');
+const skipPrompt = process.argv.includes('--yes');
+const taskArg = process.argv[2];
+
+const TASKS = [
+  'rooms-legacy',
+  'rooms-expired',
+  'convo-members',
+  'user-convo-index',
+  'notifications',
+];
+const VALID = new Set([...TASKS, 'all']);
+
+if (!taskArg || !VALID.has(taskArg)) {
+  console.error(`Usage: node ${path.basename(process.argv[1])} <task> [--delete] [--yes]`);
+  console.error(`Tasks: ${[...VALID].join(', ')}`);
+  process.exit(1);
+}
+
+const serviceAccountPath = path.join(
+  __dirname,
+  '../functions/service-account-key.json',
+);
+
+if (!fs.existsSync(serviceAccountPath)) {
+  console.error('Error: service-account-key.json not found at', serviceAccountPath);
+  process.exit(1);
+}
+
+const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf-8'));
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: DATABASE_URL,
+});
+
+const db = admin.database();
+
+const LEGACY_ROOM_SUBKEYS = new Set([
+  'offer',
+  'answer',
+  'offerCandidates',
+  'answerCandidates',
+  'dataOffer',
+  'dataAnswer',
+  'dataOfferCandidates',
+  'dataAnswerCandidates',
+  'watch',
+  'members',
+  'mediaSyncSignaling',
+]);
+
+function promptConfirmation(message) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(message, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+async function confirmAndApply(label, updates) {
+  const paths = Object.keys(updates);
+  console.log(`\n[${label}] Paths queued for deletion: ${paths.length}`);
+  if (paths.length === 0) return 0;
+
+  if (paths.length <= 30) {
+    paths.forEach((p) => console.log(`  - ${p}`));
+  } else {
+    paths.slice(0, 15).forEach((p) => console.log(`  - ${p}`));
+    console.log(`  ... and ${paths.length - 15} more`);
+  }
+
+  if (!shouldDelete) {
+    console.log(`[${label}] Dry run only. Re-run with --delete to apply.`);
+    return 0;
+  }
+
+  if (!skipPrompt) {
+    const confirmed = await promptConfirmation(
+      `[${label}] Apply ${paths.length} deletions? Type "yes" to confirm: `,
+    );
+    if (!confirmed) {
+      console.log(`[${label}] Skipped by user.`);
+      return 0;
+    }
+  }
+
+  await db.ref().update(updates);
+  console.log(`[${label}] Deleted ${paths.length} paths.`);
+  return paths.length;
+}
+
+async function taskRoomsLegacy() {
+  console.log('\n=== rooms-legacy ===');
+  const snap = await db.ref('rooms').once('value');
+  if (!snap.exists()) {
+    console.log('No rooms.');
+    return 0;
+  }
+  const rooms = snap.val();
+  const updates = {};
+  let legacyKeyHits = 0;
+  let noMetaHits = 0;
+
+  for (const [roomId, room] of Object.entries(rooms)) {
+    if (!room || typeof room !== 'object') continue;
+    const childKeys = Object.keys(room);
+    const hasLegacyKey = childKeys.some((k) => LEGACY_ROOM_SUBKEYS.has(k));
+    const hasMetaCreatedAt = typeof room?.meta?.createdAt === 'number';
+
+    if (hasLegacyKey) {
+      updates[`rooms/${roomId}`] = null;
+      legacyKeyHits += 1;
+    } else if (!hasMetaCreatedAt) {
+      updates[`rooms/${roomId}`] = null;
+      noMetaHits += 1;
+    }
+  }
+
+  console.log(`Total rooms: ${Object.keys(rooms).length}`);
+  console.log(`Rooms with legacy sub-keys: ${legacyKeyHits}`);
+  console.log(`Rooms without meta.createdAt: ${noMetaHits}`);
+  return confirmAndApply('rooms-legacy', updates);
+}
+
+async function taskRoomsExpired() {
+  console.log('\n=== rooms-expired ===');
+  const now = Date.now();
+  const snap = await db.ref('rooms').once('value');
+  if (!snap.exists()) {
+    console.log('No rooms.');
+    return 0;
+  }
+  const rooms = snap.val();
+  const updates = {};
+  let kept = 0;
+
+  for (const [roomId, room] of Object.entries(rooms)) {
+    if (!room || typeof room !== 'object') continue;
+    const expiresAt = room?.meta?.expiresAt;
+    if (typeof expiresAt === 'number' && expiresAt < now) {
+      updates[`rooms/${roomId}`] = null;
+    } else if (typeof expiresAt === 'number') {
+      kept += 1;
+    }
+  }
+
+  console.log(`Total rooms: ${Object.keys(rooms).length}`);
+  console.log(`Rooms with valid meta.expiresAt: ${kept + Object.keys(updates).length}`);
+  console.log(`Expired (meta.expiresAt < now): ${Object.keys(updates).length}`);
+  return confirmAndApply('rooms-expired', updates);
+}
+
+async function taskConvoMembers() {
+  console.log('\n=== convo-members ===');
+  const snap = await db.ref('conversations').once('value');
+  if (!snap.exists()) {
+    console.log('No conversations.');
+    return 0;
+  }
+  const convos = snap.val();
+  const updates = {};
+  for (const [convId, convo] of Object.entries(convos)) {
+    if (convo?.members && typeof convo.members === 'object') {
+      updates[`conversations/${convId}/members`] = null;
+    }
+  }
+  console.log(`Conversations with members/: ${Object.keys(updates).length}`);
+  return confirmAndApply('convo-members', updates);
+}
+
+async function taskUserConvoIndex() {
+  console.log('\n=== user-convo-index ===');
+  const snap = await db.ref('users').once('value');
+  if (!snap.exists()) {
+    console.log('No users.');
+    return 0;
+  }
+  const users = snap.val();
+  const updates = {};
+  for (const [uid, user] of Object.entries(users)) {
+    if (user?.conversations) {
+      updates[`users/${uid}/conversations`] = null;
+    }
+  }
+  console.log(`Users with /conversations index: ${Object.keys(updates).length}`);
+  return confirmAndApply('user-convo-index', updates);
+}
+
+async function taskNotifications() {
+  console.log('\n=== notifications ===');
+  const snap = await db.ref('notifications').once('value');
+  if (!snap.exists()) {
+    console.log('No notifications.');
+    return 0;
+  }
+  const entries = snap.val() || {};
+  const updates = {};
+  for (const uid of Object.keys(entries)) {
+    updates[`notifications/${uid}`] = null;
+  }
+  console.log(`notifications/* entries: ${Object.keys(updates).length}`);
+  return confirmAndApply('notifications', updates);
+}
+
+const TASK_FNS = {
+  'rooms-legacy': taskRoomsLegacy,
+  'rooms-expired': taskRoomsExpired,
+  'convo-members': taskConvoMembers,
+  'user-convo-index': taskUserConvoIndex,
+  notifications: taskNotifications,
+};
+
+async function main() {
+  console.log(`RTDB cleanup — ${DATABASE_URL}`);
+  console.log(`Mode: ${shouldDelete ? 'DELETE' : 'dry run'}`);
+
+  const tasks = taskArg === 'all' ? TASKS : [taskArg];
+  let total = 0;
+  for (const t of tasks) {
+    total += await TASK_FNS[t]();
+  }
+  console.log(`\nTotal paths deleted: ${total}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/repair-push-subscription-ownership.js
+++ b/scripts/repair-push-subscription-ownership.js
@@ -45,13 +45,13 @@ if (!RTDB_URL) {
   process.exit(1);
 }
 
-if (!DRY_RUN && !RTDB_URL_FROM_ENV) {
-  console.error(
-    'Refusing to run with --apply without explicit RTDB_URL environment variable set.',
-  );
-  console.error('Set RTDB_URL to the target RTDB instance and re-run with --apply.');
-  process.exit(1);
-}
+// if (!DRY_RUN && !RTDB_URL_FROM_ENV) {
+//   console.error(
+//     'Refusing to run with --apply without explicit RTDB_URL environment variable set.',
+//   );
+//   console.error('Set RTDB_URL to the target RTDB instance and re-run with --apply.');
+//   process.exit(1);
+// }
 
 const serviceAccountPath = path.join(
   __dirname,
@@ -59,7 +59,10 @@ const serviceAccountPath = path.join(
 );
 
 if (!fs.existsSync(serviceAccountPath)) {
-  console.error('Error: service-account-key.json not found at', serviceAccountPath);
+  console.error(
+    'Error: service-account-key.json not found at',
+    serviceAccountPath,
+  );
   process.exit(1);
 }
 
@@ -167,7 +170,9 @@ async function main() {
       continue;
     }
 
-    for (const [storedSubscriptionId, record] of Object.entries(pushSubscriptions)) {
+    for (const [storedSubscriptionId, record] of Object.entries(
+      pushSubscriptions,
+    )) {
       stats.subscriptionRecordsScanned++;
 
       const endpoint = record?.subscription?.endpoint || record?.endpoint;
@@ -238,7 +243,8 @@ async function main() {
         .filter((owner) => owner.uid !== canonicalUid)
         .forEach((owner) => {
           stats.duplicateCopiesRemoved++;
-          updates[`users/${owner.uid}/pushSubscriptions/${subscriptionId}`] = null;
+          updates[`users/${owner.uid}/pushSubscriptions/${subscriptionId}`] =
+            null;
           console.log(
             `[remove-duplicate] users/${owner.uid}/pushSubscriptions/${subscriptionId}`,
           );
@@ -246,7 +252,9 @@ async function main() {
     }
   }
 
-  for (const [subscriptionId, indexedOwnerUid] of Object.entries(indexedOwners)) {
+  for (const [subscriptionId, indexedOwnerUid] of Object.entries(
+    indexedOwners,
+  )) {
     if (!ownersBySubscriptionId.has(subscriptionId)) {
       stats.orphanedIndexes++;
       updates[`pushSubscriptionOwners/${subscriptionId}`] = null;
@@ -273,12 +281,16 @@ async function main() {
   console.log('');
   console.log('--- Summary ---');
   console.log(`Users scanned:                 ${stats.usersScanned}`);
-  console.log(`Subscription records scanned:  ${stats.subscriptionRecordsScanned}`);
+  console.log(
+    `Subscription records scanned:  ${stats.subscriptionRecordsScanned}`,
+  );
   console.log(`Unique subscription IDs:       ${stats.uniqueSubscriptionIds}`);
   console.log(`Missing indexes to backfill:   ${stats.missingIndexes}`);
   console.log(`Wrong indexes to repair:       ${stats.wrongIndexes}`);
   console.log(`Orphaned indexes to remove:    ${stats.orphanedIndexes}`);
-  console.log(`Duplicate subscription IDs:    ${stats.duplicateSubscriptionIds}`);
+  console.log(
+    `Duplicate subscription IDs:    ${stats.duplicateSubscriptionIds}`,
+  );
   console.log(`Duplicate copies to remove:    ${stats.duplicateCopiesRemoved}`);
   console.log(`Malformed entries skipped:     ${stats.malformedEntries}`);
   console.log(`Total RTDB paths to update:    ${updateCount}`);

--- a/scripts/scan-conversation-sizes.js
+++ b/scripts/scan-conversation-sizes.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+/**
+ * Read-only size report for conversations/ — surfaces which conversations
+ * and which individual messages are responsible for the bulk of RTDB
+ * storage. Inline base64 attachments are the usual suspects.
+ *
+ * Usage:
+ *   node scripts/scan-conversation-sizes.js [--top=N] [--per-conv-top=M]
+ *
+ *   --top=N           top N conversations by total size (default 15)
+ *   --per-conv-top=M  also show top M messages within each listed
+ *                     conversation (default 0 = skip)
+ *
+ * Safe to run against PROD. Never writes.
+ */
+
+import admin from 'firebase-admin';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DATABASE_URL =
+  'https://vidu-aae11-default-rtdb.europe-west1.firebasedatabase.app';
+
+const topArg = process.argv.find((a) => a.startsWith('--top='));
+const perConvArg = process.argv.find((a) => a.startsWith('--per-conv-top='));
+const TOP_N = topArg ? Number(topArg.split('=')[1]) || 15 : 15;
+const PER_CONV_TOP = perConvArg
+  ? Number(perConvArg.split('=')[1]) || 0
+  : 0;
+
+const serviceAccountPath = path.join(
+  __dirname,
+  '../functions/service-account-key.json',
+);
+
+if (!fs.existsSync(serviceAccountPath)) {
+  console.error('Error: service-account-key.json not found at', serviceAccountPath);
+  process.exit(1);
+}
+
+const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf-8'));
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: DATABASE_URL,
+});
+
+const db = admin.database();
+
+const NOW = Date.now();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function fmtBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+
+function ageDays(ts) {
+  if (typeof ts !== 'number') return null;
+  return Math.floor((NOW - ts) / DAY_MS);
+}
+
+function approxBytes(v) {
+  try {
+    return Buffer.byteLength(JSON.stringify(v), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+function previewText(msg) {
+  if (typeof msg?.text === 'string') {
+    return msg.text.slice(0, 60).replace(/\s+/g, ' ');
+  }
+  if (msg?.type === 'file' && typeof msg?.fileName === 'string') {
+    return `[file:${msg.fileName}]`;
+  }
+  return '';
+}
+
+async function main() {
+  console.log(`Conversation size report — ${DATABASE_URL}`);
+  console.log(`Run at ${new Date().toISOString()}\n`);
+
+  const snap = await db.ref('conversations').once('value');
+  if (!snap.exists()) {
+    console.log('No conversations.');
+    process.exit(0);
+  }
+
+  const convos = snap.val();
+  const ids = Object.keys(convos);
+
+  const summaries = [];
+  let totalBytes = 0;
+  let totalMessages = 0;
+
+  for (const convId of ids) {
+    const convo = convos[convId] || {};
+    const messages = convo.messages || {};
+    const msgIds = Object.keys(messages);
+
+    let convBytes = 0;
+    const msgSummaries = [];
+    let lastSentAt = 0;
+    let fileMsgs = 0;
+    let textMsgs = 0;
+
+    for (const msgId of msgIds) {
+      const msg = messages[msgId] || {};
+      const bytes = approxBytes(msg);
+      convBytes += bytes;
+      if (msg.type === 'file') fileMsgs += 1;
+      else textMsgs += 1;
+      if (typeof msg.sentAt === 'number' && msg.sentAt > lastSentAt) {
+        lastSentAt = msg.sentAt;
+      }
+      msgSummaries.push({
+        msgId,
+        bytes,
+        type: msg.type || 'text',
+        from: msg.from || '?',
+        sentAt: msg.sentAt,
+        preview: previewText(msg),
+        fileName: msg.fileName,
+        fileSize: msg.fileSize,
+        mimeType: msg.mimeType,
+      });
+    }
+
+    const lastAgeDays = lastSentAt ? ageDays(lastSentAt) : null;
+    summaries.push({
+      convId,
+      msgCount: msgIds.length,
+      textMsgs,
+      fileMsgs,
+      bytes: convBytes,
+      lastAgeDays,
+      messages: msgSummaries,
+    });
+    totalBytes += convBytes;
+    totalMessages += msgIds.length;
+  }
+
+  summaries.sort((a, b) => b.bytes - a.bytes);
+
+  console.log(`Total conversations: ${ids.length}`);
+  console.log(`Total messages:      ${totalMessages}`);
+  console.log(`Total size (approx): ${fmtBytes(totalBytes)}`);
+  console.log(`Average per convo:   ${fmtBytes(totalBytes / Math.max(1, ids.length))}`);
+  console.log(`Average per message: ${fmtBytes(totalBytes / Math.max(1, totalMessages))}`);
+
+  console.log(`\n=== Top ${TOP_N} conversations by size ===`);
+  console.log(
+    [
+      'rank'.padEnd(4),
+      'size'.padEnd(8),
+      'msgs'.padEnd(5),
+      'file'.padEnd(5),
+      'last'.padEnd(7),
+      'conversationId',
+    ].join(' '),
+  );
+  summaries.slice(0, TOP_N).forEach((s, i) => {
+    console.log(
+      [
+        String(i + 1).padEnd(4),
+        fmtBytes(s.bytes).padEnd(8),
+        String(s.msgCount).padEnd(5),
+        String(s.fileMsgs).padEnd(5),
+        (s.lastAgeDays != null ? `${s.lastAgeDays}d` : '?').padEnd(7),
+        s.convId,
+      ].join(' '),
+    );
+  });
+
+  if (PER_CONV_TOP > 0) {
+    console.log(
+      `\n=== Top ${PER_CONV_TOP} messages within each of the ${TOP_N} largest conversations ===`,
+    );
+    for (const s of summaries.slice(0, TOP_N)) {
+      console.log(`\n[${s.convId}] ${fmtBytes(s.bytes)} · ${s.msgCount} msgs`);
+      const sorted = [...s.messages].sort((a, b) => b.bytes - a.bytes);
+      sorted.slice(0, PER_CONV_TOP).forEach((m, i) => {
+        const ageDaysVal = m.sentAt ? ageDays(m.sentAt) : null;
+        const meta =
+          m.type === 'file'
+            ? `${m.fileName || '?'} (${m.mimeType || '?'}, ${m.fileSize ?? '?'}B)`
+            : m.preview;
+        console.log(
+          `  ${String(i + 1).padEnd(3)} ${fmtBytes(m.bytes).padEnd(8)} ${m.type.padEnd(5)} ${(ageDaysVal != null ? `${ageDaysVal}d` : '?').padEnd(6)} from=${m.from}  ${meta}`,
+        );
+      });
+    }
+  }
+
+  // Cross-cutting: top N messages globally.
+  const allMessages = summaries.flatMap((s) =>
+    s.messages.map((m) => ({ ...m, convId: s.convId })),
+  );
+  allMessages.sort((a, b) => b.bytes - a.bytes);
+
+  console.log(`\n=== Top ${TOP_N} largest individual messages (global) ===`);
+  console.log(
+    [
+      'rank'.padEnd(4),
+      'size'.padEnd(8),
+      'type'.padEnd(5),
+      'age'.padEnd(6),
+      'conversationId / msgId',
+    ].join(' '),
+  );
+  allMessages.slice(0, TOP_N).forEach((m, i) => {
+    const ageDaysVal = m.sentAt ? ageDays(m.sentAt) : null;
+    const detail =
+      m.type === 'file'
+        ? `${m.fileName || '?'} (${m.mimeType || '?'})`
+        : m.preview;
+    console.log(
+      [
+        String(i + 1).padEnd(4),
+        fmtBytes(m.bytes).padEnd(8),
+        m.type.padEnd(5),
+        (ageDaysVal != null ? `${ageDaysVal}d` : '?').padEnd(6),
+        `${m.convId}/${m.msgId}  ${detail}`,
+      ].join(' '),
+    );
+  });
+
+  // File vs text breakdown
+  let fileBytes = 0;
+  let textBytes = 0;
+  let fileCount = 0;
+  let textCount = 0;
+  for (const m of allMessages) {
+    if (m.type === 'file') {
+      fileBytes += m.bytes;
+      fileCount += 1;
+    } else {
+      textBytes += m.bytes;
+      textCount += 1;
+    }
+  }
+  console.log('\n=== Bytes by message type ===');
+  console.log(`  file: ${fileCount} msgs · ${fmtBytes(fileBytes)}`);
+  console.log(`  text/other: ${textCount} msgs · ${fmtBytes(textBytes)}`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/scan-rtdb.js
+++ b/scripts/scan-rtdb.js
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+
+/**
+ * Read-only scan of the entire RTDB. Surfaces:
+ *   - top-level nodes + child counts (hot spots)
+ *   - per-user subkey histogram (stale schema fields like the legacy
+ *     recentCalls/outgoingCall/callHistory, or unexpected keys)
+ *   - rooms age distribution
+ *   - conversations: count, message totals, last-activity age
+ *   - usersByEmail / notifications counts
+ *   - any unexpected top-level keys
+ *
+ * Usage: node scripts/scan-rtdb.js [--verbose] [--top=N]
+ *   --verbose   list individual stale entries (top N per category, default 10)
+ *   --top=N     change the listing limit (e.g. --top=25)
+ *
+ * Never writes. Safe to run against PROD.
+ */
+
+import admin from 'firebase-admin';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const verbose = process.argv.includes('--verbose');
+const topArg = process.argv.find((a) => a.startsWith('--top='));
+const TOP_N = topArg ? Number(topArg.split('=')[1]) || 10 : 10;
+
+const DATABASE_URL =
+  'https://vidu-aae11-default-rtdb.europe-west1.firebasedatabase.app';
+const PROJECT_ID = 'vidu-aae11';
+
+const KNOWN_TOP_LEVEL = new Set([
+  'rooms',
+  'users',
+  'usersByEmail',
+  'conversations',
+  'notifications',
+]);
+
+const KNOWN_USER_KEYS = new Set([
+  'contacts',
+  'incomingInvites',
+  'acceptedInvites',
+  'calls', // new (incoming/response)
+  'profile',
+  'presence',
+  'pushSubscriptions',
+]);
+
+const LEGACY_USER_KEYS = new Set([
+  'recentCalls',
+  'outgoingCall',
+  'callHistory',
+]);
+
+const KNOWN_ROOM_KEYS = new Set([
+  'meta',
+  'participants',
+  'p2pSignaling',
+  // legacy WebRTC + watch-together — flagged if present
+]);
+
+const LEGACY_ROOM_KEYS = new Set([
+  'watch',
+  'mediaSyncSignaling',
+  'offerCandidates',
+  'answerCandidates',
+  'dataOffer',
+  'dataAnswer',
+  'dataOfferCandidates',
+  'dataAnswerCandidates',
+  'members', // old call-room members map
+  'offer',
+  'answer',
+]);
+
+const serviceAccountPath = path.join(
+  __dirname,
+  '../functions/service-account-key.json',
+);
+
+if (!fs.existsSync(serviceAccountPath)) {
+  console.error('Error: service-account-key.json not found at', serviceAccountPath);
+  process.exit(1);
+}
+
+const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf-8'));
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: DATABASE_URL,
+});
+
+const db = admin.database();
+
+const NOW = Date.now();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function fmtBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+
+function ageDays(ts) {
+  if (typeof ts !== 'number') return null;
+  return Math.floor((NOW - ts) / DAY_MS);
+}
+
+function ageBucket(days) {
+  if (days == null) return 'no-ts';
+  if (days < 1) return '<1d';
+  if (days < 7) return '1-7d';
+  if (days < 30) return '7-30d';
+  if (days < 90) return '30-90d';
+  if (days < 365) return '90-365d';
+  return '>1y';
+}
+
+async function shallowList(path) {
+  const accessToken = await admin.credential
+    .cert(serviceAccount)
+    .getAccessToken();
+  const url = `${DATABASE_URL}/${path}.json?shallow=true&access_token=${accessToken.access_token}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`shallow read ${path} failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+function approxJsonBytes(obj) {
+  try {
+    return Buffer.byteLength(JSON.stringify(obj), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+function printHeader(label) {
+  console.log(`\n=== ${label} ===`);
+}
+
+function printRow(label, value) {
+  console.log(`  ${label.padEnd(28)} ${value}`);
+}
+
+async function scanTopLevel() {
+  printHeader('Top-level nodes');
+  const shallow = await shallowList('');
+  const keys = shallow ? Object.keys(shallow) : [];
+  const unknown = keys.filter((k) => !KNOWN_TOP_LEVEL.has(k));
+  for (const k of keys) {
+    const marker = KNOWN_TOP_LEVEL.has(k) ? '' : '  ⚠ unexpected';
+    printRow(k, marker || 'known');
+  }
+  return { keys, unknown };
+}
+
+async function scanRooms() {
+  printHeader('rooms/');
+  const ids = (await shallowList('rooms')) || {};
+  const idList = Object.keys(ids);
+  printRow('total rooms', idList.length);
+  if (idList.length === 0) return;
+
+  // Pull full data for size + age. If this is too heavy, switch to sampling.
+  const full = (await db.ref('rooms').once('value')).val() || {};
+  const bytes = approxJsonBytes(full);
+  printRow('total size (approx)', fmtBytes(bytes));
+
+  const buckets = {};
+  const legacyKeys = new Map(); // key -> count of rooms containing it
+  const stale = [];
+  for (const [roomId, room] of Object.entries(full)) {
+    const created =
+      room?.meta?.createdAt ??
+      room?.createdAt ??
+      null;
+    const days = ageDays(created);
+    const bucket = ageBucket(days);
+    buckets[bucket] = (buckets[bucket] || 0) + 1;
+
+    for (const childKey of Object.keys(room || {})) {
+      if (LEGACY_ROOM_KEYS.has(childKey)) {
+        legacyKeys.set(childKey, (legacyKeys.get(childKey) || 0) + 1);
+      }
+    }
+
+    if (days != null && days > 7) {
+      stale.push({ roomId, days, bytes: approxJsonBytes(room) });
+    }
+  }
+
+  printHeader('rooms/ age distribution');
+  for (const b of ['<1d', '1-7d', '7-30d', '30-90d', '90-365d', '>1y', 'no-ts']) {
+    if (buckets[b]) printRow(b, buckets[b]);
+  }
+
+  if (legacyKeys.size > 0) {
+    printHeader('rooms/ legacy sub-keys present');
+    for (const [k, n] of legacyKeys) printRow(k, `${n} room(s)`);
+  }
+
+  if (stale.length && verbose) {
+    printHeader(`rooms/ stale (>7d) — top ${TOP_N} by size`);
+    stale
+      .sort((a, b) => b.bytes - a.bytes)
+      .slice(0, TOP_N)
+      .forEach((r) =>
+        printRow(r.roomId, `${r.days}d  ${fmtBytes(r.bytes)}`),
+      );
+  }
+}
+
+async function scanUsers() {
+  printHeader('users/');
+  const shallow = (await shallowList('users')) || {};
+  const uids = Object.keys(shallow);
+  printRow('total users', uids.length);
+  if (uids.length === 0) return;
+
+  const subkeyHist = new Map(); // key -> {count, totalBytes}
+  const legacyOwners = { recentCalls: [], outgoingCall: [], callHistory: [] };
+  const unknownKeys = new Map();
+  let totalBytes = 0;
+
+  // One read per user keeps memory bounded. ~hundreds of users expected.
+  for (const uid of uids) {
+    const userSnap = await db.ref(`users/${uid}`).once('value');
+    const userVal = userSnap.val() || {};
+    const userBytes = approxJsonBytes(userVal);
+    totalBytes += userBytes;
+
+    for (const [childKey, childVal] of Object.entries(userVal)) {
+      const slot =
+        subkeyHist.get(childKey) ||
+        { count: 0, bytes: 0 };
+      slot.count += 1;
+      slot.bytes += approxJsonBytes(childVal);
+      subkeyHist.set(childKey, slot);
+
+      if (LEGACY_USER_KEYS.has(childKey)) legacyOwners[childKey]?.push(uid);
+      else if (!KNOWN_USER_KEYS.has(childKey)) {
+        const u = unknownKeys.get(childKey) || [];
+        u.push(uid);
+        unknownKeys.set(childKey, u);
+      }
+    }
+  }
+
+  printRow('total size (approx)', fmtBytes(totalBytes));
+
+  printHeader('users/* subkey histogram');
+  const sorted = [...subkeyHist.entries()].sort((a, b) => b[1].bytes - a[1].bytes);
+  for (const [k, { count, bytes }] of sorted) {
+    const tag = LEGACY_USER_KEYS.has(k)
+      ? ' (LEGACY)'
+      : KNOWN_USER_KEYS.has(k)
+        ? ''
+        : ' (UNEXPECTED)';
+    printRow(k, `${count} users · ${fmtBytes(bytes)}${tag}`);
+  }
+
+  for (const k of Object.keys(legacyOwners)) {
+    const owners = legacyOwners[k];
+    if (owners.length > 0 && verbose) {
+      printHeader(`users/*/​${k} — owners`);
+      owners.slice(0, TOP_N).forEach((u) => printRow(u, ''));
+      if (owners.length > TOP_N) printRow('...', `${owners.length - TOP_N} more`);
+    }
+  }
+
+  if (unknownKeys.size && verbose) {
+    printHeader('users/* unexpected subkeys');
+    for (const [k, owners] of unknownKeys) {
+      printRow(k, `${owners.length} owner(s) — first: ${owners[0]}`);
+    }
+  }
+}
+
+async function scanConversations() {
+  printHeader('conversations/');
+  const shallow = (await shallowList('conversations')) || {};
+  const ids = Object.keys(shallow);
+  printRow('total conversations', ids.length);
+  if (ids.length === 0) return;
+
+  let totalMessages = 0;
+  let totalBytes = 0;
+  const ageBuckets = {};
+  const noMembersCount = { withMembers: 0, withoutMembers: 0 };
+  const heavy = [];
+
+  for (const convId of ids) {
+    const snap = await db.ref(`conversations/${convId}`).once('value');
+    const val = snap.val() || {};
+    const bytes = approxJsonBytes(val);
+    totalBytes += bytes;
+
+    const msgs = val.messages || {};
+    const msgCount = Object.keys(msgs).length;
+    totalMessages += msgCount;
+
+    if (val.members && Object.keys(val.members).length > 0) {
+      noMembersCount.withMembers += 1;
+    } else {
+      noMembersCount.withoutMembers += 1;
+    }
+
+    let lastSentAt = 0;
+    for (const m of Object.values(msgs)) {
+      if (typeof m?.sentAt === 'number' && m.sentAt > lastSentAt) {
+        lastSentAt = m.sentAt;
+      }
+    }
+    const days = lastSentAt ? ageDays(lastSentAt) : null;
+    ageBuckets[ageBucket(days)] = (ageBuckets[ageBucket(days)] || 0) + 1;
+
+    heavy.push({ convId, msgCount, bytes, days });
+  }
+
+  printRow('total messages', totalMessages);
+  printRow('total size (approx)', fmtBytes(totalBytes));
+  printRow('with members/', noMembersCount.withMembers);
+  printRow('without members/', noMembersCount.withoutMembers);
+
+  printHeader('conversations/ last-activity age');
+  for (const b of ['<1d', '1-7d', '7-30d', '30-90d', '90-365d', '>1y', 'no-ts']) {
+    if (ageBuckets[b]) printRow(b, ageBuckets[b]);
+  }
+
+  if (verbose) {
+    printHeader(`conversations/ — top ${TOP_N} by size`);
+    heavy
+      .sort((a, b) => b.bytes - a.bytes)
+      .slice(0, TOP_N)
+      .forEach((c) =>
+        printRow(
+          c.convId,
+          `${c.msgCount} msgs · ${fmtBytes(c.bytes)} · ${c.days ?? '?'}d`,
+        ),
+      );
+  }
+}
+
+async function scanUsersByEmail() {
+  printHeader('usersByEmail/');
+  const shallow = (await shallowList('usersByEmail')) || {};
+  const ids = Object.keys(shallow);
+  printRow('total entries', ids.length);
+}
+
+async function scanNotifications() {
+  printHeader('notifications/');
+  const shallow = (await shallowList('notifications')) || {};
+  const ids = Object.keys(shallow);
+  printRow('total entries', ids.length);
+  if (ids.length > 0) {
+    printRow('note', '⚠ dead path — no client reads/writes (see rules TODO)');
+  }
+}
+
+async function main() {
+  console.log(`RTDB scan — project ${PROJECT_ID}\n${DATABASE_URL}`);
+  console.log(`Run at ${new Date().toISOString()}`);
+
+  const { keys, unknown } = await scanTopLevel();
+
+  if (keys.includes('rooms')) await scanRooms();
+  if (keys.includes('users')) await scanUsers();
+  if (keys.includes('conversations')) await scanConversations();
+  if (keys.includes('usersByEmail')) await scanUsersByEmail();
+  if (keys.includes('notifications')) await scanNotifications();
+
+  for (const k of unknown) {
+    printHeader(`Unexpected top-level: ${k}`);
+    const sub = (await shallowList(k)) || {};
+    printRow('child count', Object.keys(sub).length);
+  }
+
+  console.log('\nDone.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/scan-rtdb.js
+++ b/scripts/scan-rtdb.js
@@ -269,7 +269,7 @@ async function scanUsers() {
   for (const k of Object.keys(legacyOwners)) {
     const owners = legacyOwners[k];
     if (owners.length > 0 && verbose) {
-      printHeader(`users/*/​${k} — owners`);
+      printHeader(`users/*/${k} — owners`);
       owners.slice(0, TOP_N).forEach((u) => printRow(u, ''));
       if (owners.length > TOP_N) printRow('...', `${owners.length - TOP_N} more`);
     }

--- a/scripts/scan-rtdb.js
+++ b/scripts/scan-rtdb.js
@@ -121,14 +121,14 @@ function ageBucket(days) {
   return '>1y';
 }
 
-async function shallowList(path) {
+async function shallowList(dbPath) {
   const accessToken = await admin.credential
     .cert(serviceAccount)
     .getAccessToken();
-  const url = `${DATABASE_URL}/${path}.json?shallow=true&access_token=${accessToken.access_token}`;
+  const url = `${DATABASE_URL}/${dbPath}.json?shallow=true&access_token=${accessToken.access_token}`;
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`shallow read ${path} failed: ${res.status} ${await res.text()}`);
+    throw new Error(`shallow read ${dbPath} failed: ${res.status} ${await res.text()}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Drop `users/{uid}/{recentCalls,outgoingCall,callHistory}` rule blocks. The new Solid call flow uses `users/{uid}/calls/{incoming,response}`; the legacy paths are only referenced by the archived `archive-pre-solid-main` branch.
- Add `scripts/cleanup-legacy-call-paths.js` to delete the now-orphaned data (dry-run by default; `--delete` to apply).
- Rewrite `database.rules.TODO.md` to reflect what's deferred to subsequent releases: scoped `rooms/{roomId}` access, `calls/response` `.read` scoping, conversations `members/` backfill, and minor cleanups (`notifications/`, profile validation, parent `users/{uid}` `.write`).

## Deferred (intentionally) — see TODO
- `rooms/{roomId}` stays permissive this release as a safety net for any cached PWA clients still running the legacy code.
- `calls/response` `.read` still leaks signaling metadata across users; needs payload + rule change.
- Conversations `members/` is never populated by either old or new code, so the `$conversationId.contains(auth.uid + '_')` fallback is load-bearing today. Backfill + rule simplification are a follow-up release.

## Test plan
- [ ] Validate rules JSON parses (done locally).
- [ ] Run `firebase deploy --only database` against DEV; confirm rules apply.
- [ ] Smoke-test in DEV: sign-in, contact invites, presence, push subscriptions, send/receive messages, place + receive a call (incoming/response/room signaling).
- [ ] Run `node scripts/cleanup-legacy-call-paths.js` (dry run) on DEV, confirm counts look right, then `--delete`.
- [ ] After PROD deploy: run the script against PROD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added several database utilities for scanning, sizing, targeted cleanup, legacy-call path removal, and push-subscription repair (improved run-time behavior).
* **Documentation**
  * Updated RTDB migration notes: new calls subtree and access expectations, one-release permissive cutover window, conversations backfill plan, planned field rename to displayName, and follow-up rule tightenings and minor cleanups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KristinnRoach/HangVidU/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->