### PR TITLE
Realtime signaling on a Cloudflare Durable Object; promote src/realtime/ layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ VITE_YOUTUBE_API_KEY=your_youtube_api_key_here
 # PWA
 # Set to 0 to disable PWA registration/update handling.
 VITE_ENABLE_PWA=1
+
+# Realtime signaling (Cloudflare Durable Object worker)
+# ws://localhost:8787 for `wrangler dev`; wss://<your-worker-domain> in prod.
+VITE_SIGNALING_URL=ws://localhost:8787
+# 'do' = Durable Object (Cloudflare), 'rtdb' = legacy Firebase RTDB fallback.
+VITE_SIGNALING_BACKEND=do

--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,8 @@ playwright/.cache/
 .vitest-attachments/
 .vite-plugin-mkcert/
 
-# Go executables draft
-go-server/
-
-react-sandbox/
-refactor-draft/
-
+# Generated when running playgrounds
+playgrounds/boundary-imports.json
 
 # Notes / examples / drafts 
 reference-examples/
@@ -43,9 +39,6 @@ trash/
 # Temporary files
 tmp/
 temp/
-
-# Build exectuables to run local server (possibly add later)
-go-server/executables/
 
 # Below are some default gitignore entries from Vite template that might be unecessary (TODO in a cleanup session)
 
@@ -119,7 +112,10 @@ docs/misc/
 docs/WIP_Architecture/REFERENCE_WebDevSimplified.md
 docs/WIP_Architecture/references/solidjs.llms.txt
 
+# Scripts
 scripts/migrate-usersbyemail-display-name-to-user-name.js
+
+# Git worktrees
 .worktrees/
 
 **/OLD_*.js

--- a/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
+++ b/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
@@ -20,7 +20,7 @@ This establishes the **realtime vs persistence** split:
 | Auth seam | `workers/signaling/src/auth.ts` | `authenticate(request, env) → { userId }` | leak provider choice past return type |
 | Durable Object | `workers/signaling/src/signaling-room.ts` | Presence + relay fan-out | parse SDP, persist, know channels |
 | Transport | `src/realtime/signaling-socket.ts` | Connect / reconnect / heartbeat | hold signaling semantics |
-| Adapter | `src/features/signaling/p2p/do-room-signaling.ts` | Map `P2PRoomSignaling` ↔ protocol | know transport internals |
+| Adapter | `src/realtime/signaling/do-room-signaling.ts` | Map `P2PRoomSignaling` ↔ protocol | know transport internals |
 
 The DO is a **relay**: it holds only presence (who's joined). SDP/ICE are
 forwarded peer-to-peer and discarded. `media-sync` later = a new `channel`
@@ -33,10 +33,10 @@ value in the protocol — no DO or structural change.
 
 ## Auth
 
-Slice 1 verifies a Firebase ID token in `authenticate()`. The return type is
-provider-agnostic (`{ userId }`), so migrating off Firebase later replaces one
-file. Signature verification is a documented TODO (see auth.ts) — acceptable
-for the prototype, must be closed before real users.
+`authenticate()` verifies the Firebase ID token's RS256 signature (Google JWKS,
+WebCrypto) plus claims (aud/iss/exp/iat/sub). Return type is provider-agnostic
+(`Identity | null`), so migrating off Firebase later replaces only this file's
+internals. Production-ready.
 
 ## Checklist
 
@@ -46,8 +46,8 @@ for the prototype, must be closed before real users.
 - [x] 4. `authenticate()` seam — Firebase ID token, **RS256 signature verified** against Google's JWKS (WebCrypto, keys cached per Cache-Control) + claim checks (aud/iss/exp/iat/sub). Provider-agnostic `{ userId }` return.
 - [x] 5. Worker `index.ts` — auth → `getByName(roomId)` → WS handoff
 - [x] 6. `src/realtime/signaling-socket.ts` — reconnecting WS client (+ `src/realtime/protocol.ts` re-export)
-- [x] 7. `src/features/signaling/p2p/do-room-signaling.ts` — implements `P2PRoomSignaling` over the socket
-- [x] 8. Factory in `features/signaling/index.js` (`createRoomSignaling`) — `VITE_SIGNALING_BACKEND` flag, **default `do`**; wired into `call-handshake.tsx`. Client `pnpm ts` clean.
+- [x] 7. `src/realtime/signaling/do-room-signaling.ts` — implements `P2PRoomSignaling` over the socket
+- [x] 8. Factory in `src/realtime/signaling/index.js` (barrel: `src/realtime/index.ts`) (`createRoomSignaling`) — `VITE_SIGNALING_BACKEND` flag, **default `do`**; wired into `call-handshake.tsx`. Client `pnpm ts` clean.
 - [x] 9. Verify — manual browser call ✅ (real 2-peer call through the DO). Automated guards:
   - DO relay/presence test (`test/signaling-room.test.ts`)
   - Worker routing + auth test (`test/worker.test.ts`): 404 / 426 / 401 (missing, expired, bad-aud, tampered-signature) / 101 valid signed token (signs with a generated keypair + stubs the JWKS endpoint)

--- a/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
+++ b/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
@@ -45,10 +45,25 @@ for the prototype, must be closed before real users.
 - [x] 3. `SignalingRoom` DO — presence + relay over hibernatable WebSockets
 - [x] 4. `authenticate()` seam — Firebase ID token (claims-only; signature TODO), provider-agnostic return
 - [x] 5. Worker `index.ts` — auth → `getByName(roomId)` → WS handoff
-- [ ] 6. `src/realtime/signaling-socket.ts` — reconnecting WS client
-- [ ] 7. `src/features/signaling/p2p/do-room-signaling.ts` — implement the port
-- [ ] 8. Factory/flag in `features/signaling/p2p/index.js` — RTDB default, flag → DO
-- [ ] 9. Verify — DO tests (`@cloudflare/vitest-pool-workers`) + Chromium E2E call
+- [x] 6. `src/realtime/signaling-socket.ts` — reconnecting WS client (+ `src/realtime/protocol.ts` re-export)
+- [x] 7. `src/features/signaling/p2p/do-room-signaling.ts` — implements `P2PRoomSignaling` over the socket
+- [x] 8. Factory in `features/signaling/index.js` (`createRoomSignaling`) — `VITE_SIGNALING_BACKEND` flag, **default `do`**; wired into `call-handshake.tsx`. Client `pnpm ts` clean.
+- [ ] 9. Verify — **manual browser test first (in progress)**, then DO/E2E tests (deferred until manual pass)
+
+## Manual verification (run locally)
+
+1. `cd workers/signaling && pnpm dev` — wrangler dev serves the DO at `ws://localhost:8787`.
+2. In repo root: `pnpm dev:local` (https://localhost:5173).
+3. `VITE_SIGNALING_BACKEND=do` and `VITE_SIGNALING_URL=ws://localhost:8787` are already in `.env.development`.
+4. Start a call between two logged-in sessions → signaling now flows through the DO, not RTDB.
+
+Flip `VITE_SIGNALING_BACKEND=rtdb` to fall back instantly if needed.
+
+Notes:
+- Auth: client sends its real Firebase ID token as the `bearer` subprotocol; the
+  worker validates `aud`/`iss`/`exp` against `vidu-aae11` (signature still TODO).
+- `localhost` is mixed-content exempt, so `ws://` works from the https dev page.
+- Client changes left uncommitted pending your manual pass.
 
 ## Migration path (preserved, no work now)
 

--- a/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
+++ b/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
@@ -48,7 +48,14 @@ for the prototype, must be closed before real users.
 - [x] 6. `src/realtime/signaling-socket.ts` — reconnecting WS client (+ `src/realtime/protocol.ts` re-export)
 - [x] 7. `src/features/signaling/p2p/do-room-signaling.ts` — implements `P2PRoomSignaling` over the socket
 - [x] 8. Factory in `features/signaling/index.js` (`createRoomSignaling`) — `VITE_SIGNALING_BACKEND` flag, **default `do`**; wired into `call-handshake.tsx`. Client `pnpm ts` clean.
-- [ ] 9. Verify — **manual browser test first (in progress)**, then DO/E2E tests (deferred until manual pass)
+- [x] 9. Verify — manual browser call ✅ (real 2-peer call through the DO). Automated guards:
+  - DO relay/presence test (`test/signaling-room.test.ts`)
+  - Worker routing + auth test (`test/worker.test.ts`): 404 / 426 / 401 (missing, expired, bad-aud) / 101 valid
+  - Client adapter mapping test (`do-room-signaling.test.js`): join/re-join, presence, offer/answer/ICE relay, peer+channel routing, cleanup
+  - Deferred: full Chromium 2-peer E2E (covered manually for now)
+
+**Auth refactor:** `authenticate()` now returns `Identity | null` (no throwing) —
+cleaner request-path guard and avoids async-throw noise in the test runner.
 
 ## Manual verification (run locally)
 

--- a/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
+++ b/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
@@ -43,14 +43,14 @@ for the prototype, must be closed before real users.
 - [x] 1. Scaffold `workers/signaling/` (package.json, wrangler.jsonc, tsconfig, .gitignore) — deps installed standalone (`--ignore-workspace`), `pnpm typecheck` clean
 - [x] 2. `shared/signaling/protocol.ts` — wire types
 - [x] 3. `SignalingRoom` DO — presence + relay over hibernatable WebSockets
-- [x] 4. `authenticate()` seam — Firebase ID token (claims-only; signature TODO), provider-agnostic return
+- [x] 4. `authenticate()` seam — Firebase ID token, **RS256 signature verified** against Google's JWKS (WebCrypto, keys cached per Cache-Control) + claim checks (aud/iss/exp/iat/sub). Provider-agnostic `{ userId }` return.
 - [x] 5. Worker `index.ts` — auth → `getByName(roomId)` → WS handoff
 - [x] 6. `src/realtime/signaling-socket.ts` — reconnecting WS client (+ `src/realtime/protocol.ts` re-export)
 - [x] 7. `src/features/signaling/p2p/do-room-signaling.ts` — implements `P2PRoomSignaling` over the socket
 - [x] 8. Factory in `features/signaling/index.js` (`createRoomSignaling`) — `VITE_SIGNALING_BACKEND` flag, **default `do`**; wired into `call-handshake.tsx`. Client `pnpm ts` clean.
 - [x] 9. Verify — manual browser call ✅ (real 2-peer call through the DO). Automated guards:
   - DO relay/presence test (`test/signaling-room.test.ts`)
-  - Worker routing + auth test (`test/worker.test.ts`): 404 / 426 / 401 (missing, expired, bad-aud) / 101 valid
+  - Worker routing + auth test (`test/worker.test.ts`): 404 / 426 / 401 (missing, expired, bad-aud, tampered-signature) / 101 valid signed token (signs with a generated keypair + stubs the JWKS endpoint)
   - Client adapter mapping test (`do-room-signaling.test.js`): join/re-join, presence, offer/answer/ICE relay, peer+channel routing, cleanup
   - Deferred: full Chromium 2-peer E2E (covered manually for now)
 
@@ -68,9 +68,17 @@ Flip `VITE_SIGNALING_BACKEND=rtdb` to fall back instantly if needed.
 
 Notes:
 - Auth: client sends its real Firebase ID token as the `bearer` subprotocol; the
-  worker validates `aud`/`iss`/`exp` against `vidu-aae11` (signature still TODO).
+  worker verifies the RS256 signature (Google JWKS) + claims against `vidu-aae11`.
+  Production-ready. Switching auth provider later = replace the verify internals
+  in `auth.ts`; the `authenticate()` seam and `{ userId }` contract stay.
 - `localhost` is mixed-content exempt, so `ws://` works from the https dev page.
-- Client changes left uncommitted pending your manual pass.
+
+## Deploy
+
+- `pnpm deploy:do` (wrangler deploy). Set `FIREBASE_PROJECT_ID` var (already
+  `vidu-aae11` in `wrangler.jsonc`) and point `VITE_SIGNALING_URL` at the prod
+  `wss://` worker URL for the client build.
+- Root scripts: `pnpm dev:do` / `deploy:do` / `test:do`.
 
 ## Migration path (preserved, no work now)
 

--- a/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
+++ b/docs/WIP_Architecture/SIGNALING_DO_SLICE1.md
@@ -1,0 +1,57 @@
+# Slice 1 — WebRTC Room Signaling on a Durable Object
+
+## Goal
+
+Move realtime room signaling (SDP / ICE / presence) off RTDB onto a Cloudflare
+Durable Object, swappable behind the existing `P2PRoomSignaling` port. RTDB
+adapter stays as the fallback. Persistence (contacts, messages, user) stays on
+RTDB — this slice touches realtime only.
+
+This establishes the **realtime vs persistence** split:
+- `src/infra/firebase-rtdb.js` + `src/storage/**` → persistence (RTDB)
+- `workers/signaling/` + `src/realtime/**` → ephemeral coordination (Durable Objects)
+
+## Boundaries
+
+| Layer | Path | Responsibility | Must NOT |
+|-------|------|----------------|----------|
+| Contract | `shared/signaling/protocol.ts` | Wire message types, shared by client + worker | depend on RTDB, Firebase, or DOM |
+| Worker router | `workers/signaling/src/index.ts` | Authenticate, map `roomId → DO`, hand off WS | hold signaling logic |
+| Auth seam | `workers/signaling/src/auth.ts` | `authenticate(request, env) → { userId }` | leak provider choice past return type |
+| Durable Object | `workers/signaling/src/signaling-room.ts` | Presence + relay fan-out | parse SDP, persist, know channels |
+| Transport | `src/realtime/signaling-socket.ts` | Connect / reconnect / heartbeat | hold signaling semantics |
+| Adapter | `src/features/signaling/p2p/do-room-signaling.ts` | Map `P2PRoomSignaling` ↔ protocol | know transport internals |
+
+The DO is a **relay**: it holds only presence (who's joined). SDP/ICE are
+forwarded peer-to-peer and discarded. `media-sync` later = a new `channel`
+value in the protocol — no DO or structural change.
+
+## Stable contracts (do not churn)
+
+- Client: `P2PRoomSignaling` (`@kidlib/p2p`) — unchanged.
+- Wire: `protocol.ts` envelope — `join` / `leave` / `relay` ↔ `peers` / `relay` / `error`.
+
+## Auth
+
+Slice 1 verifies a Firebase ID token in `authenticate()`. The return type is
+provider-agnostic (`{ userId }`), so migrating off Firebase later replaces one
+file. Signature verification is a documented TODO (see auth.ts) — acceptable
+for the prototype, must be closed before real users.
+
+## Checklist
+
+- [x] 1. Scaffold `workers/signaling/` (package.json, wrangler.jsonc, tsconfig, .gitignore) — deps installed standalone (`--ignore-workspace`), `pnpm typecheck` clean
+- [x] 2. `shared/signaling/protocol.ts` — wire types
+- [x] 3. `SignalingRoom` DO — presence + relay over hibernatable WebSockets
+- [x] 4. `authenticate()` seam — Firebase ID token (claims-only; signature TODO), provider-agnostic return
+- [x] 5. Worker `index.ts` — auth → `getByName(roomId)` → WS handoff
+- [ ] 6. `src/realtime/signaling-socket.ts` — reconnecting WS client
+- [ ] 7. `src/features/signaling/p2p/do-room-signaling.ts` — implement the port
+- [ ] 8. Factory/flag in `features/signaling/p2p/index.js` — RTDB default, flag → DO
+- [ ] 9. Verify — DO tests (`@cloudflare/vitest-pool-workers`) + Chromium E2E call
+
+## Migration path (preserved, no work now)
+
+RTDB + DO adapters coexist behind the flag → cut over per environment → delete
+`firebase-room-signaling.js` once proven. Call-invite mailbox + media-sync are
+later slices reusing `src/realtime/` transport and this protocol envelope.

--- a/docs/WIP_Architecture/STRUCTURE.md
+++ b/docs/WIP_Architecture/STRUCTURE.md
@@ -16,6 +16,13 @@ The two foundational layers:
 Rule of thumb for placing a util: if it has no app/domain knowledge and no
 imports outside `lib`, it belongs in `src/lib/utils/`; otherwise `src/shared/utils/`.
 
+Two sibling infrastructure layers sit below features, splitting state by lifetime:
+
+- **`src/storage/`** — persistence (durable data: contacts, messages, user). Backed by RTDB.
+- **`src/realtime/`** — ephemeral coordination (WebRTC signaling; later media-sync). Backed by a Cloudflare Durable Object (`workers/signaling/`). Holds the DO transport, wire protocol, and `P2PRoomSignaling` adapters behind one barrel.
+
+Both are backend-agnostic behind their ports; features import them (realtime directly, storage via `stores`).
+
 ## Module layout
 
 - Every module has one barrel: `src/<module>/index.js` (or `index.ts`).

--- a/docs/WIP_Architecture/lint/boundaries/BOUNDARY_MAP.md
+++ b/docs/WIP_Architecture/lint/boundaries/BOUNDARY_MAP.md
@@ -10,6 +10,7 @@ Source of truth is `eslint.boundaries.config.js`. This doc mirrors it.
 - `src/features/<name>/**` -> `feature(<name>)`
 - `src/stores/**` -> `stores`
 - `src/storage/**` -> `storage`
+- `src/realtime/**` -> `realtime`
 - `src/infra/**` -> `infra`
 - `src/shared/*`, `src/shared/events/**`, `src/shared/i18n/**`, `src/shared/utils/**` -> `shared`
 - `src/lib/**` -> `lib`
@@ -23,9 +24,10 @@ Each layer may import from itself plus:
 | from         | may also import                                          |
 | ------------ | -------------------------------------------------------- |
 | `app`        | auth, stores, feature, components, shared, lib           |
-| `feature(X)` | auth, shared, lib, components, infra, stores, feature(X) |
+| `feature(X)` | auth, shared, lib, components, infra, stores, realtime, feature(X) |
 | `stores`     | auth, shared, lib, storage, infra, feature               |
 | `storage`    | shared, lib, infra                                       |
+| `realtime`   | shared, lib, infra, auth                                 |
 | `auth`       | shared, lib, infra, components                           |
 | `components` | auth, shared, lib                                        |
 | `infra`      | lib                                                      |
@@ -40,6 +42,9 @@ Each layer may import from itself plus:
 - `shared` is app-aware cross-cutting code — may import only `shared` and `lib`
   (plus explicit temporary feature exceptions, currently none).
 - `infra` is the external-system bootstrap layer (vendor SDKs + env config).
+- `storage` (persistence) and `realtime` (ephemeral coordination — WebRTC
+  signaling, later media-sync) are sibling infrastructure layers below
+  features. `realtime` also imports `auth` (token for the signaling worker).
 - `app` is the shell/lifecycle root. UI bridges live here.
 - `src/components/` is the Solid UI composition root. Components never import
   `app` — the arrow points the other way.

--- a/eslint.boundaries.config.js
+++ b/eslint.boundaries.config.js
@@ -81,10 +81,11 @@ overrides.push(
             { type: 'components' },
             { type: 'infra' },
             { type: 'stores' },
+            { type: 'realtime' },
           ],
         },
         message:
-          'Features may import from auth, shared, lib, components, infra, stores, or other features.',
+          'Features may import from auth, shared, lib, components, infra, stores, realtime, or other features.',
       },
     ],
   ),
@@ -164,6 +165,28 @@ overrides.push(
         },
         message:
           'Storage is the persistence layer — may only import from storage, shared, lib, and infra.',
+      },
+    ],
+  ),
+);
+
+overrides.push(
+  dependencyRule(
+    ['src/realtime/*.{js,jsx,ts,tsx}', 'src/realtime/**/*.{js,jsx,ts,tsx}'],
+    [
+      {
+        from: { type: 'realtime' },
+        allow: {
+          to: [
+            { type: 'realtime' },
+            { type: 'shared' },
+            { type: 'lib' },
+            { type: 'infra' },
+            { type: 'auth' },
+          ],
+        },
+        message:
+          'Realtime is the ephemeral-coordination layer (sibling of storage) — may only import from realtime, shared, lib, infra, and auth.',
       },
     ],
   ),
@@ -303,6 +326,14 @@ export default [
           pattern: [
             'src/storage/*.{js,jsx,ts,tsx}',
             'src/storage/**/*.{js,jsx,ts,tsx}',
+          ],
+        },
+        {
+          type: 'realtime',
+          mode: 'full',
+          pattern: [
+            'src/realtime/*.{js,jsx,ts,tsx}',
+            'src/realtime/**/*.{js,jsx,ts,tsx}',
           ],
         },
         {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "dev": "pnpm kill:silent && concurrently -k -n vite,tunnel \"vite\" \"cloudflared --no-autoupdate tunnel --config /dev/null --url https://localhost:5173 --no-tls-verify run vidu-dev\"",
     "dev:local": "vite",
+    "dev:do": "pnpm -C workers/signaling run dev",
+    "deploy:do": "pnpm -C workers/signaling run deploy",
+    "test:do": "pnpm -C workers/signaling run test",
     "debug:edge": "zsh scripts/debug/launch-pwa-edge.sh",
     "worktree": "scripts/git-worktree.sh",
     "delete:user": "node scripts/delete-user-account.js",

--- a/playgrounds/boundary-imports.json
+++ b/playgrounds/boundary-imports.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-29T00:55:31.840Z",
+  "generatedAt": "2026-05-29T10:25:11.730Z",
   "scannedFiles": 231,
   "importsScanned": 598,
   "importsResolved": 435,

--- a/shared/signaling/protocol.ts
+++ b/shared/signaling/protocol.ts
@@ -38,6 +38,7 @@ export function isClientMessage(value: unknown): value is ClientMessage {
     case 'relay':
       return (
         typeof m.to === 'string' &&
+        m.to.length > 0 &&
         (m.channel === 'sdp' || m.channel === 'ice') &&
         'data' in m
       );

--- a/shared/signaling/protocol.ts
+++ b/shared/signaling/protocol.ts
@@ -1,0 +1,34 @@
+/**
+ * Signaling wire protocol — single source of truth shared by the client
+ * transport (`src/realtime/`) and the Durable Object worker (`workers/signaling/`).
+ *
+ * Transport-agnostic and side-agnostic: no RTDB, Firebase, DOM, or Workers types.
+ * The Durable Object is a dumb relay — it understands `join`/`leave`/`relay`
+ * for presence and addressed fan-out, and nothing about SDP/ICE contents.
+ *
+ * Extending later (e.g. media-playback-sync) = add a `RelayChannel` value.
+ * Do not add channel-specific message shapes here; keep `relay` generic.
+ */
+
+export type PeerId = string;
+
+/** Payload bucket for relayed messages. Add values to extend; never reshape. */
+export type RelayChannel = 'sdp' | 'ice';
+
+/** Client → Durable Object. */
+export type ClientMessage =
+  | { t: 'join'; peerId: PeerId }
+  | { t: 'leave' }
+  | { t: 'relay'; to: PeerId; channel: RelayChannel; data: unknown };
+
+/** Durable Object → client. */
+export type ServerMessage =
+  | { t: 'peers'; peers: PeerId[] }
+  | { t: 'relay'; from: PeerId; channel: RelayChannel; data: unknown }
+  | { t: 'error'; message: string };
+
+export function isClientMessage(value: unknown): value is ClientMessage {
+  if (!value || typeof value !== 'object') return false;
+  const t = (value as { t?: unknown }).t;
+  return t === 'join' || t === 'leave' || t === 'relay';
+}

--- a/shared/signaling/protocol.ts
+++ b/shared/signaling/protocol.ts
@@ -29,6 +29,19 @@ export type ServerMessage =
 
 export function isClientMessage(value: unknown): value is ClientMessage {
   if (!value || typeof value !== 'object') return false;
-  const t = (value as { t?: unknown }).t;
-  return t === 'join' || t === 'leave' || t === 'relay';
+  const m = value as Record<string, unknown>;
+  switch (m.t) {
+    case 'join':
+      return typeof m.peerId === 'string' && m.peerId.length > 0;
+    case 'leave':
+      return true;
+    case 'relay':
+      return (
+        typeof m.to === 'string' &&
+        (m.channel === 'sdp' || m.channel === 'ice') &&
+        'data' in m
+      );
+    default:
+      return false;
+  }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -21,6 +21,10 @@ interface ImportMetaEnv {
   // Application
   readonly VITE_ENABLE_PWA: string;
   readonly VITE_SENTRY_DSN: string;
+
+  // Realtime signaling (Cloudflare Durable Object worker)
+  readonly VITE_SIGNALING_URL: string;
+  readonly VITE_SIGNALING_BACKEND: 'do' | 'rtdb';
 }
 
 interface ImportMeta {

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -9,7 +9,7 @@ import {
 } from 'solid-js';
 
 import { useP2PContext } from '../../shared/p2p-context.js';
-import { createRoomSignaling } from '../signaling/index.js';
+import { createRoomSignaling } from '../../realtime/index.js';
 import type { CallInvite } from './model/call-schema.js';
 import { CallHandshakeController } from './call-handshake-controller.js';
 import type {

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -9,7 +9,7 @@ import {
 } from 'solid-js';
 
 import { useP2PContext } from '../../shared/p2p-context.js';
-import { createFirebaseRoomSignaling } from '../signaling/p2p/firebase-room-signaling.js';
+import { createRoomSignaling } from '../signaling/index.js';
 import type { CallInvite } from './model/call-schema.js';
 import { CallHandshakeController } from './call-handshake-controller.js';
 import type {
@@ -41,7 +41,7 @@ export function CallHandshakeProvider(props: ParentProps) {
 
   const controller = new CallHandshakeController({
     p2p,
-    createSignaling: createFirebaseRoomSignaling,
+    createSignaling: createRoomSignaling,
     onStateChange: setHandshakeState,
     onCalleeBusy: setIsCalleeBusy,
   });

--- a/src/features/signaling/index.js
+++ b/src/features/signaling/index.js
@@ -1,4 +1,28 @@
-// src/features/call/signaling/index.js
+// src/features/signaling/index.js
+//
+// Room-signaling factory. Selects the realtime backend behind the stable
+// `@kidlib/p2p` `P2PRoomSignaling` port:
+//   - 'do'   → Cloudflare Durable Object worker (default)
+//   - 'rtdb' → legacy Firebase RTDB (fallback during migration)
+//
+// Controlled by VITE_SIGNALING_BACKEND. Both adapters are kept in tree until
+// the DO path is verified in production; then the RTDB adapter is removed.
 
-// Firebase signaling adapter that bridges @kidlib/p2p to Firebase RTDB.
-export { createFirebaseRoomSignaling } from './p2p/firebase-room-signaling.js';
+import { createFirebaseRoomSignaling } from './p2p/firebase-room-signaling.js';
+import { createDoRoomSignaling } from './p2p/do-room-signaling.js';
+
+export { createFirebaseRoomSignaling, createDoRoomSignaling };
+
+/** @typedef {import('@kidlib/p2p').CreateRoomSignalingOptions} CreateRoomSignalingOptions */
+/** @typedef {import('@kidlib/p2p').P2PRoomSignaling} P2PRoomSignaling */
+
+/**
+ * @param {CreateRoomSignalingOptions} options
+ * @returns {P2PRoomSignaling}
+ */
+export function createRoomSignaling(options) {
+  const backend = import.meta.env.VITE_SIGNALING_BACKEND ?? 'do';
+  return backend === 'rtdb'
+    ? createFirebaseRoomSignaling(options)
+    : createDoRoomSignaling(options);
+}

--- a/src/features/signaling/p2p/do-room-signaling.test.js
+++ b/src/features/signaling/p2p/do-room-signaling.test.js
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- mock the transport so no real WebSocket is opened ---
+let socket;
+
+vi.mock('../../../realtime/signaling-socket', () => ({
+  createSignalingSocket: vi.fn(() => {
+    const messageHandlers = new Set();
+    const openHandlers = new Set();
+    socket = {
+      sent: [],
+      emit: (m) => messageHandlers.forEach((h) => h(m)),
+      open: () => openHandlers.forEach((h) => h()),
+      closed: false,
+    };
+    return {
+      send: (m) => socket.sent.push(m),
+      onMessage: (h) => {
+        messageHandlers.add(h);
+        return () => messageHandlers.delete(h);
+      },
+      onOpen: (h) => {
+        openHandlers.add(h);
+        return () => openHandlers.delete(h);
+      },
+      close: () => {
+        socket.closed = true;
+      },
+    };
+  }),
+}));
+
+vi.mock('../../../auth/index.js', () => ({
+  getLoggedInUserToken: vi.fn(async () => 'test-token'),
+}));
+
+const { createDoRoomSignaling } = await import('./do-room-signaling.ts');
+
+describe('createDoRoomSignaling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends join and re-joins on reconnect', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    signaling.join('peer-a');
+    expect(socket.sent).toEqual([{ t: 'join', peerId: 'peer-a' }]);
+
+    socket.sent.length = 0;
+    socket.open(); // simulate (re)connect
+    expect(socket.sent).toEqual([{ t: 'join', peerId: 'peer-a' }]);
+  });
+
+  it('forwards presence to onPeers subscribers', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    const seen = [];
+    signaling.onPeers((peers) => seen.push(peers));
+
+    socket.emit({ t: 'peers', peers: ['peer-a', 'peer-b'] });
+    expect(seen).toEqual([['peer-a', 'peer-b']]);
+  });
+
+  it('maps offer/answer/ICE onto addressed relay messages', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    const peer = signaling.createPeerSignaling({
+      localPeerId: 'peer-a',
+      remotePeerId: 'peer-b',
+    });
+
+    peer.sendOffer({ type: 'offer', sdp: 'x' });
+    peer.sendCandidate({ candidate: 'c' });
+
+    expect(socket.sent).toEqual([
+      {
+        t: 'relay',
+        to: 'peer-b',
+        channel: 'sdp',
+        data: { kind: 'offer', payload: { type: 'offer', sdp: 'x' } },
+      },
+      { t: 'relay', to: 'peer-b', channel: 'ice', data: { candidate: 'c' } },
+    ]);
+  });
+
+  it('routes inbound relays by peer + channel, discriminating offer vs answer', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    const peer = signaling.createPeerSignaling({
+      localPeerId: 'peer-a',
+      remotePeerId: 'peer-b',
+    });
+
+    const offers = [];
+    const answers = [];
+    const candidates = [];
+    peer.onOffer((o) => offers.push(o));
+    peer.onAnswer((a) => answers.push(a));
+    peer.onRemoteCandidate((c) => candidates.push(c));
+
+    const relay = (channel, data, from = 'peer-b') => ({
+      t: 'relay',
+      from,
+      channel,
+      data,
+    });
+
+    socket.emit(relay('sdp', { kind: 'answer', payload: { type: 'answer' } }));
+    socket.emit(relay('sdp', { kind: 'offer', payload: { type: 'offer' } }));
+    socket.emit(relay('ice', { candidate: 'c1' }));
+    // a different peer's traffic must not leak into this pair
+    socket.emit(relay('ice', { candidate: 'nope' }, 'peer-z'));
+
+    expect(offers).toEqual([{ type: 'offer' }]);
+    expect(answers).toEqual([{ type: 'answer' }]);
+    expect(candidates).toEqual([{ candidate: 'c1' }]);
+  });
+
+  it('closes the socket on cleanup', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    signaling.join('peer-a');
+    socket.sent.length = 0;
+
+    signaling.cleanupSignaling();
+    expect(socket.sent).toEqual([{ t: 'leave' }]);
+    expect(socket.closed).toBe(true);
+  });
+});

--- a/src/features/signaling/p2p/do-room-signaling.ts
+++ b/src/features/signaling/p2p/do-room-signaling.ts
@@ -1,0 +1,151 @@
+import type {
+  CreateRoomSignalingOptions,
+  P2PRoomPeerSignalingOptions,
+  P2PRoomSignaling,
+  RtcSignalingSource,
+} from '@kidlib/p2p';
+import { getLoggedInUserToken } from '../../../auth/index.js';
+import {
+  createSignalingSocket,
+  type SignalingSocket,
+} from '../../../realtime/signaling-socket';
+import type { RelayChannel, ServerMessage } from '../../../realtime/protocol';
+
+/**
+ * Durable Object `P2PRoomSignaling` — drop-in replacement for
+ * `createFirebaseRoomSignaling`. Talks to the signaling worker over one
+ * WebSocket per room and maps the port's offer/answer/ICE calls onto the
+ * generic `relay` protocol. The DO is a dumb relay; the SDP offer-vs-answer
+ * distinction is an adapter-owned convention carried in the relay payload.
+ */
+
+/** Offer and answer share the `sdp` channel; this disambiguates them. */
+interface SdpEnvelope {
+  kind: 'offer' | 'answer';
+  payload: RTCSessionDescriptionInit;
+}
+
+interface RelaySubscription {
+  from: string;
+  channel: RelayChannel;
+  handler: (data: unknown) => void;
+}
+
+function signalingUrl(roomId: string): string {
+  const base = (import.meta.env.VITE_SIGNALING_URL ?? 'ws://localhost:8787')
+    .trim()
+    .replace(/\/$/, '');
+  return `${base}/rooms/${encodeURIComponent(roomId)}/signal`;
+}
+
+export function createDoRoomSignaling({
+  roomId,
+}: CreateRoomSignalingOptions): P2PRoomSignaling {
+  if (!roomId) throw new Error('createDoRoomSignaling: roomId is required');
+
+  const socket: SignalingSocket = createSignalingSocket({
+    url: signalingUrl(roomId),
+    getProtocols: async () => {
+      const token = await getLoggedInUserToken();
+      return token ? ['bearer', token] : [];
+    },
+  });
+
+  let joinedPeerId: string | null = null;
+  const peersHandlers = new Set<(peerIds: string[]) => void>();
+  const relaySubs = new Set<RelaySubscription>();
+
+  socket.onMessage((message: ServerMessage) => {
+    switch (message.t) {
+      case 'peers':
+        peersHandlers.forEach((h) => h(message.peers));
+        return;
+      case 'relay':
+        for (const sub of relaySubs) {
+          if (sub.from === message.from && sub.channel === message.channel) {
+            sub.handler(message.data);
+          }
+        }
+        return;
+      case 'error':
+        console.warn('[signaling] worker error:', message.message);
+        return;
+    }
+  });
+
+  // Restore presence after every (re)connect.
+  socket.onOpen(() => {
+    if (joinedPeerId) socket.send({ t: 'join', peerId: joinedPeerId });
+  });
+
+  function subscribeRelay(
+    from: string,
+    channel: RelayChannel,
+    handler: (data: unknown) => void,
+  ): () => void {
+    const sub: RelaySubscription = { from, channel, handler };
+    relaySubs.add(sub);
+    return () => relaySubs.delete(sub);
+  }
+
+  return {
+    join(peerId) {
+      joinedPeerId = peerId;
+      socket.send({ t: 'join', peerId });
+    },
+
+    leave(peerId) {
+      socket.send({ t: 'leave' });
+      if (joinedPeerId === peerId) joinedPeerId = null;
+    },
+
+    onPeers(callback) {
+      peersHandlers.add(callback);
+      return () => peersHandlers.delete(callback);
+    },
+
+    createPeerSignaling({
+      remotePeerId,
+    }: P2PRoomPeerSignalingOptions): RtcSignalingSource {
+      const sendRelay = (channel: RelayChannel, data: unknown) =>
+        socket.send({ t: 'relay', to: remotePeerId, channel, data });
+
+      return {
+        sendOffer: (offer) =>
+          sendRelay('sdp', { kind: 'offer', payload: offer } as SdpEnvelope),
+        sendAnswer: (answer) =>
+          sendRelay('sdp', { kind: 'answer', payload: answer } as SdpEnvelope),
+
+        onOffer(callback) {
+          return subscribeRelay(remotePeerId, 'sdp', (data) => {
+            const env = data as SdpEnvelope;
+            if (env?.kind === 'offer') callback(env.payload);
+          });
+        },
+        onAnswer(callback) {
+          return subscribeRelay(remotePeerId, 'sdp', (data) => {
+            const env = data as SdpEnvelope;
+            if (env?.kind === 'answer') callback(env.payload);
+          });
+        },
+
+        sendCandidate: (candidate) => sendRelay('ice', candidate),
+        onRemoteCandidate(callback) {
+          return subscribeRelay(remotePeerId, 'ice', (data) => {
+            if (data) callback(data as RTCIceCandidateInit);
+          });
+        },
+      };
+    },
+
+    cleanupSignaling() {
+      if (joinedPeerId) {
+        socket.send({ t: 'leave' });
+        joinedPeerId = null;
+      }
+      relaySubs.clear();
+      peersHandlers.clear();
+      socket.close();
+    },
+  };
+}

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -1,0 +1,14 @@
+// src/realtime/index.ts — barrel for the realtime layer (ephemeral coordination).
+//
+// Sibling of src/storage/ (persistence). Houses the Durable Object transport,
+// the shared wire protocol, and the P2PRoomSignaling backend adapters. Cross-
+// module consumers import from here, not from subpaths.
+
+export { createRoomSignaling } from './signaling/index.js';
+
+export type {
+  PeerId,
+  RelayChannel,
+  ClientMessage,
+  ServerMessage,
+} from './protocol';

--- a/src/realtime/protocol.ts
+++ b/src/realtime/protocol.ts
@@ -1,0 +1,11 @@
+/**
+ * Client-facing re-export of the signaling wire protocol. The canonical
+ * definition lives in `shared/signaling/protocol.ts` (shared with the worker);
+ * client code imports it from here so the cross-boundary path stays in one spot.
+ */
+export type {
+  PeerId,
+  RelayChannel,
+  ClientMessage,
+  ServerMessage,
+} from '../../shared/signaling/protocol';

--- a/src/realtime/signaling-socket.ts
+++ b/src/realtime/signaling-socket.ts
@@ -1,0 +1,110 @@
+import type { ClientMessage, ServerMessage } from './protocol';
+
+/**
+ * Thin reconnecting WebSocket client to the signaling worker. Transport only —
+ * it knows nothing about rooms, peers, SDP, or ICE. Outgoing messages are
+ * queued until the socket is open; consumers re-establish room state via the
+ * `onOpen` hook (fired on every (re)connect).
+ */
+export interface SignalingSocket {
+  send(message: ClientMessage): void;
+  onMessage(handler: (message: ServerMessage) => void): () => void;
+  onOpen(handler: () => void): () => void;
+  close(): void;
+}
+
+export interface SignalingSocketOptions {
+  url: string;
+  /**
+   * Resolves the WebSocket subprotocols for each (re)connect — e.g.
+   * `['bearer', <freshIdToken>]`. Called per connection so auth can refresh.
+   */
+  getProtocols?: () => Promise<string[]> | string[];
+  maxBackoffMs?: number;
+}
+
+export function createSignalingSocket(
+  options: SignalingSocketOptions,
+): SignalingSocket {
+  const maxBackoff = options.maxBackoffMs ?? 10_000;
+  const messageHandlers = new Set<(m: ServerMessage) => void>();
+  const openHandlers = new Set<() => void>();
+  const sendQueue: string[] = [];
+
+  let ws: WebSocket | null = null;
+  let closed = false;
+  let backoff = 500;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  async function connect(): Promise<void> {
+    if (closed) return;
+    let protocols: string[] = [];
+    try {
+      protocols = (await options.getProtocols?.()) ?? [];
+    } catch (error) {
+      console.warn('[signaling] failed to resolve protocols:', error);
+      scheduleReconnect();
+      return;
+    }
+    if (closed) return;
+
+    const socket = new WebSocket(options.url, protocols);
+    ws = socket;
+
+    socket.addEventListener('open', () => {
+      backoff = 500;
+      for (const data of sendQueue.splice(0)) socket.send(data);
+      openHandlers.forEach((h) => h());
+    });
+    socket.addEventListener('message', (event) => {
+      let message: ServerMessage;
+      try {
+        message = JSON.parse(event.data as string) as ServerMessage;
+      } catch {
+        return;
+      }
+      messageHandlers.forEach((h) => h(message));
+    });
+    socket.addEventListener('close', () => {
+      if (ws === socket) ws = null;
+      scheduleReconnect();
+    });
+    socket.addEventListener('error', () => socket.close());
+  }
+
+  function scheduleReconnect(): void {
+    if (closed || reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = undefined;
+      void connect();
+    }, backoff);
+    backoff = Math.min(backoff * 2, maxBackoff);
+  }
+
+  void connect();
+
+  return {
+    send(message) {
+      const data = JSON.stringify(message);
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(data);
+      else sendQueue.push(data);
+    },
+    onMessage(handler) {
+      messageHandlers.add(handler);
+      return () => messageHandlers.delete(handler);
+    },
+    onOpen(handler) {
+      openHandlers.add(handler);
+      return () => openHandlers.delete(handler);
+    },
+    close() {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      sendQueue.length = 0;
+      messageHandlers.clear();
+      openHandlers.clear();
+      ws?.close();
+      ws = null;
+    },
+  };
+}

--- a/src/realtime/signaling/do-room-signaling.test.js
+++ b/src/realtime/signaling/do-room-signaling.test.js
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // --- mock the transport so no real WebSocket is opened ---
 let socket;
 
-vi.mock('../../../realtime/signaling-socket', () => ({
+vi.mock('../signaling-socket', () => ({
   createSignalingSocket: vi.fn(() => {
     const messageHandlers = new Set();
     const openHandlers = new Set();
@@ -30,7 +30,7 @@ vi.mock('../../../realtime/signaling-socket', () => ({
   }),
 }));
 
-vi.mock('../../../auth/index.js', () => ({
+vi.mock('../../auth/index.js', () => ({
   getLoggedInUserToken: vi.fn(async () => 'test-token'),
 }));
 

--- a/src/realtime/signaling/do-room-signaling.ts
+++ b/src/realtime/signaling/do-room-signaling.ts
@@ -4,12 +4,12 @@ import type {
   P2PRoomSignaling,
   RtcSignalingSource,
 } from '@kidlib/p2p';
-import { getLoggedInUserToken } from '../../../auth/index.js';
+import { getLoggedInUserToken } from '../../auth/index.js';
 import {
   createSignalingSocket,
   type SignalingSocket,
-} from '../../../realtime/signaling-socket';
-import type { RelayChannel, ServerMessage } from '../../../realtime/protocol';
+} from '../signaling-socket';
+import type { RelayChannel, ServerMessage } from '../protocol';
 
 /**
  * Durable Object `P2PRoomSignaling` — drop-in replacement for

--- a/src/realtime/signaling/firebase-room-signaling.js
+++ b/src/realtime/signaling/firebase-room-signaling.js
@@ -9,7 +9,7 @@ import {
   onChildAdded,
   onDisconnect,
 } from 'firebase/database';
-import { rtdb } from '../../../infra/firebase-rtdb.js';
+import { rtdb } from '../../infra/firebase-rtdb.js';
 
 /** @typedef {import('@kidlib/p2p').P2PRoomSignaling} P2PRoomSignaling */
 /** @typedef {import('@kidlib/p2p').CreateRoomSignalingOptions} CreateRoomSignalingOptions */

--- a/src/realtime/signaling/firebase-room-signaling.test.js
+++ b/src/realtime/signaling/firebase-room-signaling.test.js
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase/database', () => mocks);
-vi.mock('../../../infra/firebase-rtdb.js', () => ({
+vi.mock('../../infra/firebase-rtdb.js', () => ({
   rtdb: {},
 }));
 

--- a/src/realtime/signaling/index.js
+++ b/src/realtime/signaling/index.js
@@ -1,4 +1,4 @@
-// src/features/signaling/index.js
+// src/realtime/signaling/index.js
 //
 // Room-signaling factory. Selects the realtime backend behind the stable
 // `@kidlib/p2p` `P2PRoomSignaling` port:
@@ -8,8 +8,8 @@
 // Controlled by VITE_SIGNALING_BACKEND. Both adapters are kept in tree until
 // the DO path is verified in production; then the RTDB adapter is removed.
 
-import { createFirebaseRoomSignaling } from './p2p/firebase-room-signaling.js';
-import { createDoRoomSignaling } from './p2p/do-room-signaling.js';
+import { createFirebaseRoomSignaling } from './firebase-room-signaling.js';
+import { createDoRoomSignaling } from './do-room-signaling.js';
 
 export { createFirebaseRoomSignaling, createDoRoomSignaling };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "@features/*": ["./src/features/*"],
       "@infra/*": ["./src/infra/*"],
       "@lib/*": ["./src/lib/*"],
+      "@realtime/*": ["./src/realtime/*"],
       "@shared/*": ["./src/shared/*"],
       "@storage/*": ["./src/storage/*"],
       "@stores/*": ["./src/stores/*"],

--- a/workers/signaling/.gitignore
+++ b/workers/signaling/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+dist/
+*.log
+.dev.vars

--- a/workers/signaling/README.md
+++ b/workers/signaling/README.md
@@ -21,8 +21,9 @@ src/features/signaling/p2p/                  │ getByName(roomId)
 - **DO is a relay**: holds only presence; forwards `relay` messages to the
   addressed peer; never inspects SDP/ICE. No persistence — empty rooms evict.
 - **Wire contract**: `shared/signaling/protocol.ts` (shared with the client).
-- **Auth**: `src/auth.ts`, provider-agnostic `{ userId }`. Firebase ID-token
-  verification is minimal in slice 1 — signature check is a documented TODO.
+- **Auth**: `src/auth.ts`, provider-agnostic `{ userId }`. Verifies the Firebase
+  ID token's RS256 signature (Google JWKS, WebCrypto) + claims. Swapping auth
+  provider later touches only this file's internals.
 
 ## Endpoint
 

--- a/workers/signaling/README.md
+++ b/workers/signaling/README.md
@@ -1,0 +1,43 @@
+# hangvidu-signaling
+
+Cloudflare Worker + Durable Object for **realtime WebRTC room signaling**
+(SDP / ICE / presence). Standalone deploy artifact — not part of the root pnpm
+workspace (mirrors `functions/`). The realtime counterpart to RTDB persistence.
+
+See `docs/WIP_Architecture/SIGNALING_DO_SLICE1.md` for the slice plan and boundaries.
+
+## Architecture
+
+```
+client                         worker (this package)
+──────                         ─────────────────────
+src/realtime/signaling-socket  ──WS──►  src/index.ts        (auth + route by roomId)
+src/features/signaling/p2p/                  │ getByName(roomId)
+  do-room-signaling.ts                       ▼
+                                        src/signaling-room.ts (SignalingRoom DO)
+                                          presence + relay fan-out
+```
+
+- **DO is a relay**: holds only presence; forwards `relay` messages to the
+  addressed peer; never inspects SDP/ICE. No persistence — empty rooms evict.
+- **Wire contract**: `shared/signaling/protocol.ts` (shared with the client).
+- **Auth**: `src/auth.ts`, provider-agnostic `{ userId }`. Firebase ID-token
+  verification is minimal in slice 1 — signature check is a documented TODO.
+
+## Endpoint
+
+`GET /rooms/:roomId/signal` — WebSocket upgrade. Auth token passed as the
+`Sec-WebSocket-Protocol: bearer, <idToken>` subprotocol.
+
+## Commands
+
+```sh
+pnpm install              # first time (own lockfile, like functions/)
+pnpm dev                  # wrangler dev (local DO)
+pnpm typecheck
+pnpm test                 # vitest + @cloudflare/vitest-pool-workers
+pnpm deploy               # wrangler deploy
+
+# set the project id (vars in wrangler.jsonc, or per-env):
+# wrangler secret put / vars override — FIREBASE_PROJECT_ID
+```

--- a/workers/signaling/package.json
+++ b/workers/signaling/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hangvidu-signaling",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker + Durable Object for WebRTC room signaling (SDP/ICE/presence relay).",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest --run"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.10",
+    "@cloudflare/workers-types": "^4.20250508.0",
+    "typescript": "^5.6.0",
+    "vite": "7.3.2",
+    "vitest": "^4.1.2",
+    "wrangler": "^4.16.0"
+  }
+}

--- a/workers/signaling/pnpm-lock.yaml
+++ b/workers/signaling/pnpm-lock.yaml
@@ -1,0 +1,1574 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.10
+        version: 0.16.10(@cloudflare/workers-types@4.20260528.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(vite@7.3.2))
+      '@cloudflare/workers-types':
+        specifier: ^4.20250508.0
+        version: 4.20260528.1
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: 7.3.2
+        version: 7.3.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.7(vite@7.3.2)
+      wrangler:
+        specifier: ^4.16.0
+        version: 4.95.0(@cloudflare/workers-types@4.20260528.1)
+
+packages:
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/vitest-pool-workers@0.16.10':
+    resolution: {integrity: sha512-cHYJ67zi+L4o2Ped8DCfRv0kWl/VNaUUicl1JStxoMsw+32WxExAlYYlAjNludTN6F5y0KScLXmXma2WoTLMvw==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
+  '@cloudflare/workerd-darwin-64@1.20260526.1':
+    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260526.1':
+    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260526.1':
+    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260526.1':
+    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260526.1':
+    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260528.1':
+    resolution: {integrity: sha512-sTNOEN+8DvAOdE7MG3I/TbRGrjZnfbf0aqyTR4wzVi2GEpHTG9DzaK0MSA0z0JS2LmTUSSWimj4mB4cJaYk9rQ==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  miniflare@4.20260526.0:
+    resolution: {integrity: sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rosie-skills-darwin-arm64@0.6.4:
+    resolution: {integrity: sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  rosie-skills-freebsd-x64@0.6.4:
+    resolution: {integrity: sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==}
+    cpu: [x64]
+    os: [freebsd]
+
+  rosie-skills-linux-x64@0.6.4:
+    resolution: {integrity: sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==}
+    cpu: [x64]
+    os: [linux]
+
+  rosie-skills@0.6.4:
+    resolution: {integrity: sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  workerd@1.20260526.1:
+    resolution: {integrity: sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.95.0:
+    resolution: {integrity: sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260526.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260526.1
+
+  '@cloudflare/vitest-pool-workers@0.16.10(@cloudflare/workers-types@4.20260528.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(vite@7.3.2))':
+    dependencies:
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      cjs-module-lexer: 1.4.3
+      esbuild: 0.27.3
+      miniflare: 4.20260526.0
+      vitest: 4.1.7(vite@7.3.2)
+      wrangler: 4.95.0(@cloudflare/workers-types@4.20260528.1)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/workerd-darwin-64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260528.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@7.3.2)':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  blake3-wasm@2.1.5: {}
+
+  chai@6.2.2: {}
+
+  cjs-module-lexer@1.4.3: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  detect-libc@2.1.2: {}
+
+  error-stack-parser-es@1.0.5: {}
+
+  es-module-lexer@2.1.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  kleur@4.1.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  miniflare@4.20260526.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260526.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.1: {}
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  rosie-skills-darwin-arm64@0.6.4:
+    optional: true
+
+  rosie-skills-freebsd-x64@0.6.4:
+    optional: true
+
+  rosie-skills-linux-x64@0.6.4:
+    optional: true
+
+  rosie-skills@0.6.4:
+    optionalDependencies:
+      rosie-skills-darwin-arm64: 0.6.4
+      rosie-skills-freebsd-x64: 0.6.4
+      rosie-skills-linux-x64: 0.6.4
+
+  semver@7.8.1: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.1
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  supports-color@10.2.2: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  vite@7.3.2:
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.7(vite@7.3.2):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@7.3.2)
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  workerd@1.20260526.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260526.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260526.1
+      '@cloudflare/workerd-linux-64': 1.20260526.1
+      '@cloudflare/workerd-linux-arm64': 1.20260526.1
+      '@cloudflare/workerd-windows-64': 1.20260526.1
+
+  wrangler@4.95.0(@cloudflare/workers-types@4.20260528.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260526.0
+      path-to-regexp: 6.3.0
+      rosie-skills: 0.6.4
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260526.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260528.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.20.1: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
+
+  zod@3.25.76: {}

--- a/workers/signaling/pnpm-workspace.yaml
+++ b/workers/signaling/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
-allowBuilds:
-  esbuild: set this to true or false
-  sharp: set this to true or false
-  workerd: set this to true or false
-dangerouslyAllowAllBuilds: true
+# Only these packages may run install/build scripts (supply-chain hygiene).
+onlyBuiltDependencies:
+  - esbuild
+  - workerd
+  - sharp

--- a/workers/signaling/pnpm-workspace.yaml
+++ b/workers/signaling/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  esbuild: set this to true or false
+  sharp: set this to true or false
+  workerd: set this to true or false
+dangerouslyAllowAllBuilds: true

--- a/workers/signaling/src/auth.ts
+++ b/workers/signaling/src/auth.ts
@@ -111,7 +111,14 @@ async function fetchSigningKeys(): Promise<KeyCache> {
   }
   if (!response.ok) return { keys: new Map(), expiresAt: 0 };
 
-  const body = (await response.json()) as { keys?: (JsonWebKey & { kid?: string })[] };
+  let body: { keys?: (JsonWebKey & { kid?: string })[] };
+  try {
+    body = (await response.json()) as {
+      keys?: (JsonWebKey & { kid?: string })[];
+    };
+  } catch {
+    return { keys: new Map(), expiresAt: 0 };
+  }
   const keys = new Map<string, CryptoKey>();
   for (const jwk of body.keys ?? []) {
     if (typeof jwk.kid !== 'string') continue;

--- a/workers/signaling/src/auth.ts
+++ b/workers/signaling/src/auth.ts
@@ -3,7 +3,7 @@ import type { Env } from './index';
 /**
  * Provider-agnostic identity seam. The rest of the worker only ever sees
  * `{ userId }` — it never learns the token came from Firebase. Migrating to a
- * different auth provider later means rewriting only this file.
+ * different auth provider later means rewriting only this file's internals.
  *
  * Returns `null` on any failure rather than throwing: auth rejection is an
  * expected, non-exceptional outcome on the request path.
@@ -11,6 +11,18 @@ import type { Env } from './index';
 export interface Identity {
   userId: string;
 }
+
+/** Google's public keys for Firebase ID tokens, in JWK form. */
+const JWKS_URL =
+  'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com';
+const CLOCK_SKEW_SEC = 300;
+
+interface KeyCache {
+  keys: Map<string, CryptoKey>;
+  expiresAt: number;
+}
+// Per-isolate cache, refreshed per the JWKS response's Cache-Control max-age.
+let keyCache: KeyCache | null = null;
 
 /**
  * Authenticate a WebSocket-upgrade request. The client passes its token via the
@@ -30,38 +42,120 @@ export async function authenticate(
 }
 
 /**
- * Firebase ID token verification.
+ * Verify a Firebase ID token: validates the standard claims (aud / iss / exp /
+ * iat / sub) and the RS256 signature against Google's published public keys.
  *
- * SLICE 1 SCOPE: decodes the JWT and validates the unsigned claims
- * (iss / aud / exp) against the configured project. This is intentionally
- * minimal — see TODO below.
- *
- * TODO(before real users): verify the RS256 signature against Google's public
- * certs (https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com),
- * cached by the `Cache-Control` max-age. Without this, claims are unauthenticated.
- * Kept out of slice 1 deliberately; auth provider is also expected to change.
+ * This is the minimum required for production. To move off Firebase later,
+ * replace the claim expectations + key source below; the `{ userId }` contract
+ * and the `authenticate()` seam stay put.
  */
-function verifyFirebaseIdToken(token: string, env: Env): Identity | null {
-  const claims = decodeJwtClaims(token);
-  if (!claims) return null;
-
-  const projectId = env.FIREBASE_PROJECT_ID;
-  if (claims.aud !== projectId) return null;
-  if (claims.iss !== `https://securetoken.google.com/${projectId}`) return null;
-  if (typeof claims.exp !== 'number' || claims.exp * 1000 <= Date.now()) {
-    return null;
-  }
-
-  const userId = claims.sub;
-  return typeof userId === 'string' && userId ? { userId } : null;
-}
-
-function decodeJwtClaims(token: string): Record<string, unknown> | null {
+async function verifyFirebaseIdToken(
+  token: string,
+  env: Env,
+): Promise<Identity | null> {
   const segments = token.split('.');
   if (segments.length !== 3) return null;
+  const [headerB64, payloadB64, signatureB64] = segments;
+
+  const header = decodeJson(headerB64);
+  const claims = decodeJson(payloadB64);
+  if (!header || !claims) return null;
+  if (header.alg !== 'RS256' || typeof header.kid !== 'string') return null;
+
+  const projectId = env.FIREBASE_PROJECT_ID;
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.aud !== projectId) return null;
+  if (claims.iss !== `https://securetoken.google.com/${projectId}`) return null;
+  if (typeof claims.exp !== 'number' || claims.exp <= now) return null;
+  if (typeof claims.iat !== 'number' || claims.iat > now + CLOCK_SKEW_SEC) {
+    return null;
+  }
+  if (
+    typeof claims.auth_time === 'number' &&
+    claims.auth_time > now + CLOCK_SKEW_SEC
+  ) {
+    return null;
+  }
+  if (typeof claims.sub !== 'string' || !claims.sub) return null;
+
+  const key = await getSigningKey(header.kid);
+  if (!key) return null;
+
+  const signature = base64UrlToBytes(signatureB64);
+  if (!signature) return null;
+  const signed = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const valid = await crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    signature,
+    signed,
+  );
+  if (!valid) return null;
+
+  return { userId: claims.sub };
+}
+
+async function getSigningKey(kid: string): Promise<CryptoKey | null> {
+  if (!keyCache || keyCache.expiresAt <= Date.now()) {
+    keyCache = await fetchSigningKeys();
+  }
+  return keyCache.keys.get(kid) ?? null;
+}
+
+async function fetchSigningKeys(): Promise<KeyCache> {
+  let response: Response;
   try {
-    const json = atob(segments[1].replace(/-/g, '+').replace(/_/g, '/'));
-    return JSON.parse(json) as Record<string, unknown>;
+    response = await fetch(JWKS_URL);
+  } catch {
+    return { keys: new Map(), expiresAt: 0 };
+  }
+  if (!response.ok) return { keys: new Map(), expiresAt: 0 };
+
+  const body = (await response.json()) as { keys?: (JsonWebKey & { kid?: string })[] };
+  const keys = new Map<string, CryptoKey>();
+  for (const jwk of body.keys ?? []) {
+    if (typeof jwk.kid !== 'string') continue;
+    try {
+      keys.set(
+        jwk.kid,
+        await crypto.subtle.importKey(
+          'jwk',
+          jwk,
+          { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+          false,
+          ['verify'],
+        ),
+      );
+    } catch {
+      // skip unusable key
+    }
+  }
+  const maxAge = parseMaxAge(response.headers.get('Cache-Control'));
+  return { keys, expiresAt: Date.now() + maxAge * 1000 };
+}
+
+function parseMaxAge(cacheControl: string | null): number {
+  const match = cacheControl?.match(/max-age=(\d+)/);
+  const seconds = match ? Number(match[1]) : 3600;
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : 3600;
+}
+
+function decodeJson(segment: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(
+      atob(segment.replace(/-/g, '+').replace(/_/g, '/')),
+    ) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlToBytes(segment: string): Uint8Array | null {
+  try {
+    const binary = atob(segment.replace(/-/g, '+').replace(/_/g, '/'));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
   } catch {
     return null;
   }

--- a/workers/signaling/src/auth.ts
+++ b/workers/signaling/src/auth.ts
@@ -1,0 +1,72 @@
+import type { Env } from './index';
+
+/**
+ * Provider-agnostic identity seam. The rest of the worker only ever sees
+ * `{ userId }` — it never learns the token came from Firebase. Migrating to a
+ * different auth provider later means rewriting only this file.
+ */
+export interface Identity {
+  userId: string;
+}
+
+export class AuthError extends Error {}
+
+/**
+ * Authenticate a WebSocket-upgrade request. The client passes its token via the
+ * `Sec-WebSocket-Protocol` header (browsers cannot set arbitrary headers on the
+ * WebSocket handshake, but subprotocols are allowed): `["bearer", "<token>"]`.
+ */
+export async function authenticate(
+  request: Request,
+  env: Env,
+): Promise<Identity> {
+  const protocols = request.headers.get('Sec-WebSocket-Protocol') ?? '';
+  const parts = protocols.split(',').map((p) => p.trim());
+  const token = parts[0] === 'bearer' ? parts[1] : undefined;
+  if (!token) throw new AuthError('missing token');
+
+  return verifyFirebaseIdToken(token, env);
+}
+
+/**
+ * Firebase ID token verification.
+ *
+ * SLICE 1 SCOPE: decodes the JWT and validates the unsigned claims
+ * (iss / aud / exp) against the configured project. This is intentionally
+ * minimal — see TODO below.
+ *
+ * TODO(before real users): verify the RS256 signature against Google's public
+ * certs (https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com),
+ * cached by the `Cache-Control` max-age. Without this, claims are unauthenticated.
+ * Kept out of slice 1 deliberately; auth provider is also expected to change.
+ */
+async function verifyFirebaseIdToken(
+  token: string,
+  env: Env,
+): Promise<Identity> {
+  const claims = decodeJwtClaims(token);
+  const projectId = env.FIREBASE_PROJECT_ID;
+
+  if (claims.aud !== projectId) throw new AuthError('bad audience');
+  if (claims.iss !== `https://securetoken.google.com/${projectId}`) {
+    throw new AuthError('bad issuer');
+  }
+  if (typeof claims.exp !== 'number' || claims.exp * 1000 <= Date.now()) {
+    throw new AuthError('token expired');
+  }
+  const userId = claims.sub;
+  if (typeof userId !== 'string' || !userId) throw new AuthError('no subject');
+
+  return { userId };
+}
+
+function decodeJwtClaims(token: string): Record<string, unknown> {
+  const segments = token.split('.');
+  if (segments.length !== 3) throw new AuthError('malformed token');
+  try {
+    const json = atob(segments[1].replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    throw new AuthError('undecodable claims');
+  }
+}

--- a/workers/signaling/src/auth.ts
+++ b/workers/signaling/src/auth.ts
@@ -4,12 +4,13 @@ import type { Env } from './index';
  * Provider-agnostic identity seam. The rest of the worker only ever sees
  * `{ userId }` — it never learns the token came from Firebase. Migrating to a
  * different auth provider later means rewriting only this file.
+ *
+ * Returns `null` on any failure rather than throwing: auth rejection is an
+ * expected, non-exceptional outcome on the request path.
  */
 export interface Identity {
   userId: string;
 }
-
-export class AuthError extends Error {}
 
 /**
  * Authenticate a WebSocket-upgrade request. The client passes its token via the
@@ -19,11 +20,11 @@ export class AuthError extends Error {}
 export async function authenticate(
   request: Request,
   env: Env,
-): Promise<Identity> {
+): Promise<Identity | null> {
   const protocols = request.headers.get('Sec-WebSocket-Protocol') ?? '';
   const parts = protocols.split(',').map((p) => p.trim());
   const token = parts[0] === 'bearer' ? parts[1] : undefined;
-  if (!token) throw new AuthError('missing token');
+  if (!token) return null;
 
   return verifyFirebaseIdToken(token, env);
 }
@@ -40,33 +41,28 @@ export async function authenticate(
  * cached by the `Cache-Control` max-age. Without this, claims are unauthenticated.
  * Kept out of slice 1 deliberately; auth provider is also expected to change.
  */
-async function verifyFirebaseIdToken(
-  token: string,
-  env: Env,
-): Promise<Identity> {
+function verifyFirebaseIdToken(token: string, env: Env): Identity | null {
   const claims = decodeJwtClaims(token);
+  if (!claims) return null;
+
   const projectId = env.FIREBASE_PROJECT_ID;
-
-  if (claims.aud !== projectId) throw new AuthError('bad audience');
-  if (claims.iss !== `https://securetoken.google.com/${projectId}`) {
-    throw new AuthError('bad issuer');
-  }
+  if (claims.aud !== projectId) return null;
+  if (claims.iss !== `https://securetoken.google.com/${projectId}`) return null;
   if (typeof claims.exp !== 'number' || claims.exp * 1000 <= Date.now()) {
-    throw new AuthError('token expired');
+    return null;
   }
-  const userId = claims.sub;
-  if (typeof userId !== 'string' || !userId) throw new AuthError('no subject');
 
-  return { userId };
+  const userId = claims.sub;
+  return typeof userId === 'string' && userId ? { userId } : null;
 }
 
-function decodeJwtClaims(token: string): Record<string, unknown> {
+function decodeJwtClaims(token: string): Record<string, unknown> | null {
   const segments = token.split('.');
-  if (segments.length !== 3) throw new AuthError('malformed token');
+  if (segments.length !== 3) return null;
   try {
     const json = atob(segments[1].replace(/-/g, '+').replace(/_/g, '/'));
     return JSON.parse(json) as Record<string, unknown>;
   } catch {
-    throw new AuthError('undecodable claims');
+    return null;
   }
 }

--- a/workers/signaling/src/index.ts
+++ b/workers/signaling/src/index.ts
@@ -1,0 +1,37 @@
+import { authenticate, AuthError } from './auth';
+import { SignalingRoom } from './signaling-room';
+
+export { SignalingRoom };
+
+export interface Env {
+  SIGNALING_ROOM: DurableObjectNamespace<SignalingRoom>;
+  FIREBASE_PROJECT_ID: string;
+}
+
+// Route: GET /rooms/:roomId/signal  (WebSocket upgrade)
+const ROOM_PATH = /^\/rooms\/([^/]+)\/signal$/;
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const match = url.pathname.match(ROOM_PATH);
+    if (!match) return new Response('Not found', { status: 404 });
+
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('Expected WebSocket upgrade', { status: 426 });
+    }
+
+    try {
+      await authenticate(request, env);
+    } catch (error) {
+      const status = error instanceof AuthError ? 401 : 500;
+      return new Response(status === 401 ? 'Unauthorized' : 'Auth error', {
+        status,
+      });
+    }
+
+    const roomId = decodeURIComponent(match[1]);
+    const stub = env.SIGNALING_ROOM.getByName(roomId);
+    return stub.fetch(request);
+  },
+} satisfies ExportedHandler<Env>;

--- a/workers/signaling/src/index.ts
+++ b/workers/signaling/src/index.ts
@@ -1,4 +1,4 @@
-import { authenticate, AuthError } from './auth';
+import { authenticate } from './auth';
 import { SignalingRoom } from './signaling-room';
 
 export { SignalingRoom };
@@ -21,14 +21,8 @@ export default {
       return new Response('Expected WebSocket upgrade', { status: 426 });
     }
 
-    try {
-      await authenticate(request, env);
-    } catch (error) {
-      const status = error instanceof AuthError ? 401 : 500;
-      return new Response(status === 401 ? 'Unauthorized' : 'Auth error', {
-        status,
-      });
-    }
+    const identity = await authenticate(request, env);
+    if (!identity) return new Response('Unauthorized', { status: 401 });
 
     const roomId = decodeURIComponent(match[1]);
     const stub = env.SIGNALING_ROOM.getByName(roomId);

--- a/workers/signaling/src/index.ts
+++ b/workers/signaling/src/index.ts
@@ -24,7 +24,12 @@ export default {
     const identity = await authenticate(request, env);
     if (!identity) return new Response('Unauthorized', { status: 401 });
 
-    const roomId = decodeURIComponent(match[1]);
+    let roomId: string;
+    try {
+      roomId = decodeURIComponent(match[1]);
+    } catch {
+      return new Response('Invalid roomId', { status: 400 });
+    }
     const stub = env.SIGNALING_ROOM.getByName(roomId);
     return stub.fetch(request);
   },

--- a/workers/signaling/src/signaling-room.ts
+++ b/workers/signaling/src/signaling-room.ts
@@ -1,0 +1,149 @@
+import { DurableObject } from 'cloudflare:workers';
+import {
+  isClientMessage,
+  type ClientMessage,
+  type PeerId,
+  type ServerMessage,
+} from '../../../shared/signaling/protocol';
+import type { Env } from './index';
+
+/** Survives hibernation via ws.serializeAttachment(). */
+interface SocketState {
+  peerId: PeerId | null;
+}
+
+/**
+ * One instance per room (keyed by roomId). A dumb relay:
+ *   - tracks presence (joined peers)
+ *   - forwards `relay` messages to the addressed peer
+ * It never inspects SDP/ICE contents. State is derived from the live socket
+ * set, so nothing is persisted — an empty room simply hibernates and evicts.
+ */
+export class SignalingRoom extends DurableObject<Env> {
+  async fetch(request: Request): Promise<Response> {
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('Expected WebSocket upgrade', { status: 426 });
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+
+    // Accept first, then attach state (serializeAttachment requires an
+    // already-accepted hibernatable socket). peerId is unknown until `join`.
+    this.ctx.acceptWebSocket(server);
+    this.setSocketState(server, { peerId: null });
+
+    // Echo the auth subprotocol; browsers abort the handshake if the server
+    // does not confirm one of the offered subprotocols.
+    const headers: HeadersInit = {};
+    if ((request.headers.get('Sec-WebSocket-Protocol') ?? '').includes('bearer')) {
+      headers['Sec-WebSocket-Protocol'] = 'bearer';
+    }
+    return new Response(null, { status: 101, webSocket: client, headers });
+  }
+
+  async webSocketMessage(
+    ws: WebSocket,
+    raw: string | ArrayBuffer,
+  ): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(typeof raw === 'string' ? raw : '');
+    } catch {
+      return this.sendError(ws, 'invalid JSON');
+    }
+    if (!isClientMessage(parsed)) {
+      return this.sendError(ws, 'unknown message');
+    }
+
+    const message = parsed as ClientMessage;
+    switch (message.t) {
+      case 'join':
+        this.setSocketState(ws, { peerId: message.peerId });
+        this.broadcastPeers();
+        return;
+      case 'leave':
+        this.setSocketState(ws, { peerId: null });
+        this.broadcastPeers();
+        return;
+      case 'relay':
+        return this.relay(ws, message.to, message.channel, message.data);
+    }
+  }
+
+  async webSocketClose(ws: WebSocket): Promise<void> {
+    // The socket is gone from getWebSockets() by the time presence recomputes.
+    this.broadcastPeers();
+  }
+
+  async webSocketError(ws: WebSocket): Promise<void> {
+    this.broadcastPeers();
+  }
+
+  // --- internals ---
+
+  private relay(
+    from: WebSocket,
+    to: PeerId,
+    channel: 'sdp' | 'ice',
+    data: unknown,
+  ): void {
+    const fromPeerId = this.getSocketState(from).peerId;
+    if (!fromPeerId) return this.sendError(from, 'join before relaying');
+
+    const target = this.findSocket(to);
+    if (!target) return; // peer not present; drop silently (ephemeral)
+
+    this.send(target, {
+      t: 'relay',
+      from: fromPeerId,
+      channel,
+      data,
+    });
+  }
+
+  private broadcastPeers(): void {
+    const peers = this.peerIds();
+    const payload: ServerMessage = { t: 'peers', peers };
+    for (const ws of this.ctx.getWebSockets()) {
+      if (this.getSocketState(ws).peerId) this.send(ws, payload);
+    }
+  }
+
+  private peerIds(): PeerId[] {
+    const ids: PeerId[] = [];
+    for (const ws of this.ctx.getWebSockets()) {
+      const { peerId } = this.getSocketState(ws);
+      if (peerId) ids.push(peerId);
+    }
+    return ids;
+  }
+
+  private findSocket(peerId: PeerId): WebSocket | null {
+    for (const ws of this.ctx.getWebSockets()) {
+      if (this.getSocketState(ws).peerId === peerId) return ws;
+    }
+    return null;
+  }
+
+  private send(ws: WebSocket, message: ServerMessage): void {
+    try {
+      ws.send(JSON.stringify(message));
+    } catch {
+      // Socket closing; presence rebroadcast on close handles cleanup.
+    }
+  }
+
+  private sendError(ws: WebSocket, message: string): void {
+    this.send(ws, { t: 'error', message });
+  }
+
+  private getSocketState(ws: WebSocket): SocketState {
+    return (ws.deserializeAttachment() as SocketState | null) ?? { peerId: null };
+  }
+
+  private setSocketState(ws: WebSocket, state: SocketState): void {
+    ws.serializeAttachment(state);
+  }
+}

--- a/workers/signaling/test/signaling-room.test.ts
+++ b/workers/signaling/test/signaling-room.test.ts
@@ -1,0 +1,62 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import type { ServerMessage } from '../../../shared/signaling/protocol';
+
+/** Open a hibernatable WS straight to the DO (bypasses the Worker auth layer). */
+async function connect(roomId: string) {
+  const stub = (env as any).SIGNALING_ROOM.getByName(roomId);
+  const res = await stub.fetch(
+    new Request(`https://do/rooms/${roomId}/signal`, {
+      headers: { Upgrade: 'websocket' },
+    }),
+  );
+  const ws = res.webSocket as WebSocket;
+  ws.accept();
+
+  const queue: ServerMessage[] = [];
+  const waiters: ((m: ServerMessage) => void)[] = [];
+  ws.addEventListener('message', (e: MessageEvent) => {
+    const msg = JSON.parse(e.data as string) as ServerMessage;
+    const w = waiters.shift();
+    if (w) w(msg);
+    else queue.push(msg);
+  });
+
+  return {
+    send: (m: unknown) => ws.send(JSON.stringify(m)),
+    next: () =>
+      new Promise<ServerMessage>((resolve) => {
+        const m = queue.shift();
+        if (m) resolve(m);
+        else waiters.push(resolve);
+      }),
+  };
+}
+
+describe('SignalingRoom', () => {
+  it('tracks presence and relays signaling between peers', async () => {
+    const a = await connect('room-1');
+    const b = await connect('room-1');
+
+    a.send({ t: 'join', peerId: 'peer-a' });
+    expect(await a.next()).toEqual({ t: 'peers', peers: ['peer-a'] });
+
+    b.send({ t: 'join', peerId: 'peer-b' });
+    for (const peer of [a, b]) {
+      const msg = await peer.next();
+      expect(msg.t).toBe('peers');
+      expect(msg.t === 'peers' && [...msg.peers].sort()).toEqual([
+        'peer-a',
+        'peer-b',
+      ]);
+    }
+
+    a.send({ t: 'relay', to: 'peer-b', channel: 'sdp', data: { sdp: 'offer' } });
+    expect(await b.next()).toEqual({
+      t: 'relay',
+      from: 'peer-a',
+      channel: 'sdp',
+      data: { sdp: 'offer' },
+    });
+  });
+});

--- a/workers/signaling/test/worker.test.ts
+++ b/workers/signaling/test/worker.test.ts
@@ -1,28 +1,77 @@
 import { env, SELF } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const PROJECT_ID = (env as any).FIREBASE_PROJECT_ID as string;
+const KID = 'test-key-1';
+const JWKS_URL =
+  'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com';
 
-function b64url(obj: unknown): string {
-  return btoa(JSON.stringify(obj))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+let privateKey: CryptoKey;
+const originalFetch = globalThis.fetch;
+
+function b64urlFromString(s: string): string {
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
-
-/** Build an unsigned-but-well-formed Firebase-style ID token (claims only). */
-function fakeToken(claims: Record<string, unknown>): string {
-  return `${b64url({ alg: 'RS256' })}.${b64url(claims)}.sig`;
+function b64urlFromBytes(buf: ArrayBuffer): string {
+  let binary = '';
+  const bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return b64urlFromString(binary);
 }
 
 function validClaims() {
+  const now = Math.floor(Date.now() / 1000);
   return {
     aud: PROJECT_ID,
     iss: `https://securetoken.google.com/${PROJECT_ID}`,
-    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: now - 10,
+    exp: now + 3600,
     sub: 'user-1',
   };
 }
+
+async function signToken(claims: Record<string, unknown>): Promise<string> {
+  const headerB64 = b64urlFromString(JSON.stringify({ alg: 'RS256', kid: KID }));
+  const payloadB64 = b64urlFromString(JSON.stringify(claims));
+  const data = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const sig = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', privateKey, data);
+  return `${headerB64}.${payloadB64}.${b64urlFromBytes(sig)}`;
+}
+
+beforeAll(async () => {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  );
+  privateKey = pair.privateKey;
+  const publicJwk = await crypto.subtle.exportKey('jwk', pair.publicKey);
+
+  // Serve our public key as Google's JWKS. The worker's auth code runs in this
+  // same isolate, so stubbing the global fetch intercepts its JWKS lookup.
+  const jwks = {
+    keys: [{ ...publicJwk, kid: KID, alg: 'RS256', use: 'sig' }],
+  };
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url === JWKS_URL) {
+      return new Response(JSON.stringify(jwks), {
+        status: 200,
+        headers: { 'cache-control': 'max-age=3600' },
+      });
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
 
 function upgrade(path: string, protocol?: string): Promise<Response> {
   const headers: Record<string, string> = { Upgrade: 'websocket' };
@@ -32,34 +81,46 @@ function upgrade(path: string, protocol?: string): Promise<Response> {
 
 describe('signaling worker routing + auth', () => {
   it('404s unknown paths', async () => {
-    const res = await SELF.fetch('https://signaling/nope');
-    expect(res.status).toBe(404);
+    expect((await SELF.fetch('https://signaling/nope')).status).toBe(404);
   });
 
   it('426s the room path without an Upgrade header', async () => {
-    const res = await SELF.fetch('https://signaling/rooms/r1/signal');
-    expect(res.status).toBe(426);
+    expect((await SELF.fetch('https://signaling/rooms/r1/signal')).status).toBe(
+      426,
+    );
   });
 
   it('401s when no token is provided', async () => {
-    const res = await upgrade('/rooms/r1/signal');
-    expect(res.status).toBe(401);
+    expect((await upgrade('/rooms/r1/signal')).status).toBe(401);
   });
 
   it('401s an expired token', async () => {
-    const token = fakeToken({ ...validClaims(), exp: 1 });
-    const res = await upgrade('/rooms/r1/signal', `bearer, ${token}`);
-    expect(res.status).toBe(401);
+    const token = await signToken({ ...validClaims(), exp: 1 });
+    expect((await upgrade('/rooms/r1/signal', `bearer, ${token}`)).status).toBe(
+      401,
+    );
   });
 
   it('401s a wrong-audience token', async () => {
-    const token = fakeToken({ ...validClaims(), aud: 'someone-else' });
-    const res = await upgrade('/rooms/r1/signal', `bearer, ${token}`);
-    expect(res.status).toBe(401);
+    const token = await signToken({ ...validClaims(), aud: 'someone-else' });
+    expect((await upgrade('/rooms/r1/signal', `bearer, ${token}`)).status).toBe(
+      401,
+    );
   });
 
-  it('upgrades with a valid token', async () => {
-    const token = fakeToken(validClaims());
+  it('401s a token with a tampered payload (bad signature)', async () => {
+    const token = await signToken(validClaims());
+    const [h, , s] = token.split('.');
+    const forged = b64urlFromString(
+      JSON.stringify({ ...validClaims(), sub: 'attacker' }),
+    );
+    expect(
+      (await upgrade('/rooms/r1/signal', `bearer, ${h}.${forged}.${s}`)).status,
+    ).toBe(401);
+  });
+
+  it('upgrades with a valid signed token', async () => {
+    const token = await signToken(validClaims());
     const res = await upgrade('/rooms/r1/signal', `bearer, ${token}`);
     expect(res.status).toBe(101);
     expect(res.webSocket).toBeTruthy();

--- a/workers/signaling/test/worker.test.ts
+++ b/workers/signaling/test/worker.test.ts
@@ -1,0 +1,67 @@
+import { env, SELF } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+const PROJECT_ID = (env as any).FIREBASE_PROJECT_ID as string;
+
+function b64url(obj: unknown): string {
+  return btoa(JSON.stringify(obj))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/** Build an unsigned-but-well-formed Firebase-style ID token (claims only). */
+function fakeToken(claims: Record<string, unknown>): string {
+  return `${b64url({ alg: 'RS256' })}.${b64url(claims)}.sig`;
+}
+
+function validClaims() {
+  return {
+    aud: PROJECT_ID,
+    iss: `https://securetoken.google.com/${PROJECT_ID}`,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    sub: 'user-1',
+  };
+}
+
+function upgrade(path: string, protocol?: string): Promise<Response> {
+  const headers: Record<string, string> = { Upgrade: 'websocket' };
+  if (protocol) headers['Sec-WebSocket-Protocol'] = protocol;
+  return SELF.fetch(`https://signaling${path}`, { headers });
+}
+
+describe('signaling worker routing + auth', () => {
+  it('404s unknown paths', async () => {
+    const res = await SELF.fetch('https://signaling/nope');
+    expect(res.status).toBe(404);
+  });
+
+  it('426s the room path without an Upgrade header', async () => {
+    const res = await SELF.fetch('https://signaling/rooms/r1/signal');
+    expect(res.status).toBe(426);
+  });
+
+  it('401s when no token is provided', async () => {
+    const res = await upgrade('/rooms/r1/signal');
+    expect(res.status).toBe(401);
+  });
+
+  it('401s an expired token', async () => {
+    const token = fakeToken({ ...validClaims(), exp: 1 });
+    const res = await upgrade('/rooms/r1/signal', `bearer, ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('401s a wrong-audience token', async () => {
+    const token = fakeToken({ ...validClaims(), aud: 'someone-else' });
+    const res = await upgrade('/rooms/r1/signal', `bearer, ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('upgrades with a valid token', async () => {
+    const token = fakeToken(validClaims());
+    const res = await upgrade('/rooms/r1/signal', `bearer, ${token}`);
+    expect(res.status).toBe(101);
+    expect(res.webSocket).toBeTruthy();
+  });
+});

--- a/workers/signaling/tsconfig.json
+++ b/workers/signaling/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "../../shared/signaling/**/*.ts"]
+}

--- a/workers/signaling/vitest.config.ts
+++ b/workers/signaling/vitest.config.ts
@@ -1,0 +1,8 @@
+import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+import { defineConfig } from 'vitest/config';
+
+// vitest 4 + pool-workers 0.16: the pool is a Vite plugin; the old
+// defineWorkersConfig/poolOptions shape was removed.
+export default defineConfig({
+  plugins: [cloudflareTest({ wrangler: { configPath: './wrangler.jsonc' } })],
+});

--- a/workers/signaling/wrangler.jsonc
+++ b/workers/signaling/wrangler.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "hangvidu-signaling",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-05-01",
+  "observability": { "enabled": true },
+  "durable_objects": {
+    "bindings": [{ "name": "SIGNALING_ROOM", "class_name": "SignalingRoom" }],
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["SignalingRoom"] }],
+  "vars": {
+    // Firebase project id used to validate ID-token claims (aud/iss).
+    // Override per environment; not a secret.
+    "FIREBASE_PROJECT_ID": "vidu-aae11",
+  },
+}


### PR DESCRIPTION
## Summary

Establishes the **realtime vs persistence** split and migrates WebRTC room signaling (SDP / ICE / presence) off Firebase RTDB onto a Cloudflare Durable Object — behind the unchanged `@kidlib/p2p` `P2PRoomSignaling` port, so it's a per-environment flag flip, not a rewrite. Persistence (contacts, messages, user) stays on RTDB and migrates later in its own slice.

- **Realtime / ephemeral** → `workers/signaling/` (DO) + `src/realtime/` (client). New first-class boundary layer mirroring `src/storage/`.
- **Persistence** → Firebase RTDB (unchanged).

## What's included

**Server (`workers/signaling/`, standalone wrangler pkg, mirrors `functions/`)**
- `SignalingRoom` Durable Object: presence + addressed relay over hibernatable WebSockets. Pure relay — no SDP knowledge, no persistence; empty rooms hibernate/evict.
- Worker router: authenticate → `getByName(roomId)` → WS handoff.
- Auth (`auth.ts`): verifies Firebase ID token **RS256 signature** (Google JWKS via WebCrypto, keys cached per `Cache-Control`) + claims (aud/iss/exp/iat/sub). Provider-agnostic `authenticate() → Identity | null` seam — swapping auth provider later touches only this file. Production-ready.

**Client (`src/realtime/`)**
- `signaling-socket.ts`: reconnecting WS transport (queues until open; re-joins on reconnect).
- `signaling/`: `do-room-signaling.ts` + `firebase-room-signaling.js` adapters; `createRoomSignaling` factory selected by `VITE_SIGNALING_BACKEND` (`do` default, `rtdb` fallback). Barrel `src/realtime/index.ts`.

**Shared contract**
- `shared/signaling/protocol.ts`: wire envelope shared by client + worker (like `shared/push-notifications/`). `media-sync` later = a new `channel` value, no structural change.

**Architecture / boundaries**
- `src/realtime/` promoted to a first-class boundary element (was unclassified and invisible to the checker): `realtime → [realtime, shared, lib, infra, auth]`, `feature → realtime`. Updated `eslint.boundaries.config.js`, `BOUNDARY_MAP.md`, `STRUCTURE.md`; added `@realtime/*` alias.
- Root scripts: `pnpm dev:do` / `deploy:do` / `test:do`.

## Verification

- Manual: real 2-peer call over the DO. ✅
- Automated: DO relay/presence test; worker routing + auth (404/426/401 incl. expired, bad-aud, tampered-signature; 101 valid signed token via generated keypair + stubbed JWKS); client adapter mapping test. Worker 8/8, client signaling 7/7.
- `pnpm ts` clean; full boundary lint green.

See `docs/WIP_Architecture/SIGNALING_DO_SLICE1.md` for the full slice plan.

## Deferred / follow-ups

- Not yet deployed — needs `pnpm deploy:do` + prod `VITE_SIGNALING_URL` (`wss://`).
- Full Chromium 2-peer E2E (covered manually for now).
- Later slices: call-invite mailbox + media-playback-sync (reuse `src/realtime/` transport + protocol).

## Notes for review

- Token passed via `Sec-WebSocket-Protocol: bearer, <idToken>` (browsers can't set WS headers); server echoes `bearer`.
- `localhost` is mixed-content exempt, so `ws://` works from the https dev page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added switchable realtime signaling backend (env vars) and a Cloudflare Durable Objects signaling option; added a reconnecting WebSocket client and room-based signaling adapter.

* **Documentation**
  * Added detailed realtime signaling architecture, migration guidance, and worker README.

* **Tests**
  * Added tests for worker routing/auth, durable-object room relay, and client signaling behavior.

* **Chores**
  * Added signaling worker project, scripts, workspace config, and TypeScript path alias; updated .gitignore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KristinnRoach/HangVidU/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->