### PR TITLE
Consolidate conversation state into ConversationActivity

### DIFF
--- a/scripts/backfill-conversation-last-read-at.js
+++ b/scripts/backfill-conversation-last-read-at.js
@@ -51,6 +51,7 @@ admin.initializeApp({
 });
 
 const db = admin.database();
+const conversationOwnership = new Map();
 
 function isObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -79,6 +80,36 @@ async function applyInBatches(updates) {
 }
 
 const latestSentAtByConversation = new Map();
+
+function directConversationIdHasUser(conversationId, userId) {
+  return conversationId.split('_').includes(userId);
+}
+
+async function userBelongsToConversation(
+  conversationId,
+  userId,
+  currentMemberExists,
+) {
+  if (currentMemberExists) return true;
+
+  const cacheKey = `${conversationId}:${userId}`;
+  if (conversationOwnership.has(cacheKey)) {
+    return conversationOwnership.get(cacheKey);
+  }
+
+  const snap = await db.ref(`conversations/${conversationId}`).once('value');
+  const conversation = snap.val();
+  const belongs =
+    isObject(conversation) &&
+    ((isObject(conversation.members) &&
+      isObject(conversation.members[userId])) ||
+      (isObject(conversation.participants) &&
+        isObject(conversation.participants[userId])) ||
+      directConversationIdHasUser(conversationId, userId));
+
+  conversationOwnership.set(cacheKey, belongs);
+  return belongs;
+}
 
 async function getLatestSentAt(conversationId) {
   if (latestSentAtByConversation.has(conversationId)) {
@@ -109,6 +140,7 @@ async function run() {
   let userCount = 0;
   let contactCount = 0;
   let skippedNoConversation = 0;
+  let skippedNotMember = 0;
   let skippedExisting = 0;
   let legacyNoTimestampedMessage = 0;
 
@@ -134,6 +166,17 @@ async function run() {
         .ref(`conversations/${conversationId}/members/${userId}`)
         .once('value');
       const current = currentMember.val();
+      const belongsToConversation = await userBelongsToConversation(
+        conversationId,
+        userId,
+        currentMember.exists(),
+      );
+
+      if (!belongsToConversation) {
+        skippedNotMember += 1;
+        continue;
+      }
+
       const hasExistingLastRead =
         isObject(current) && typeof current.lastReadAt === 'number';
 
@@ -160,6 +203,7 @@ async function run() {
   console.log(`Queued writes: ${paths.length}`);
   console.log(`Skipped existing lastReadAt: ${skippedExisting}`);
   console.log(`Skipped missing conversationId: ${skippedNoConversation}`);
+  console.log(`Skipped non-member contacts: ${skippedNotMember}`);
   console.log(`Legacy no timestamped messages: ${legacyNoTimestampedMessage}`);
 
   if (paths.length > 0) {

--- a/src/features/contacts/components/ContactEntry.jsx
+++ b/src/features/contacts/components/ContactEntry.jsx
@@ -72,8 +72,14 @@ export default function ContactEntry(props) {
       </button>
 
       <Show when={props.hasUnread}>
-        <span class='unread-badge' aria-live='polite' aria-atomic='true'>
-          •
+        <span
+          class='unread-badge'
+          aria-live='polite'
+          aria-atomic='true'
+          role='status'
+          aria-label='Unread'
+        >
+          <span aria-hidden='true'>•</span>
         </span>
       </Show>
 

--- a/src/features/contacts/docs/CONTRACT.md
+++ b/src/features/contacts/docs/CONTRACT.md
@@ -12,8 +12,9 @@
   - does not import persistence directly
 
 - Current split
-  - writes: `saveContact`, `updateContact`, `deleteContact`, `recordInteraction`, `recordInteractionByConversation`, `handleHangUp`
-  - reads: `getAllContacts`, `getContactById`, `getContactByRoomId`, `getConversationId`, `getAllContactsSorted`, `getContactByMostRecentInteraction`, `getContactsIsHydrated`
+  - writes: `saveContact`, `updateContact`, `deleteContact`, `handleHangUp`
+  - reads: `getAllContacts`, `getContactById`, `getContactByRoomId`, `getConversationId`, `getContactsIsHydrated`
+  - per-conversation activity (sort key + unread badge) comes from `MessageRepository.watchConversationActivity`, not the contacts store
   - lifecycle: `hydrateContacts`, `resetContacts`
 
 - Storage boundary

--- a/src/features/contacts/useContacts.ts
+++ b/src/features/contacts/useContacts.ts
@@ -27,6 +27,18 @@ export function useContacts() {
   const runtime = createMessagingRuntime();
 
   const activityWatchers = new Map<string, () => void>();
+  let activityWatchUserId: string | null = null;
+  let activityWatchGeneration = 0;
+
+  function clearActivity() {
+    setActivity(
+      produce((current) => {
+        for (const conversationId of Object.keys(current)) {
+          delete current[conversationId];
+        }
+      }),
+    );
+  }
 
   function stopActivityWatchers() {
     for (const unsubscribe of activityWatchers.values()) unsubscribe();
@@ -74,6 +86,7 @@ export function useContacts() {
 
     createEffect(() => {
       const userId = getLoggedInUserId();
+      const generation = ++activityWatchGeneration;
       const conversationIds = new Set(
         Object.values(contactsState.byId)
           .map((c: any) => c?.conversationId as string | null | undefined)
@@ -82,7 +95,15 @@ export function useContacts() {
 
       if (!userId) {
         stopActivityWatchers();
+        clearActivity();
+        activityWatchUserId = null;
         return;
+      }
+
+      if (activityWatchUserId !== userId) {
+        stopActivityWatchers();
+        clearActivity();
+        activityWatchUserId = userId;
       }
 
       for (const [conversationId, unsubscribe] of activityWatchers) {
@@ -100,6 +121,12 @@ export function useContacts() {
           conversationId,
           userId,
           (next) => {
+            if (
+              generation !== activityWatchGeneration ||
+              activityWatchUserId !== userId ||
+              !conversationIds.has(conversationId)
+            )
+              return;
             setActivity(conversationId, next);
           },
           (error) => {
@@ -113,20 +140,38 @@ export function useContacts() {
         if (typeof result === 'function') {
           activityWatchers.set(conversationId, result);
         } else {
-          void result.then((unsubscribe) => {
-            if (conversationIds.has(conversationId)) {
-              activityWatchers.set(conversationId, unsubscribe);
-            } else {
-              unsubscribe();
-            }
-          });
+          void result
+            .then((unsubscribe) => {
+              if (
+                generation === activityWatchGeneration &&
+                activityWatchUserId === userId &&
+                conversationIds.has(conversationId)
+              ) {
+                activityWatchers.set(conversationId, unsubscribe);
+              } else {
+                unsubscribe();
+              }
+            })
+            .catch((error) => {
+              if (
+                generation !== activityWatchGeneration ||
+                activityWatchUserId !== userId
+              )
+                return;
+              console.warn('[contacts] activity watch failed', {
+                conversationId,
+                error,
+              });
+            });
         }
       }
     });
   });
 
   onCleanup(() => {
+    activityWatchGeneration += 1;
     stopActivityWatchers();
+    clearActivity();
   });
 
   return { contacts };

--- a/src/features/contacts/useContacts.ts
+++ b/src/features/contacts/useContacts.ts
@@ -1,10 +1,8 @@
 import { createEffect, onCleanup, onMount } from 'solid-js';
 import { createStore, produce } from 'solid-js/store';
 import { getLoggedInUserId } from '../../auth/index.js';
-import {
-  getContactsStore,
-  recordInteractionByConversation,
-} from '../../stores/contactsStore.js';
+import { getContactsStore } from '../../stores/contactsStore.js';
+import type { ConversationActivity } from '../messaging-next/interfaces.js';
 import { createMessagingRuntime } from '../messaging-next/messaging-runtime.js';
 
 type ContactRow = {
@@ -14,38 +12,57 @@ type ContactRow = {
   hasUnread: boolean;
 };
 
+const EMPTY_ACTIVITY: ConversationActivity = {
+  latestSentAt: 0,
+  latestSenderId: null,
+  lastReadAt: 0,
+};
+
 export function useContacts() {
   const contactsState = getContactsStore();
   const [contacts, setContacts] = createStore<ContactRow[]>([]);
-  const [unread, setUnread] = createStore<Record<string, boolean>>({});
+  const [activity, setActivity] = createStore<
+    Record<string, ConversationActivity>
+  >({});
   const runtime = createMessagingRuntime();
 
-  const unreadWatchers = new Map<string, () => void>();
+  const activityWatchers = new Map<string, () => void>();
 
-  function stopUnreadWatchers() {
-    for (const unsubscribe of unreadWatchers.values()) unsubscribe();
-    unreadWatchers.clear();
+  function stopActivityWatchers() {
+    for (const unsubscribe of activityWatchers.values()) unsubscribe();
+    activityWatchers.clear();
   }
 
   onMount(() => {
     createEffect(() => {
+      const userId = getLoggedInUserId();
+
       const rows: ContactRow[] = Object.values(contactsState.byId)
-        .sort((a: any, b: any) => {
-          const aTime = a?.lastInteractionAt || a?.savedAt || 0;
-          const bTime = b?.lastInteractionAt || b?.savedAt || 0;
-          if (aTime !== bTime) return bTime - aTime;
-          const aName = (a?.contactNickName || '').toLowerCase();
-          const bName = (b?.contactNickName || '').toLowerCase();
-          return aName.localeCompare(bName);
+        .map((c: any) => {
+          const conversationId: string | null = c.conversationId ?? null;
+          const act = conversationId
+            ? (activity[conversationId] ?? EMPTY_ACTIVITY)
+            : EMPTY_ACTIVITY;
+          const sortKey = act.latestSentAt || c?.savedAt || 0;
+          const hasUnread =
+            Boolean(userId) &&
+            act.latestSenderId !== null &&
+            act.latestSenderId !== userId &&
+            act.latestSentAt > act.lastReadAt;
+          return {
+            id: c.contactId ?? '',
+            name: c.contactNickName ?? null,
+            conversationId,
+            hasUnread,
+            _sortKey: sortKey,
+            _name: (c?.contactNickName || '').toLowerCase(),
+          };
         })
-        .map((c: any) => ({
-          id: c.contactId ?? '',
-          name: c.contactNickName ?? null,
-          conversationId: c.conversationId ?? null,
-          hasUnread: c.conversationId
-            ? (unread[c.conversationId] ?? false)
-            : false,
-        }));
+        .sort((a, b) => {
+          if (a._sortKey !== b._sortKey) return b._sortKey - a._sortKey;
+          return a._name.localeCompare(b._name);
+        })
+        .map(({ _sortKey, _name, ...row }) => row);
 
       setContacts(
         produce((arr: ContactRow[]) => {
@@ -58,37 +75,35 @@ export function useContacts() {
     createEffect(() => {
       const userId = getLoggedInUserId();
       const conversationIds = new Set(
-        contacts
-          .map((row) => row.conversationId)
+        Object.values(contactsState.byId)
+          .map((c: any) => c?.conversationId as string | null | undefined)
           .filter((id): id is string => Boolean(id)),
       );
 
       if (!userId) {
-        stopUnreadWatchers();
+        stopActivityWatchers();
         return;
       }
 
-      for (const [conversationId, unsubscribe] of unreadWatchers) {
+      for (const [conversationId, unsubscribe] of activityWatchers) {
         if (!conversationIds.has(conversationId)) {
           unsubscribe();
-          unreadWatchers.delete(conversationId);
+          activityWatchers.delete(conversationId);
+          setActivity(produce((a) => void delete a[conversationId]));
         }
       }
 
       for (const conversationId of conversationIds) {
-        if (unreadWatchers.has(conversationId)) continue;
+        if (activityWatchers.has(conversationId)) continue;
 
-        const result = runtime.messageRepository.watchHasUnread(
+        const result = runtime.messageRepository.watchConversationActivity(
           conversationId,
           userId,
-          (hasUnread) => {
-            setUnread(conversationId, hasUnread);
-            if (hasUnread) {
-              void recordInteractionByConversation(conversationId);
-            }
+          (next) => {
+            setActivity(conversationId, next);
           },
           (error) => {
-            console.warn('[contacts] unread watch failed', {
+            console.warn('[contacts] activity watch failed', {
               conversationId,
               error,
             });
@@ -96,11 +111,11 @@ export function useContacts() {
         );
 
         if (typeof result === 'function') {
-          unreadWatchers.set(conversationId, result);
+          activityWatchers.set(conversationId, result);
         } else {
           void result.then((unsubscribe) => {
             if (conversationIds.has(conversationId)) {
-              unreadWatchers.set(conversationId, unsubscribe);
+              activityWatchers.set(conversationId, unsubscribe);
             } else {
               unsubscribe();
             }
@@ -111,7 +126,7 @@ export function useContacts() {
   });
 
   onCleanup(() => {
-    stopUnreadWatchers();
+    stopActivityWatchers();
   });
 
   return { contacts };

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -219,10 +219,17 @@ export default function ConversationPanel(props: ConversationPanelProps) {
             queueMicrotask(scrollToEnd);
             queueMicrotask(focusInput);
             if (latestMessageId) {
-              void runtime.messageRepository.markConversationRead(
-                source.conversationId,
-                source.myUserId,
-              );
+              void Promise.resolve(
+                runtime.messageRepository.markConversationRead(
+                  source.conversationId,
+                  source.myUserId,
+                ),
+              ).catch((error) => {
+                console.warn('[conversation] failed to mark conversation read', {
+                  conversationId: source.conversationId,
+                  error,
+                });
+              });
             }
           },
           (error) => {
@@ -239,10 +246,19 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         if (typeof result === 'function') {
           cleanup = result;
         } else {
-          void result.then((unsub) => {
-            if (disposed) unsub();
-            else cleanup = unsub;
-          });
+          void result
+            .then((unsub) => {
+              if (disposed) unsub();
+              else cleanup = unsub;
+            })
+            .catch((error) => {
+              if (disposed || source.conversationId !== state.conversationId) {
+                return;
+              }
+              setHistoryError(error);
+              setHistoryLoading(false);
+              suppressScroll = false;
+            });
         }
 
         onCleanup(() => {

--- a/src/features/messaging-next/adapters/in-memory.ts
+++ b/src/features/messaging-next/adapters/in-memory.ts
@@ -1,4 +1,5 @@
 import type {
+  ConversationActivity,
   IncomingMessage,
   MessageRepository,
   ReactionMap,
@@ -11,12 +12,11 @@ export function createInMemoryMessageRepository(): MessageRepository {
     ConversationId,
     Array<(messages: IncomingMessage[]) => void>
   >();
-  const unreadSubs = new Map<
+  const activitySubs = new Map<
     ConversationId,
     Array<{
       userId: UserId;
-      onChange: (hasUnread: boolean) => void;
-      last: boolean | null;
+      onChange: (activity: ConversationActivity) => void;
     }>
   >();
   const rxnSubs = new Map<
@@ -40,20 +40,21 @@ export function createInMemoryMessageRepository(): MessageRepository {
     for (const cb of recentSubs.get(conversationId) ?? []) cb(messages);
   }
 
-  function hasUnread(conversationId: ConversationId, userId: UserId) {
+  function activitySnapshot(
+    conversationId: ConversationId,
+    userId: UserId,
+  ): ConversationActivity {
     const latest = getStored(conversationId).at(-1);
-    if (!latest || latest.senderId === userId) return false;
-    const readAt = lastReadAt.get(readKey(conversationId, userId)) ?? 0;
-    return latest.sentAt > readAt;
+    return {
+      latestSentAt: latest?.sentAt ?? 0,
+      latestSenderId: latest?.senderId ?? null,
+      lastReadAt: lastReadAt.get(readKey(conversationId, userId)) ?? 0,
+    };
   }
 
-  function notifyUnread(conversationId: ConversationId) {
-    for (const sub of unreadSubs.get(conversationId) ?? []) {
-      const next = hasUnread(conversationId, sub.userId);
-      if (next !== sub.last) {
-        sub.last = next;
-        sub.onChange(next);
-      }
+  function notifyActivity(conversationId: ConversationId) {
+    for (const sub of activitySubs.get(conversationId) ?? []) {
+      sub.onChange(activitySnapshot(conversationId, sub.userId));
     }
   }
 
@@ -85,26 +86,27 @@ export function createInMemoryMessageRepository(): MessageRepository {
       };
       getStored(msg.conversationId).push(msg);
       notifyRecent(msg.conversationId);
-      notifyUnread(msg.conversationId);
+      notifyActivity(msg.conversationId);
       return { id: msg.messageId, sentAt: msg.sentAt };
     },
 
     markConversationRead(conversationId, userId) {
       lastReadAt.set(readKey(conversationId, userId), Date.now());
-      notifyUnread(conversationId);
+      notifyActivity(conversationId);
     },
 
-    watchHasUnread(conversationId, userId, onChange) {
-      const list = unreadSubs.get(conversationId) ?? [];
-      const initial = hasUnread(conversationId, userId);
-      const sub = { userId, onChange, last: initial };
+    watchConversationActivity(conversationId, userId, onChange) {
+      const list = activitySubs.get(conversationId) ?? [];
+      const sub = { userId, onChange };
       list.push(sub);
-      unreadSubs.set(conversationId, list);
-      onChange(initial);
+      activitySubs.set(conversationId, list);
+      onChange(activitySnapshot(conversationId, userId));
       return () => {
-        unreadSubs.set(
+        activitySubs.set(
           conversationId,
-          (unreadSubs.get(conversationId) ?? []).filter((item) => item !== sub),
+          (activitySubs.get(conversationId) ?? []).filter(
+            (item) => item !== sub,
+          ),
         );
       };
     },

--- a/src/features/messaging-next/adapters/in-memory.ts
+++ b/src/features/messaging-next/adapters/in-memory.ts
@@ -17,6 +17,9 @@ export function createInMemoryMessageRepository(): MessageRepository {
     Array<{
       userId: UserId;
       onChange: (activity: ConversationActivity) => void;
+      lastEmittedSentAt: number;
+      lastEmittedReadAt: number;
+      lastEmittedSenderId: UserId | null | undefined;
     }>
   >();
   const rxnSubs = new Map<
@@ -54,7 +57,16 @@ export function createInMemoryMessageRepository(): MessageRepository {
 
   function notifyActivity(conversationId: ConversationId) {
     for (const sub of activitySubs.get(conversationId) ?? []) {
-      sub.onChange(activitySnapshot(conversationId, sub.userId));
+      const next = activitySnapshot(conversationId, sub.userId);
+      if (
+        next.latestSentAt === sub.lastEmittedSentAt &&
+        next.lastReadAt === sub.lastEmittedReadAt &&
+        next.latestSenderId === sub.lastEmittedSenderId
+      ) continue;
+      sub.lastEmittedSentAt = next.latestSentAt;
+      sub.lastEmittedReadAt = next.lastReadAt;
+      sub.lastEmittedSenderId = next.latestSenderId;
+      sub.onChange(next);
     }
   }
 
@@ -97,10 +109,17 @@ export function createInMemoryMessageRepository(): MessageRepository {
 
     watchConversationActivity(conversationId, userId, onChange) {
       const list = activitySubs.get(conversationId) ?? [];
-      const sub = { userId, onChange };
+      const initial = activitySnapshot(conversationId, userId);
+      const sub = {
+        userId,
+        onChange,
+        lastEmittedSentAt: initial.latestSentAt,
+        lastEmittedReadAt: initial.lastReadAt,
+        lastEmittedSenderId: initial.latestSenderId,
+      };
       list.push(sub);
       activitySubs.set(conversationId, list);
-      onChange(activitySnapshot(conversationId, userId));
+      onChange(initial);
       return () => {
         activitySubs.set(
           conversationId,

--- a/src/features/messaging-next/adapters/rtdb.test.js
+++ b/src/features/messaging-next/adapters/rtdb.test.js
@@ -153,7 +153,7 @@ describe('messaging-next RTDB adapter', () => {
     );
   });
 
-  it('emits hasUnread when the latest message is from someone else and newer than lastReadAt', () => {
+  it('emits conversation activity with latest message and lastReadAt', () => {
     const unsubscribeLatest = vi.fn();
     const unsubscribeRead = vi.fn();
     const calls = [];
@@ -175,20 +175,22 @@ describe('messaging-next RTDB adapter', () => {
       });
 
     const repository = createRTDBMessageRepository();
-    const unsubscribe = repository.watchHasUnread(
+    const unsubscribe = repository.watchConversationActivity(
       'user-a_user-b',
       'user-a',
-      (hasUnread) => calls.push(hasUnread),
+      (activity) => calls.push(activity),
     );
 
-    expect(calls).toEqual([true]);
+    expect(calls).toEqual([
+      { latestSentAt: 200, latestSenderId: 'user-b', lastReadAt: 100 },
+    ]);
 
     unsubscribe();
     expect(unsubscribeLatest).toHaveBeenCalled();
     expect(unsubscribeRead).toHaveBeenCalled();
   });
 
-  it('emits hasUnread=false when the latest message is the users own', () => {
+  it('emits activity reflecting the users own latest message', () => {
     const calls = [];
     vi.mocked(onValue)
       .mockImplementationOnce((_queryRef, next) => {
@@ -205,9 +207,13 @@ describe('messaging-next RTDB adapter', () => {
       });
 
     const repository = createRTDBMessageRepository();
-    repository.watchHasUnread('user-a_user-b', 'user-a', (h) => calls.push(h));
+    repository.watchConversationActivity('user-a_user-b', 'user-a', (a) =>
+      calls.push(a),
+    );
 
-    expect(calls).toEqual([false]);
+    expect(calls).toEqual([
+      { latestSentAt: 200, latestSenderId: 'user-a', lastReadAt: 0 },
+    ]);
   });
 
   it('loads shared conversation metadata without draft state', async () => {

--- a/src/features/messaging-next/adapters/rtdb.ts
+++ b/src/features/messaging-next/adapters/rtdb.ts
@@ -219,9 +219,22 @@ export function createRTDBMessageRepository(): MessageRepository {
       let lastReadAt = 0;
       let hasLatest = false;
       let hasRead = false;
+      let lastEmittedSentAt = -1;
+      let lastEmittedReadAt = -1;
+      let lastEmittedSenderId: UserId | null | undefined = undefined;
 
       function emit() {
         if (!hasLatest || !hasRead) return;
+        if (
+          latestSentAt === lastEmittedSentAt &&
+          lastReadAt === lastEmittedReadAt &&
+          latestSenderId === lastEmittedSenderId
+        )
+          return;
+
+        lastEmittedSentAt = latestSentAt;
+        lastEmittedReadAt = lastReadAt;
+        lastEmittedSenderId = latestSenderId;
         onChange({ latestSentAt, latestSenderId, lastReadAt });
       }
 

--- a/src/features/messaging-next/adapters/rtdb.ts
+++ b/src/features/messaging-next/adapters/rtdb.ts
@@ -213,24 +213,16 @@ export function createRTDBMessageRepository(): MessageRepository {
       });
     },
 
-    watchHasUnread(conversationId, userId, onChange, onError) {
+    watchConversationActivity(conversationId, userId, onChange, onError) {
       let latestSenderId: UserId | null = null;
       let latestSentAt = 0;
       let lastReadAt = 0;
       let hasLatest = false;
       let hasRead = false;
-      let lastEmitted: boolean | null = null;
 
       function emit() {
         if (!hasLatest || !hasRead) return;
-        const hasUnread =
-          latestSenderId !== null &&
-          latestSenderId !== userId &&
-          latestSentAt > lastReadAt;
-        if (hasUnread !== lastEmitted) {
-          lastEmitted = hasUnread;
-          onChange(hasUnread);
-        }
+        onChange({ latestSentAt, latestSenderId, lastReadAt });
       }
 
       const unsubscribeLatest = onValue(

--- a/src/features/messaging-next/docs/WIP/unread-counter-model.html
+++ b/src/features/messaging-next/docs/WIP/unread-counter-model.html
@@ -1,0 +1,500 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Unread Counter Model</title>
+    <style>
+      :root {
+        --bg: #0e1014;
+        --panel: #161a21;
+        --panel-2: #1d222b;
+        --border: #2a313d;
+        --text: #e6e9ef;
+        --muted: #8b95a7;
+        --accent: #7aa2f7;
+        --send: #9ece6a;
+        --read: #e0af68;
+        --reset: #f7768e;
+        --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          14px/1.5 system-ui,
+          -apple-system,
+          sans-serif;
+        min-height: 100vh;
+      }
+      .app {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      header {
+        grid-column: 1 / -1;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 4px;
+      }
+      header p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 16px;
+      }
+      .panel h2 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        margin: 0 0 12px;
+        font-weight: 600;
+      }
+      .members {
+        display: grid;
+        gap: 10px;
+      }
+      .member {
+        display: grid;
+        grid-template-columns: 80px 28px 1fr auto;
+        gap: 10px;
+        align-items: center;
+        padding: 10px 12px;
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+      }
+      .name {
+        font-weight: 600;
+      }
+      .badge-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--border);
+        transition:
+          background-color 0.2s,
+          transform 0.2s;
+        justify-self: center;
+      }
+      .badge-dot.unread {
+        background: var(--reset);
+        transform: scale(1.3);
+      }
+      .meta {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--muted);
+      }
+      .meta .derived {
+        color: var(--accent);
+        font-size: 10px;
+        display: block;
+        margin-top: 1px;
+      }
+      .actions {
+        display: flex;
+        gap: 6px;
+      }
+      button {
+        background: var(--panel-2);
+        color: var(--text);
+        border: 1px solid var(--border);
+        padding: 6px 10px;
+        border-radius: 6px;
+        cursor: pointer;
+        font: inherit;
+        font-size: 12px;
+      }
+      button:hover {
+        border-color: var(--accent);
+      }
+      button.send {
+        border-color: #3a5a2e;
+        color: var(--send);
+      }
+      button.read {
+        border-color: #5a4a1e;
+        color: var(--read);
+      }
+      .log {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--muted);
+        max-height: 180px;
+        overflow-y: auto;
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px;
+      }
+      .log .entry {
+        padding: 2px 0;
+      }
+      .log .entry.latest {
+        color: var(--text);
+      }
+      pre.tree {
+        font-family: var(--mono);
+        font-size: 12px;
+        margin: 0;
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px;
+        overflow-x: auto;
+        line-height: 1.55;
+        color: var(--text);
+      }
+      pre.tree .k {
+        color: var(--accent);
+      }
+      pre.tree .s {
+        color: var(--send);
+      }
+      pre.tree .n {
+        color: var(--read);
+      }
+      pre.tree .c {
+        color: var(--muted);
+      }
+      pre.tree .d {
+        color: var(--reset);
+      }
+      .legend {
+        grid-column: 1 / -1;
+        display: flex;
+        gap: 18px;
+        font-size: 12px;
+        color: var(--muted);
+        flex-wrap: wrap;
+      }
+      .legend code {
+        font-family: var(--mono);
+        background: var(--panel-2);
+        padding: 1px 6px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+        color: var(--text);
+      }
+      .reset-btn {
+        background: transparent;
+        color: var(--muted);
+        font-size: 11px;
+        border: none;
+        padding: 0;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+      .reset-btn:hover {
+        color: var(--reset);
+      }
+      .formula {
+        font-family: var(--mono);
+        font-size: 12px;
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px 14px;
+        margin-bottom: 14px;
+        color: var(--muted);
+        line-height: 1.7;
+      }
+      .formula .hi {
+        color: var(--accent);
+      }
+      .formula .op {
+        color: var(--reset);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <h1>Unread counter model</h1>
+        <p>
+          Unread is <strong>derived</strong>, not stored. On send: write message
+          — no member node touched. On read: write
+          <code>lastReadAt</code> timestamp to own member node. Badge =
+          <code
+            >latestSentAt &gt; lastReadAt &amp;&amp; latestSenderId !== me</code
+          >.
+          <button class="reset-btn" id="resetAll">reset</button>
+        </p>
+      </header>
+
+      <section class="panel">
+        <h2>Members (contacts list view)</h2>
+        <div class="formula">
+          <span class="hi">hasUnread(uid)</span>
+          <span class="op"> = </span>
+          latestSentAt <span class="op">&gt;</span> members[uid].lastReadAt
+          <span class="op">&amp;&amp;</span>
+          latestSenderId <span class="op">!==</span> uid
+        </div>
+        <div class="members" id="members"></div>
+      </section>
+
+      <section class="panel">
+        <h2>Backend state (RTDB shape)</h2>
+        <pre class="tree" id="tree"></pre>
+      </section>
+
+      <section class="panel" style="grid-column: 1 / -1">
+        <h2>
+          watchConversationActivity — two subscriptions (acting as
+          <span id="actorName" style="color: var(--accent)">Alice</span>)
+        </h2>
+        <div style="display: flex; gap: 8px; margin-bottom: 12px">
+          <button data-actor="alice">as Alice</button>
+          <button data-actor="bob">as Bob</button>
+          <button data-actor="carol">as Carol</button>
+        </div>
+        <pre class="tree" id="rules"></pre>
+      </section>
+
+      <section class="panel" style="grid-column: 1 / -1">
+        <h2>Action log</h2>
+        <div class="log" id="log"></div>
+      </section>
+
+      <div class="legend">
+        <span><code>send</code> → push message, members untouched</span>
+        <span
+          ><code>read</code> → write
+          <code>lastReadAt = serverTimestamp()</code></span
+        >
+        <span
+          >badge derived from
+          <code
+            >latestSentAt &gt; lastReadAt &amp;&amp; latestSenderId !== me</code
+          ></span
+        >
+      </div>
+    </div>
+
+    <script>
+      const MEMBERS = ['alice', 'bob', 'carol'];
+      const NAMES = { alice: 'Alice', bob: 'Bob', carol: 'Carol' };
+      let state = freshState();
+      let log = [];
+      let lastSentBy = null;
+      let lastReadBy = null;
+      let actor = 'alice';
+      let tick = 1000; // simulated time counter
+
+      function freshState() {
+        return {
+          messages: [],
+          members: Object.fromEntries(
+            MEMBERS.map((u) => [u, { lastReadAt: 0 }]),
+          ),
+        };
+      }
+
+      function latestMsg() {
+        return state.messages.at(-1) ?? null;
+      }
+
+      function hasUnread(uid) {
+        const latest = latestMsg();
+        if (!latest) return false;
+        return (
+          latest.sentAt > state.members[uid].lastReadAt && latest.from !== uid
+        );
+      }
+
+      function send(uid) {
+        tick += 1000;
+        const msgId = `m${state.messages.length + 1}`;
+        state.messages.push({ id: msgId, from: uid, sentAt: tick });
+        lastSentBy = uid;
+        lastReadBy = null;
+        const unreadFor = MEMBERS.filter((u) => hasUnread(u));
+        log.unshift({
+          text: `${NAMES[uid]} sent ${msgId} (sentAt=${tick}) — unread for: ${unreadFor.map((u) => NAMES[u]).join(', ') || 'none'}`,
+        });
+        render();
+      }
+
+      function read(uid) {
+        tick += 100;
+        const prev = hasUnread(uid);
+        state.members[uid].lastReadAt = tick;
+        lastReadBy = uid;
+        lastSentBy = null;
+        log.unshift({
+          text: `${NAMES[uid]} read → lastReadAt=${tick} (was unread: ${prev})`,
+        });
+        render();
+      }
+
+      function reset() {
+        state = freshState();
+        log = [];
+        lastSentBy = null;
+        lastReadBy = null;
+        tick = 1000;
+        render();
+      }
+
+      function fmtTs(ts) {
+        if (!ts) return '—';
+        return `t=${ts}`;
+      }
+
+      function render() {
+        const m = document.getElementById('members');
+        m.innerHTML = '';
+        for (const uid of MEMBERS) {
+          const unread = hasUnread(uid);
+          const latest = latestMsg();
+          const lra = state.members[uid].lastReadAt;
+
+          const derivation = latest
+            ? `${latest.sentAt} > ${lra} && from≠${uid} → ${unread}`
+            : 'no messages';
+
+          const row = document.createElement('div');
+          row.className = 'member';
+          row.innerHTML = `
+            <span class="name">${NAMES[uid]}</span>
+            <span class="badge-dot ${unread ? 'unread' : ''}" title="hasUnread=${unread}"></span>
+            <span class="meta">
+              lastReadAt: ${fmtTs(lra)}
+              <span class="derived">${derivation}</span>
+            </span>
+            <span class="actions">
+              <button class="send" data-act="send" data-uid="${uid}">send</button>
+              <button class="read" data-act="read" data-uid="${uid}">read</button>
+            </span>
+          `;
+          m.appendChild(row);
+        }
+
+        // RTDB tree
+        const tree = document.getElementById('tree');
+        const lines = [];
+        lines.push(
+          `<span class="k">conversations/</span><span class="c">abc/</span>`,
+        );
+        lines.push(`  <span class="k">members/</span>`);
+        for (const uid of MEMBERS) {
+          const lra = state.members[uid].lastReadAt;
+          const isRecentReader = lastReadBy === uid;
+          lines.push(`    <span class="k">${uid}/</span>`);
+          lines.push(
+            `      lastReadAt: <span class="${isRecentReader ? 'd' : 'n'}">${lra || 0}</span>`,
+          );
+        }
+        lines.push(
+          `  <span class="k">messages/</span><span class="c"> ← limitToLast(1) for activity</span>`,
+        );
+        const recent = state.messages.slice(-4);
+        if (recent.length === 0) {
+          lines.push(`    <span class="c">(none)</span>`);
+        } else {
+          for (const msg of recent) {
+            const isLatest = msg === latestMsg();
+            const cls = isLatest ? 's' : 'c';
+            lines.push(
+              `    <span class="${cls}">${msg.id}</span>: { from: <span class="s">"${msg.from}"</span>, sentAt: <span class="n">${msg.sentAt}</span> }${isLatest ? ' <span class="c">← latest</span>' : ''}`,
+            );
+          }
+          if (state.messages.length > 4) {
+            lines.push(
+              `    <span class="c">… ${state.messages.length - 4} earlier</span>`,
+            );
+          }
+        }
+        tree.innerHTML = lines.join('\n');
+
+        // Log
+        const lg = document.getElementById('log');
+        lg.innerHTML =
+          log
+            .slice(0, 30)
+            .map(
+              (e, i) =>
+                `<div class="entry ${i === 0 ? 'latest' : ''}">${e.text}</div>`,
+            )
+            .join('') || '<div class="entry">No actions yet.</div>';
+
+        renderRules();
+      }
+
+      function renderRules() {
+        document.getElementById('actorName').textContent = NAMES[actor];
+        const rows = [];
+        rows.push(`<span class="c"># auth.uid === "${actor}"</span>`);
+        rows.push('');
+        rows.push(`<span class="k">sub 1 — messages (limitToLast 1)</span>`);
+        rows.push(
+          `  path:    conversations/abc/<span class="s">messages</span>`,
+        );
+        rows.push(`  purpose: get latestSentAt + latestSenderId`);
+        rows.push(
+          `  read:    <span class="s">ALLOW</span> <span class="c">// member of conversation</span>`,
+        );
+        rows.push(
+          `  write:   <span class="s">ALLOW</span> <span class="c">// if newData.from === "${actor}" (send)</span>`,
+        );
+        rows.push('');
+        rows.push(`<span class="k">sub 2 — own member node</span>`);
+        rows.push(
+          `  path:    conversations/abc/<span class="s">members/${actor}</span>`,
+        );
+        rows.push(`  purpose: get lastReadAt for "${actor}" only`);
+        rows.push(
+          `  read:    <span class="s">ALLOW</span> <span class="c">// own node</span>`,
+        );
+        rows.push(
+          `  write:   <span class="s">ALLOW</span> <span class="c">// markConversationRead() writes lastReadAt: serverTimestamp()</span>`,
+        );
+        rows.push('');
+        for (const uid of MEMBERS) {
+          if (uid === actor) continue;
+          rows.push(
+            `  members/<span class="k">${uid}</span> <span class="c">(peer — not subscribed, not needed)</span>`,
+          );
+          rows.push(`    read:  <span class="d">DENY</span>`);
+          rows.push(`    write: <span class="d">DENY</span>`);
+        }
+        document.getElementById('rules').innerHTML = rows.join('\n');
+      }
+
+      document.addEventListener('click', (e) => {
+        const t = e.target;
+        if (t.tagName !== 'BUTTON') return;
+        if (t.dataset.act === 'send') send(t.dataset.uid);
+        else if (t.dataset.act === 'read') read(t.dataset.uid);
+      });
+
+      document.querySelectorAll('[data-actor]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          actor = btn.dataset.actor;
+          renderRules();
+        });
+      });
+
+      document.getElementById('resetAll').addEventListener('click', reset);
+
+      renderRules();
+      render();
+    </script>
+  </body>
+</html>

--- a/src/features/messaging-next/interfaces.ts
+++ b/src/features/messaging-next/interfaces.ts
@@ -72,7 +72,10 @@ export type MessageRepository = {
   /**
    * Watch a conversation's activity signal — the latest message timestamp and
    * sender, plus the user's lastReadAt. Consumers derive sort order and unread
-   * state from this single source.
+   * state from this single source. Implementations must invoke onChange once
+   * with the current ConversationActivity immediately after a successful
+   * subscription, then invoke it again whenever any field changes. onError may
+   * be called if the initial snapshot cannot be delivered.
    */
   watchConversationActivity(
     conversationId: ConversationId,

--- a/src/features/messaging-next/interfaces.ts
+++ b/src/features/messaging-next/interfaces.ts
@@ -28,6 +28,17 @@ export type P2PChatEnvelope = {
 /** emoji → userId → true  (RTDB nested-object shape, JSON-safe) */
 export type ReactionMap = Record<string, Record<UserId, true>>;
 
+/**
+ * Per-conversation activity snapshot. Single source for both list-ordering
+ * (latestSentAt) and the unread badge (latestSenderId !== me && latestSentAt > lastReadAt).
+ * Zero values mean "no data yet."
+ */
+export type ConversationActivity = {
+  latestSentAt: number;
+  latestSenderId: UserId | null;
+  lastReadAt: number;
+};
+
 export type MessageRepository = {
   /** Load recent messages for a conversation, newest last. */
   loadMessages(
@@ -59,13 +70,14 @@ export type MessageRepository = {
   ): void | Promise<void>;
 
   /**
-   * Watch whether a user has any unread remote messages in a conversation.
-   * Binary signal — counts are intentionally omitted for now.
+   * Watch a conversation's activity signal — the latest message timestamp and
+   * sender, plus the user's lastReadAt. Consumers derive sort order and unread
+   * state from this single source.
    */
-  watchHasUnread(
+  watchConversationActivity(
     conversationId: ConversationId,
     userId: UserId,
-    onChange: (hasUnread: boolean) => void,
+    onChange: (activity: ConversationActivity) => void,
     onError?: (error: unknown) => void,
   ): (() => void) | Promise<() => void>;
 

--- a/src/features/messaging-next/tests/conversation.actions.test.js
+++ b/src/features/messaging-next/tests/conversation.actions.test.js
@@ -78,6 +78,23 @@ describe('messaging-next conversation actions', () => {
     ]);
   });
 
+  it('removes an optimistic message when the canonical message already arrived', () => {
+    const store = createConversationState();
+    const actions = createConversationActions(store);
+
+    start(actions);
+    actions.addOptimisticMessage({
+      ...message({ id: 'temp-1', senderId: 'me', sentAt: 10 }),
+      status: 'sending',
+    });
+    actions.receiveMessage(message({ id: 'real-1', senderId: 'me', sentAt: 10 }));
+
+    actions.markSent('temp-1', 'real-1');
+
+    expect(store.state.messages.map((msg) => msg.id)).toEqual(['real-1']);
+    expect(store.state.messages[0].status).toBe('sent');
+  });
+
   it('merges loaded history in chronological order without marking it unread', () => {
     const store = createConversationState();
     const actions = createConversationActions(store);

--- a/src/features/messaging-next/use-conversation.ts
+++ b/src/features/messaging-next/use-conversation.ts
@@ -16,7 +16,6 @@ import type {
 import type { ConversationStateStore } from './conversation.state.js';
 import type { ConversationActions } from './conversation.actions.js';
 import { sortMessagesBySentAt } from './message-ordering.js';
-import { recordInteractionByConversation } from '../../stores/contactsStore.js';
 
 type UseConversationOptions = {
   repository: MessageRepository;
@@ -135,7 +134,6 @@ export function useConversation({
     const chatMessage = envelopeToChatMessage(envelope.message, 'private');
     if (chatMessage) {
       actions.receiveMessage(chatMessage);
-      void recordInteractionByConversation(chatMessage.conversationId);
     }
   }
 
@@ -243,7 +241,6 @@ export function useConversation({
       actions.markFailed(tempId);
     } finally {
       actions.setSending(false);
-      void recordInteractionByConversation(conversationId);
     }
   }
 

--- a/src/stores/contactsStore.ts
+++ b/src/stores/contactsStore.ts
@@ -5,10 +5,7 @@ import {
   createContactsLocalStorageRepository,
   createContactsRTDBRepository,
 } from '../storage/contacts/index.js';
-import {
-  resolveContactIdFromDirectConversationId,
-  resolveDirectConversationId,
-} from '../shared/utils/direct-conversation-id.js';
+import { resolveDirectConversationId } from '../shared/utils/direct-conversation-id.js';
 
 type Contact = any;
 
@@ -69,21 +66,6 @@ export function getContactByRoomId(
 
 export function getConversationId(contactId: string): string | null {
   return state.byId[contactId]?.conversationId ?? null;
-}
-
-export function getAllContactsSorted(): Contact[] {
-  return Object.values(state.byId).sort((a: any, b: any) => {
-    const aTime = a?.lastInteractionAt || a?.savedAt || 0;
-    const bTime = b?.lastInteractionAt || b?.savedAt || 0;
-    if (aTime !== bTime) return bTime - aTime;
-    const aName = (a?.contactNickName || '').toLowerCase();
-    const bName = (b?.contactNickName || '').toLowerCase();
-    return aName.localeCompare(bName);
-  });
-}
-
-export function getContactByMostRecentInteraction(): Contact | null {
-  return getAllContactsSorted()[0] ?? null;
 }
 
 export function getContactsIsHydrated(): boolean {
@@ -157,31 +139,6 @@ export async function deleteContact(contactId: string): Promise<boolean> {
     logFailure('deleteContact', error, { contactId });
     return false;
   }
-}
-
-export async function recordInteraction(contactId: string) {
-  if (!contactId || !getLoggedInUserId()) return null;
-  try {
-    const updated = await getRepo().patch(contactId, {
-      lastInteractionAt: Date.now(),
-    });
-    if (updated) setState('byId', contactId, updated);
-    return updated;
-  } catch (error) {
-    logFailure('recordInteraction', error, { contactId });
-    return null;
-  }
-}
-
-export async function recordInteractionByConversation(conversationId: string) {
-  const myUserId = getLoggedInUserId();
-  if (!conversationId || !myUserId) return null;
-  const contactId = resolveContactIdFromDirectConversationId(
-    conversationId,
-    myUserId,
-  );
-  if (!contactId) return null;
-  return recordInteraction(contactId);
 }
 
 export async function handleHangUp(contactUserId: string, roomId: string) {


### PR DESCRIPTION
Stacks on #515.

## Summary
- Replaces `watchHasUnread` with `watchConversationActivity`, exposing `{ latestSentAt, latestSenderId, lastReadAt }`. Sort key and unread badge now derive from one source.
- Fixes contacts-list ordering bug: an incoming unread message was outranking a more-recent outgoing message because `recordInteractionByConversation` stamped `lastInteractionAt = Date.now()` at the moment the watcher noticed, not when the message was sent. Sort now uses the message's actual `sentAt`.
- Drops `recordInteraction` / `recordInteractionByConversation` and their two call sites (send + P2P receive). Drops unused `getAllContactsSorted` / `getContactByMostRecentInteraction`.

## Deferred
- P2P messages no longer affect sort order (acceptable — P2P is ephemeral, lost on reload anyway).
- No optimistic `latestSentAt` bump on send — kept the refactor scope tight.
- `lastInteractionAt` schema field stays for now; just unused going forward.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` on impacted files (10/10 pass)
- [x] Manual: send to contact B, have contact A message you. B stays above A until A's `sentAt` actually exceeds B's.
- [x] Manual: unread dot appears on incoming, clears on opening conversation, survives reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated unread message detection to derive state from conversation activity rather than separate tracking mechanisms, improving consistency with message timestamps.
  * Refactored contact sorting to prioritize latest message activity timestamps, providing more relevant ordering.

* **Documentation**
  * Updated contract documentation to clarify responsibility boundaries between contacts and messaging systems.
  * Added reference documentation for activity-based unread computation model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KristinnRoach/HangVidU/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->