### PR TITLE
Fix realtime messaging read state

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -68,11 +68,11 @@
         ".read": "auth != null && (data.child('members').child(auth.uid).exists() || $conversationId.contains(auth.uid + '_') || $conversationId.contains('_' + auth.uid))",
         "members": {
           "$uid": {
-            ".write": "auth != null && !data.exists() && newData.val() === true && (($conversationId.contains(auth.uid + '_') || $conversationId.contains('_' + auth.uid)) && ($conversationId.contains($uid + '_') || $conversationId.contains('_' + $uid)))"
+            ".write": "auth != null && $uid === auth.uid && (data.exists() || $conversationId.contains(auth.uid + '_') || $conversationId.contains('_' + auth.uid))"
           }
         },
         "messages": {
-          ".indexOn": ["from"],
+          ".indexOn": ["from", "sentAt"],
           "$messageId": {
             ".write": "auth != null && (root.child('conversations').child($conversationId).child('members').child(auth.uid).exists() || $conversationId.contains(auth.uid + '_') || $conversationId.contains('_' + auth.uid))"
           }

--- a/scripts/backfill-conversation-last-read-at.js
+++ b/scripts/backfill-conversation-last-read-at.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill conversations/{conversationId}/members/{userId}/lastReadAt from
+ * existing saved contacts.
+ *
+ * Dry-run by default.
+ *
+ * Usage:
+ *   node scripts/backfill-conversation-last-read-at.js
+ *   node scripts/backfill-conversation-last-read-at.js --write
+ *   node scripts/backfill-conversation-last-read-at.js --write --yes
+ *   node scripts/backfill-conversation-last-read-at.js --write --overwrite
+ *
+ * If a legacy conversation has no numeric message sentAt values, lastReadAt is
+ * backfilled as 0 so it is treated as already read without making it look recent.
+ */
+
+import admin from 'firebase-admin';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import readline from 'readline';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DATABASE_URL =
+  'https://vidu-aae11-default-rtdb.europe-west1.firebasedatabase.app';
+const BATCH_SIZE = 400;
+const PREVIEW_LIMIT = 30;
+
+const shouldWrite = process.argv.includes('--write');
+const skipPrompt = process.argv.includes('--yes');
+const overwriteExisting = process.argv.includes('--overwrite');
+
+const serviceAccountPath = path.join(
+  __dirname,
+  '../functions/service-account-key.json',
+);
+
+if (!fs.existsSync(serviceAccountPath)) {
+  console.error('Error: service-account-key.json not found at', serviceAccountPath);
+  process.exit(1);
+}
+
+const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf-8'));
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: DATABASE_URL,
+});
+
+const db = admin.database();
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function promptConfirmation(message) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(message, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+async function applyInBatches(updates) {
+  const entries = Object.entries(updates);
+  for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+    const batch = Object.fromEntries(entries.slice(i, i + BATCH_SIZE));
+    await db.ref().update(batch);
+    console.log(`Applied ${Math.min(i + BATCH_SIZE, entries.length)}/${entries.length}`);
+  }
+}
+
+const latestSentAtByConversation = new Map();
+
+async function getLatestSentAt(conversationId) {
+  if (latestSentAtByConversation.has(conversationId)) {
+    return latestSentAtByConversation.get(conversationId);
+  }
+
+  const snap = await db
+    .ref(`conversations/${conversationId}/messages`)
+    .orderByChild('sentAt')
+    .limitToLast(1)
+    .once('value');
+
+  let latestSentAt = null;
+  snap.forEach((child) => {
+    const sentAt = child.val()?.sentAt;
+    if (typeof sentAt === 'number') latestSentAt = sentAt;
+  });
+
+  latestSentAtByConversation.set(conversationId, latestSentAt);
+  return latestSentAt;
+}
+
+async function run() {
+  const usersSnap = await db.ref('users').once('value');
+  const users = usersSnap.val() || {};
+  const updates = {};
+
+  let userCount = 0;
+  let contactCount = 0;
+  let skippedNoConversation = 0;
+  let skippedExisting = 0;
+  let legacyNoTimestampedMessage = 0;
+
+  for (const [userId, user] of Object.entries(users)) {
+    if (!isObject(user)) continue;
+    userCount += 1;
+
+    const contacts = isObject(user.contacts) ? user.contacts : {};
+    for (const contact of Object.values(contacts)) {
+      if (!isObject(contact)) continue;
+      contactCount += 1;
+
+      const conversationId =
+        typeof contact.conversationId === 'string'
+          ? contact.conversationId.trim()
+          : '';
+      if (!conversationId) {
+        skippedNoConversation += 1;
+        continue;
+      }
+
+      const currentMember = await db
+        .ref(`conversations/${conversationId}/members/${userId}`)
+        .once('value');
+      const current = currentMember.val();
+      const hasExistingLastRead =
+        isObject(current) && typeof current.lastReadAt === 'number';
+
+      if (hasExistingLastRead && !overwriteExisting) {
+        skippedExisting += 1;
+        continue;
+      }
+
+      const latestSentAt = await getLatestSentAt(conversationId);
+      const lastReadAt = typeof latestSentAt === 'number' ? latestSentAt : 0;
+      if (lastReadAt === 0) legacyNoTimestampedMessage += 1;
+
+      updates[`conversations/${conversationId}/members/${userId}/lastReadAt`] =
+        lastReadAt;
+    }
+  }
+
+  const paths = Object.keys(updates);
+
+  console.log('\n=== conversation lastReadAt backfill ===\n');
+  console.log(`Mode: ${shouldWrite ? 'WRITE' : 'DRY RUN'}`);
+  console.log(`Users scanned: ${userCount}`);
+  console.log(`Contacts scanned: ${contactCount}`);
+  console.log(`Queued writes: ${paths.length}`);
+  console.log(`Skipped existing lastReadAt: ${skippedExisting}`);
+  console.log(`Skipped missing conversationId: ${skippedNoConversation}`);
+  console.log(`Legacy no timestamped messages: ${legacyNoTimestampedMessage}`);
+
+  if (paths.length > 0) {
+    console.log('\nPreview:');
+    paths.slice(0, PREVIEW_LIMIT).forEach((p) => console.log(`  - ${p}`));
+    if (paths.length > PREVIEW_LIMIT) {
+      console.log(`  ... and ${paths.length - PREVIEW_LIMIT} more`);
+    }
+  }
+
+  if (!shouldWrite) {
+    console.log('\nDry run only. Re-run with --write to apply.');
+    return;
+  }
+
+  if (paths.length === 0) return;
+
+  if (!skipPrompt) {
+    const confirmed = await promptConfirmation(
+      `Apply ${paths.length} lastReadAt writes? Type "yes" to confirm: `,
+    );
+    if (!confirmed) {
+      console.log('Skipped by user.');
+      return;
+    }
+  }
+
+  await applyInBatches(updates);
+  console.log('Backfill complete.');
+}
+
+run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await admin.app().delete();
+  });

--- a/src/features/contacts/components/ContactEntry.jsx
+++ b/src/features/contacts/components/ContactEntry.jsx
@@ -22,7 +22,7 @@ function shortName(name) {
  *   id: string
  *   name: string|null
  *   conversationId: string|null
- *   unreadCount: number
+ *   hasUnread: boolean
  */
 export default function ContactEntry(props) {
   const { t } = useI18n();
@@ -71,9 +71,9 @@ export default function ContactEntry(props) {
         {shortName(displayName())}
       </button>
 
-      <Show when={props.unreadCount > 0}>
+      <Show when={props.hasUnread}>
         <span class='unread-badge' aria-live='polite' aria-atomic='true'>
-          {props.unreadCount > 99 ? '99+' : props.unreadCount}
+          •
         </span>
       </Show>
 

--- a/src/features/contacts/components/ContactsList.tsx
+++ b/src/features/contacts/components/ContactsList.tsx
@@ -1,26 +1,11 @@
-import { For, Show, createEffect } from 'solid-js';
+import { For, Show } from 'solid-js';
 import { useI18n } from '../../../shared/i18n/index';
 import ContactEntry from './ContactEntry';
 import { useContacts } from '../useContacts';
-import {
-  open as openSelectedConversation,
-  selection as selectedConversation,
-} from '../../../stores/selectedConversationStore';
 
 export default function ContactsList() {
   const { t } = useI18n();
   const { contacts } = useContacts();
-
-  createEffect(() => {
-    if (selectedConversation()?.conversationId) return;
-    if (contacts.length === 0) return;
-    if (contacts[0].conversationId) {
-      openSelectedConversation({
-        conversationId: contacts[0].conversationId,
-        displayUI: false,
-      });
-    }
-  });
 
   return (
     <div class='contacts-container'>
@@ -32,7 +17,7 @@ export default function ContactsList() {
                 id={row.id}
                 name={row.name}
                 conversationId={row.conversationId}
-                unreadCount={row.unreadCount}
+                hasUnread={row.hasUnread}
               />
             )}
           </For>

--- a/src/features/contacts/useContacts.ts
+++ b/src/features/contacts/useContacts.ts
@@ -1,34 +1,33 @@
 import { createEffect, onCleanup, onMount } from 'solid-js';
 import { createStore, produce } from 'solid-js/store';
-import { subscribe } from '../../shared/events/index.js';
-import { getContactsStore } from '../../stores/contactsStore.js';
+import { getLoggedInUserId } from '../../auth/index.js';
+import {
+  getContactsStore,
+  recordInteractionByConversation,
+} from '../../stores/contactsStore.js';
+import { createMessagingRuntime } from '../messaging-next/messaging-runtime.js';
 
 type ContactRow = {
   id: string;
   name: string | null;
   conversationId: string | null;
-  unreadCount: number;
+  hasUnread: boolean;
 };
 
 export function useContacts() {
   const contactsState = getContactsStore();
   const [contacts, setContacts] = createStore<ContactRow[]>([]);
-  const [unread, setUnread] = createStore<Record<string, number>>({});
+  const [unread, setUnread] = createStore<Record<string, boolean>>({});
+  const runtime = createMessagingRuntime();
 
-  let offUnread: (() => void) | null = null;
+  const unreadWatchers = new Map<string, () => void>();
+
+  function stopUnreadWatchers() {
+    for (const unsubscribe of unreadWatchers.values()) unsubscribe();
+    unreadWatchers.clear();
+  }
 
   onMount(() => {
-    offUnread = subscribe(
-      'evt:messaging:conversation:unread-count-changed',
-      ({
-        conversationId,
-        unreadCount,
-      }: {
-        conversationId: string;
-        unreadCount: number;
-      }) => setUnread(conversationId, unreadCount),
-    ) as () => void;
-
     createEffect(() => {
       const rows: ContactRow[] = Object.values(contactsState.byId)
         .sort((a: any, b: any) => {
@@ -43,7 +42,9 @@ export function useContacts() {
           id: c.contactId ?? '',
           name: c.contactNickName ?? null,
           conversationId: c.conversationId ?? null,
-          unreadCount: c.conversationId ? (unread[c.conversationId] ?? 0) : 0,
+          hasUnread: c.conversationId
+            ? (unread[c.conversationId] ?? false)
+            : false,
         }));
 
       setContacts(
@@ -53,9 +54,65 @@ export function useContacts() {
         }),
       );
     });
+
+    createEffect(() => {
+      const userId = getLoggedInUserId();
+      const conversationIds = new Set(
+        contacts
+          .map((row) => row.conversationId)
+          .filter((id): id is string => Boolean(id)),
+      );
+
+      if (!userId) {
+        stopUnreadWatchers();
+        return;
+      }
+
+      for (const [conversationId, unsubscribe] of unreadWatchers) {
+        if (!conversationIds.has(conversationId)) {
+          unsubscribe();
+          unreadWatchers.delete(conversationId);
+        }
+      }
+
+      for (const conversationId of conversationIds) {
+        if (unreadWatchers.has(conversationId)) continue;
+
+        const result = runtime.messageRepository.watchHasUnread(
+          conversationId,
+          userId,
+          (hasUnread) => {
+            setUnread(conversationId, hasUnread);
+            if (hasUnread) {
+              void recordInteractionByConversation(conversationId);
+            }
+          },
+          (error) => {
+            console.warn('[contacts] unread watch failed', {
+              conversationId,
+              error,
+            });
+          },
+        );
+
+        if (typeof result === 'function') {
+          unreadWatchers.set(conversationId, result);
+        } else {
+          void result.then((unsubscribe) => {
+            if (conversationIds.has(conversationId)) {
+              unreadWatchers.set(conversationId, unsubscribe);
+            } else {
+              unsubscribe();
+            }
+          });
+        }
+      }
+    });
   });
 
-  onCleanup(() => offUnread?.());
+  onCleanup(() => {
+    stopUnreadWatchers();
+  });
 
   return { contacts };
 }

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -5,7 +5,6 @@ import {
   Switch,
   createEffect,
   createMemo,
-  createResource,
   createSignal,
   on,
   onCleanup,
@@ -20,13 +19,15 @@ import { createMessagingRuntime } from './messaging-runtime.js';
 
 import { createConversationState } from './conversation.state.js';
 import { createConversationActions } from './conversation.actions.js';
-import {
-  loadConversationHistory,
-  useConversation,
-} from './use-conversation.js';
+import { envelopeToChatMessage, useConversation } from './use-conversation.js';
+import { sortMessagesBySentAt } from './message-ordering.js';
 import { clearLocalDraft, saveLocalDraft } from './local-drafts.js';
 import type { ConversationId, UserId } from './types.js';
-import type { ConversationSelection, MessageAttachment } from './interfaces.js';
+import type {
+  ChatMessage,
+  ConversationSelection,
+  MessageAttachment,
+} from './interfaces.js';
 
 import styles from './ConversationPanel.module.css';
 
@@ -82,6 +83,10 @@ function MessageHistorySkeleton() {
       <div class={`${styles.skeletonBubble} ${styles.skeletonOwn}`} />
     </div>
   );
+}
+
+function isChatMessage(message: ChatMessage | null): message is ChatMessage {
+  return Boolean(message);
 }
 
 type ConversationPanelProps = {
@@ -158,16 +163,10 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       };
     },
     null,
-    {
-      equals: (a, b) =>
-        a?.conversationId === b?.conversationId && a?.myUserId === b?.myUserId,
-    },
   );
 
-  const [history] = createResource(historySource, ({ conversationId }) =>
-    loadConversationHistory(runtime.messageRepository, conversationId),
-  );
-
+  const [historyLoading, setHistoryLoading] = createSignal(false);
+  const [historyError, setHistoryError] = createSignal<unknown>(null);
   const [historyReady, setHistoryReady] = createSignal(false);
 
   createEffect(
@@ -192,26 +191,67 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         if (!source || !selection) {
           actions.resetConversation();
           suppressScroll = false;
+          setHistoryLoading(false);
+          setHistoryError(null);
           return;
         }
 
         actions.startConversation(selection, source.myUserId);
+
+        setHistoryLoading(true);
+        setHistoryError(null);
+
+        const result = runtime.messageRepository.watchRecentMessages(
+          source.conversationId,
+          (messages) => {
+            if (source.conversationId !== state.conversationId) return;
+
+            const latestMessageId = messages.at(-1)?.messageId;
+            const loadedMessages = sortMessagesBySentAt(
+              messages
+                .map((msg) => envelopeToChatMessage(msg, 'persisted'))
+                .filter(isChatMessage),
+            );
+            actions.mergeLoadedMessages(loadedMessages);
+            setHistoryReady(true);
+            setHistoryLoading(false);
+            suppressScroll = false;
+            queueMicrotask(scrollToEnd);
+            queueMicrotask(focusInput);
+            if (latestMessageId) {
+              void runtime.messageRepository.markConversationRead(
+                source.conversationId,
+                source.myUserId,
+              );
+            }
+          },
+          (error) => {
+            if (source.conversationId !== state.conversationId) return;
+            setHistoryError(error);
+            setHistoryLoading(false);
+            suppressScroll = false;
+          },
+        );
+
+        let cleanup: (() => void) | undefined;
+        let disposed = false;
+
+        if (typeof result === 'function') {
+          cleanup = result;
+        } else {
+          void result.then((unsub) => {
+            if (disposed) unsub();
+            else cleanup = unsub;
+          });
+        }
+
+        onCleanup(() => {
+          disposed = true;
+          cleanup?.();
+        });
       },
     ),
   );
-
-  createEffect(() => {
-    const source = historySource();
-    const loadedMessages = history();
-    if (!source || history.loading || history.error || !loadedMessages) return;
-    if (source.conversationId !== state.conversationId) return;
-
-    actions.mergeLoadedMessages(loadedMessages);
-    setHistoryReady(true);
-    suppressScroll = false;
-    queueMicrotask(scrollToEnd);
-    queueMicrotask(focusInput); // Not needed with autofocus attribute?
-  });
 
   const { send } = useConversation({
     repository: runtime.messageRepository,
@@ -243,9 +283,9 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         fallback={<div class={styles.empty}>Conversation not found</div>}
       >
         <LoadBoundary
-          loading={history.loading}
+          loading={historyLoading()}
           fallback={<MessageHistorySkeleton />}
-          error={history.error}
+          error={historyError()}
           errorFallback={
             <div class={styles.empty}>{t('conversation.load_error')}</div>
           }

--- a/src/features/messaging-next/adapters/in-memory.ts
+++ b/src/features/messaging-next/adapters/in-memory.ts
@@ -7,24 +7,74 @@ import type { ConversationId, UserId } from '../types.js';
 
 export function createInMemoryMessageRepository(): MessageRepository {
   const stored = new Map<ConversationId, IncomingMessage[]>();
-  const msgSubs = new Map<
+  const recentSubs = new Map<
     ConversationId,
-    Array<(msg: IncomingMessage) => void>
+    Array<(messages: IncomingMessage[]) => void>
+  >();
+  const unreadSubs = new Map<
+    ConversationId,
+    Array<{
+      userId: UserId;
+      onChange: (hasUnread: boolean) => void;
+      last: boolean | null;
+    }>
   >();
   const rxnSubs = new Map<
     ConversationId,
     Array<(messageId: string, reactions: ReactionMap) => void>
   >();
   const reactions = new Map<string, ReactionMap>(); // `${conversationId}:${messageId}`
+  const lastReadAt = new Map<string, number>(); // `${conversationId}:${userId}`
 
   function getStored(id: ConversationId) {
     if (!stored.has(id)) stored.set(id, []);
     return stored.get(id)!;
   }
 
+  function readKey(conversationId: ConversationId, userId: UserId) {
+    return `${conversationId}:${userId}`;
+  }
+
+  function notifyRecent(conversationId: ConversationId) {
+    const messages = [...getStored(conversationId)];
+    for (const cb of recentSubs.get(conversationId) ?? []) cb(messages);
+  }
+
+  function hasUnread(conversationId: ConversationId, userId: UserId) {
+    const latest = getStored(conversationId).at(-1);
+    if (!latest || latest.senderId === userId) return false;
+    const readAt = lastReadAt.get(readKey(conversationId, userId)) ?? 0;
+    return latest.sentAt > readAt;
+  }
+
+  function notifyUnread(conversationId: ConversationId) {
+    for (const sub of unreadSubs.get(conversationId) ?? []) {
+      const next = hasUnread(conversationId, sub.userId);
+      if (next !== sub.last) {
+        sub.last = next;
+        sub.onChange(next);
+      }
+    }
+  }
+
   return {
     loadMessages(conversationId) {
       return [...getStored(conversationId)];
+    },
+
+    watchRecentMessages(conversationId, onMessages) {
+      const list = recentSubs.get(conversationId) ?? [];
+      list.push(onMessages);
+      recentSubs.set(conversationId, list);
+      onMessages([...getStored(conversationId)]);
+      return () => {
+        recentSubs.set(
+          conversationId,
+          (recentSubs.get(conversationId) ?? []).filter(
+            (cb) => cb !== onMessages,
+          ),
+        );
+      };
     },
 
     send(message) {
@@ -34,21 +84,27 @@ export function createInMemoryMessageRepository(): MessageRepository {
         sentAt: Date.now(),
       };
       getStored(msg.conversationId).push(msg);
-      for (const cb of msgSubs.get(msg.conversationId) ?? []) cb(msg);
+      notifyRecent(msg.conversationId);
+      notifyUnread(msg.conversationId);
       return { id: msg.messageId, sentAt: msg.sentAt };
     },
 
-    subscribe(conversationId, myUserId, onMessage) {
-      const list = msgSubs.get(conversationId) ?? [];
-      const wrapped = (msg: IncomingMessage) => {
-        if (msg.senderId !== myUserId) onMessage(msg);
-      };
-      list.push(wrapped);
-      msgSubs.set(conversationId, list);
+    markConversationRead(conversationId, userId) {
+      lastReadAt.set(readKey(conversationId, userId), Date.now());
+      notifyUnread(conversationId);
+    },
+
+    watchHasUnread(conversationId, userId, onChange) {
+      const list = unreadSubs.get(conversationId) ?? [];
+      const initial = hasUnread(conversationId, userId);
+      const sub = { userId, onChange, last: initial };
+      list.push(sub);
+      unreadSubs.set(conversationId, list);
+      onChange(initial);
       return () => {
-        msgSubs.set(
+        unreadSubs.set(
           conversationId,
-          (msgSubs.get(conversationId) ?? []).filter((cb) => cb !== wrapped),
+          (unreadSubs.get(conversationId) ?? []).filter((item) => item !== sub),
         );
       };
     },

--- a/src/features/messaging-next/adapters/rtdb.test.js
+++ b/src/features/messaging-next/adapters/rtdb.test.js
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { get, serverTimestamp, set } from 'firebase/database';
+import {
+  get,
+  onValue,
+  orderByChild,
+  serverTimestamp,
+  set,
+  startAfter,
+  update,
+} from 'firebase/database';
 import {
   createRTDBConversationRepository,
   createRTDBMessageRepository,
@@ -16,12 +24,14 @@ vi.mock('firebase/database', () => ({
   get: vi.fn(),
   onChildAdded: vi.fn(),
   onChildChanged: vi.fn(),
-  onValue: vi.fn(),
+  onValue: vi.fn(() => vi.fn()),
   off: vi.fn(),
-  query: vi.fn((ref) => ref),
+  query: vi.fn((ref, ...constraints) => ({ ref, constraints })),
   limitToLast: vi.fn((count) => ({ count })),
   serverTimestamp: vi.fn(() => ({ '.sv': 'timestamp' })),
   update: vi.fn(),
+  orderByChild: vi.fn((key) => ({ orderByChild: key })),
+  startAfter: vi.fn((key) => ({ startAfter: key })),
 }));
 
 describe('messaging-next RTDB adapter', () => {
@@ -95,6 +105,109 @@ describe('messaging-next RTDB adapter', () => {
         },
       }),
     ]);
+  });
+
+  it('watches the recent message window as a full snapshot', () => {
+    const unsubscribe = vi.fn();
+    vi.mocked(onValue).mockImplementationOnce((queryRef, next) => {
+      next({
+        exists: () => true,
+        forEach: (visit) => {
+          visit({
+            key: 'msg-1',
+            val: () => ({
+              from: 'user-a',
+              fromName: 'User A',
+              text: 'hello',
+              type: 'text',
+              sentAt: 10,
+              read: false,
+            }),
+          });
+        },
+      });
+      return unsubscribe;
+    });
+
+    const repository = createRTDBMessageRepository();
+    const onMessages = vi.fn();
+    const result = repository.watchRecentMessages('user-a_user-b', onMessages);
+
+    expect(result).toBe(unsubscribe);
+    expect(onMessages).toHaveBeenCalledWith([
+      expect.objectContaining({
+        messageId: 'msg-1',
+        senderId: 'user-a',
+        payload: { type: 'text', text: 'hello' },
+      }),
+    ]);
+  });
+
+  it('marks a conversation read with a server timestamp', async () => {
+    const repository = createRTDBMessageRepository();
+    await repository.markConversationRead('user-a_user-b', 'user-a');
+
+    expect(update).toHaveBeenCalledWith(
+      { path: 'conversations/user-a_user-b/members/user-a' },
+      { lastReadAt: serverTimestamp() },
+    );
+  });
+
+  it('emits hasUnread when the latest message is from someone else and newer than lastReadAt', () => {
+    const unsubscribeLatest = vi.fn();
+    const unsubscribeRead = vi.fn();
+    const calls = [];
+
+    vi.mocked(onValue)
+      .mockImplementationOnce((_queryRef, next) => {
+        next({
+          forEach: (visit) => {
+            visit({
+              val: () => ({ from: 'user-b', sentAt: 200 }),
+            });
+          },
+        });
+        return unsubscribeLatest;
+      })
+      .mockImplementationOnce((_queryRef, next) => {
+        next({ val: () => ({ lastReadAt: 100 }) });
+        return unsubscribeRead;
+      });
+
+    const repository = createRTDBMessageRepository();
+    const unsubscribe = repository.watchHasUnread(
+      'user-a_user-b',
+      'user-a',
+      (hasUnread) => calls.push(hasUnread),
+    );
+
+    expect(calls).toEqual([true]);
+
+    unsubscribe();
+    expect(unsubscribeLatest).toHaveBeenCalled();
+    expect(unsubscribeRead).toHaveBeenCalled();
+  });
+
+  it('emits hasUnread=false when the latest message is the users own', () => {
+    const calls = [];
+    vi.mocked(onValue)
+      .mockImplementationOnce((_queryRef, next) => {
+        next({
+          forEach: (visit) => {
+            visit({ val: () => ({ from: 'user-a', sentAt: 200 }) });
+          },
+        });
+        return vi.fn();
+      })
+      .mockImplementationOnce((_queryRef, next) => {
+        next({ val: () => ({ lastReadAt: 0 }) });
+        return vi.fn();
+      });
+
+    const repository = createRTDBMessageRepository();
+    repository.watchHasUnread('user-a_user-b', 'user-a', (h) => calls.push(h));
+
+    expect(calls).toEqual([false]);
   });
 
   it('loads shared conversation metadata without draft state', async () => {

--- a/src/features/messaging-next/adapters/rtdb.ts
+++ b/src/features/messaging-next/adapters/rtdb.ts
@@ -3,7 +3,6 @@ import {
   push,
   set,
   get,
-  onChildAdded,
   onChildChanged,
   onValue,
   off,
@@ -11,8 +10,7 @@ import {
   limitToLast,
   serverTimestamp,
   update,
-  orderByKey,
-  startAfter,
+  orderByChild,
   type DataSnapshot,
 } from 'firebase/database';
 import { rtdb } from '../../../infra/firebase-rtdb.js';
@@ -45,8 +43,16 @@ function msgsRef(conversationId: ConversationId) {
   return ref(rtdb, `conversations/${conversationId}/messages`);
 }
 
+function memberRef(conversationId: ConversationId, userId: UserId) {
+  return ref(rtdb, `conversations/${conversationId}/members/${userId}`);
+}
+
 function recentMsgsQuery(conversationId: ConversationId) {
-  return query(msgsRef(conversationId), limitToLast(RECENT_MESSAGES_WINDOW));
+  return query(
+    msgsRef(conversationId),
+    orderByChild('sentAt'),
+    limitToLast(RECENT_MESSAGES_WINDOW),
+  );
 }
 
 function conversationRef(conversationId: ConversationId) {
@@ -136,6 +142,23 @@ function toConversationNode(raw: unknown): ConversationNode | null {
   return parsed.success ? parsed.data : null;
 }
 
+function messagesFromSnapshot(
+  snapshot: DataSnapshot,
+  conversationId: ConversationId,
+) {
+  if (!snapshot.exists()) return [];
+  const messages: IncomingMessage[] = [];
+  snapshot.forEach((child) => {
+    const msg = toIncoming(
+      child.val() as Record<string, unknown>,
+      child.key!,
+      conversationId,
+    );
+    if (msg) messages.push(msg);
+  });
+  return messages;
+}
+
 function conversationUpdate(
   input: ConversationUpsert,
   existing: ConversationNode | null,
@@ -157,17 +180,17 @@ export function createRTDBMessageRepository(): MessageRepository {
   return {
     async loadMessages(conversationId) {
       const snapshot = await get(recentMsgsQuery(conversationId));
-      if (!snapshot.exists()) return [];
-      const messages: IncomingMessage[] = [];
-      snapshot.forEach((child) => {
-        const msg = toIncoming(
-          child.val() as Record<string, unknown>,
-          child.key!,
-          conversationId,
-        );
-        if (msg) messages.push(msg);
-      });
-      return messages;
+      return messagesFromSnapshot(snapshot, conversationId);
+    },
+
+    watchRecentMessages(conversationId, onMessages, onError) {
+      return onValue(
+        recentMsgsQuery(conversationId),
+        (snapshot) => {
+          onMessages(messagesFromSnapshot(snapshot, conversationId));
+        },
+        (error) => onError?.(error),
+      );
     },
 
     async send(message) {
@@ -184,23 +207,63 @@ export function createRTDBMessageRepository(): MessageRepository {
       return { id: newRef.key!, sentAt: Date.now() };
     },
 
-    subscribe(conversationId, myUserId, onMessage) {
-      const msgRef = msgsRef(conversationId);
-      // Generated push keys are time-ordered. Generating one without writing
-      // gives a "now" cursor — onChildAdded only fires for messages added
-      // after attach, no historical replay over the wire.
-      const sinceKey = push(msgRef).key!;
-      const msgQuery = query(msgRef, orderByKey(), startAfter(sinceKey));
+    async markConversationRead(conversationId, userId) {
+      await update(memberRef(conversationId, userId), {
+        lastReadAt: serverTimestamp(),
+      });
+    },
 
-      const handler = (snapshot: DataSnapshot) => {
-        const raw = snapshot.val() as Record<string, unknown>;
-        if (!raw || raw.from === myUserId) return;
-        const msg = toIncoming(raw, snapshot.key!, conversationId);
-        if (msg) onMessage(msg);
+    watchHasUnread(conversationId, userId, onChange, onError) {
+      let latestSenderId: UserId | null = null;
+      let latestSentAt = 0;
+      let lastReadAt = 0;
+      let hasLatest = false;
+      let hasRead = false;
+      let lastEmitted: boolean | null = null;
+
+      function emit() {
+        if (!hasLatest || !hasRead) return;
+        const hasUnread =
+          latestSenderId !== null &&
+          latestSenderId !== userId &&
+          latestSentAt > lastReadAt;
+        if (hasUnread !== lastEmitted) {
+          lastEmitted = hasUnread;
+          onChange(hasUnread);
+        }
+      }
+
+      const unsubscribeLatest = onValue(
+        query(msgsRef(conversationId), orderByChild('sentAt'), limitToLast(1)),
+        (snapshot) => {
+          latestSenderId = null;
+          latestSentAt = 0;
+          snapshot.forEach((child) => {
+            const raw = child.val() as Record<string, unknown> | null;
+            latestSenderId = (raw?.from as UserId) ?? null;
+            latestSentAt = typeof raw?.sentAt === 'number' ? raw.sentAt : 0;
+          });
+          hasLatest = true;
+          emit();
+        },
+        (error) => onError?.(error),
+      );
+
+      const unsubscribeRead = onValue(
+        memberRef(conversationId, userId),
+        (snapshot) => {
+          const raw = snapshot.val() as { lastReadAt?: unknown } | null;
+          lastReadAt = typeof raw?.lastReadAt === 'number' ? raw.lastReadAt : 0;
+          hasRead = true;
+          emit();
+        },
+        (error) => onError?.(error),
+      );
+
+      return () => {
+        unsubscribeLatest();
+        unsubscribeRead();
       };
-
-      onChildAdded(msgQuery, handler);
-      return () => off(msgQuery, 'child_added', handler);
     },
 
     async setReaction(conversationId, messageId, emoji, userId, active) {

--- a/src/features/messaging-next/conversation.actions.ts
+++ b/src/features/messaging-next/conversation.actions.ts
@@ -82,15 +82,22 @@ export function createConversationActions(store: ConversationStateStore) {
   }
 
   function markSent(tempId: string, realId: string) {
-    setState('messages', (msgs) =>
-      sortMessagesBySentAt(
-        msgs.map((msg) => {
-          if (msg.id === tempId) return { ...msg, id: realId, status: 'sent' };
-          if (msg.id === realId) return { ...msg, status: 'sent' };
-          return msg;
+    setState('messages', (msgs) => {
+      const realMessageAlreadyArrived =
+        tempId !== realId && msgs.some((msg) => msg.id === realId);
+
+      return sortMessagesBySentAt(
+        msgs.flatMap((msg) => {
+          if (msg.id === tempId) {
+            return realMessageAlreadyArrived
+              ? []
+              : [{ ...msg, id: realId, status: 'sent' as const }];
+          }
+          if (msg.id === realId) return [{ ...msg, status: 'sent' as const }];
+          return [msg];
         }),
-      ),
-    );
+      );
+    });
   }
 
   function markFailed(tempId: string) {

--- a/src/features/messaging-next/interfaces.ts
+++ b/src/features/messaging-next/interfaces.ts
@@ -34,6 +34,17 @@ export type MessageRepository = {
     conversationId: ConversationId,
   ): IncomingMessage[] | Promise<IncomingMessage[]>;
 
+  /**
+   * Watch the current recent message window for an open conversation.
+   * The first callback is the current recent history; later callbacks include
+   * subsequent backend changes in the same window.
+   */
+  watchRecentMessages(
+    conversationId: ConversationId,
+    onMessages: (messages: IncomingMessage[]) => void,
+    onError?: (error: unknown) => void,
+  ): (() => void) | Promise<() => void>;
+
   /** Persist a message envelope. Resolves with the canonical id and timestamp. */
   send(
     msg: OutgoingMessage,
@@ -41,15 +52,21 @@ export type MessageRepository = {
     | { id: string; sentAt: number }
     | Promise<{ id: string; sentAt: number }>;
 
-  /**
-   * Subscribe to new remote messages.
-   * The adapter must skip messages sent by myUserId.
-   * Returns unsubscribe.
-   */
-  subscribe(
+  /** Mark a conversation read by userId at the current backend time. */
+  markConversationRead(
     conversationId: ConversationId,
-    myUserId: UserId,
-    onMessage: (msg: IncomingMessage) => void,
+    userId: UserId,
+  ): void | Promise<void>;
+
+  /**
+   * Watch whether a user has any unread remote messages in a conversation.
+   * Binary signal — counts are intentionally omitted for now.
+   */
+  watchHasUnread(
+    conversationId: ConversationId,
+    userId: UserId,
+    onChange: (hasUnread: boolean) => void,
+    onError?: (error: unknown) => void,
   ): (() => void) | Promise<() => void>;
 
   /**

--- a/src/features/messaging-next/tests/use-conversation.test.js
+++ b/src/features/messaging-next/tests/use-conversation.test.js
@@ -67,13 +67,12 @@ describe('messaging-next useConversation', () => {
     });
   });
 
-  it('starts live subscriptions only after history is ready', async () => {
+  it('starts reaction subscriptions only after history is ready', async () => {
     const store = createConversationState();
     const actions = createConversationActions(store);
     actions.startConversation({ conversationId: 'conversation-1' }, 'me');
 
     const repository = {
-      subscribe: vi.fn(() => () => {}),
       subscribeReactions: vi.fn(() => () => {}),
       send: vi.fn(),
     };
@@ -89,17 +88,11 @@ describe('messaging-next useConversation', () => {
         });
 
         queueMicrotask(() => {
-          expect(repository.subscribe).not.toHaveBeenCalled();
           expect(repository.subscribeReactions).not.toHaveBeenCalled();
 
           setHistoryReady(true);
 
           queueMicrotask(() => {
-            expect(repository.subscribe).toHaveBeenCalledWith(
-              'conversation-1',
-              'me',
-              expect.any(Function),
-            );
             expect(repository.subscribeReactions).toHaveBeenCalledWith(
               'conversation-1',
               expect.any(Function),

--- a/src/features/messaging-next/use-conversation.ts
+++ b/src/features/messaging-next/use-conversation.ts
@@ -146,36 +146,6 @@ export function useConversation({
 
   createEffect(() => {
     const conversationId = state.conversationId;
-    const myUserId = state.myUserId;
-    if (!conversationId || !myUserId || !historyReady()) return;
-
-    let cleanup: (() => void) | undefined;
-    let disposed = false;
-
-    const result = repository.subscribe(conversationId, myUserId, (msg) => {
-      const chatMessage = envelopeToChatMessage(msg, 'persisted');
-      if (chatMessage) {
-        actions.receiveMessage(chatMessage);
-      }
-    });
-
-    if (typeof result === 'function') {
-      cleanup = result;
-    } else {
-      void result.then((unsub) => {
-        if (disposed) unsub();
-        else cleanup = unsub;
-      });
-    }
-
-    onCleanup(() => {
-      disposed = true;
-      cleanup?.();
-    });
-  });
-
-  createEffect(() => {
-    const conversationId = state.conversationId;
     if (!conversationId || !historyReady()) return;
 
     let cleanup: (() => void) | undefined;


### PR DESCRIPTION
## Summary
- replace per-message replay subscription with recent-message window watching for open conversations
- add per-user conversation read state and contact unread indicators
- fix optimistic send reconciliation when the persisted row arrives first
- add a dry-run-first lastReadAt backfill script for existing contacts

## Validation
- node --check scripts/backfill-conversation-last-read-at.js
- dry-run: node scripts/backfill-conversation-last-read-at.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread message tracking and real-time synchronization across conversations
  * Enhanced message history loading reliability and performance

* **Style**
  * Refined contact list unread indicators to use a visual marker instead of numeric count

* **Chores**
  * Updated database security rules and conversation data consistency improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KristinnRoach/HangVidU/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->