### PR TITLE
Mute local call preview

### DIFF
--- a/src/components/media/VideoStream.test.jsx
+++ b/src/components/media/VideoStream.test.jsx
@@ -1,0 +1,43 @@
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import VideoStream from './VideoStream';
+
+function createStreamWithVideo() {
+  return {
+    getVideoTracks: () => [{ kind: 'video' }],
+  };
+}
+
+describe('VideoStream', () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('mutes local preview streams by default', () => {
+    const stream = createStreamWithVideo();
+    const { container } = render(() => (
+      <VideoStream stream={stream} local={true} preview={true} />
+    ));
+
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video.muted).toBe(true);
+    expect(video.srcObject).toBe(stream);
+  });
+
+  it('leaves remote streams audible by default', () => {
+    const { container } = render(() => (
+      <VideoStream stream={createStreamWithVideo()} />
+    ));
+
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video.muted).toBe(false);
+  });
+});

--- a/src/components/media/VideoStream.test.jsx
+++ b/src/components/media/VideoStream.test.jsx
@@ -11,7 +11,7 @@ function createStreamWithVideo() {
 
 describe('VideoStream', () => {
   beforeEach(() => {
-    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/src/components/media/VideoStream.tsx
+++ b/src/components/media/VideoStream.tsx
@@ -13,12 +13,14 @@ type Props = {
 
 export default function VideoStream(props: Props) {
   let video!: HTMLVideoElement;
+  const shouldMute = () => props.muted ?? props.local ?? props.preview ?? false;
 
   createEffect(() => {
     const stream = props.stream;
     if (!video) return;
 
     video.srcObject = stream ?? null;
+    video.muted = shouldMute();
     if (stream) {
       video.play().catch(() => {});
     }
@@ -59,7 +61,7 @@ export default function VideoStream(props: Props) {
         }}
         ref={video}
         autoplay
-        muted={props.muted}
+        muted={shouldMute()}
       />
     </Show>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent mute behavior for video streams: local preview streams default to muted and remote streams default to unmuted, ensuring the UI and playback state stay in sync.

* **Tests**
  * Added test coverage validating mute defaults and that video elements receive the provided media streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->