### PR TITLE
[codex] Fix outgoing callee name display

### DIFF
--- a/src/features/call/components/CallControls.test.jsx
+++ b/src/features/call/components/CallControls.test.jsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSignal } from 'solid-js';
+import { render, cleanup } from '@solidjs/testing-library';
+
+import { StartCallButton } from './CallControls';
+
+const mocks = vi.hoisted(() => ({
+  startCall: vi.fn(),
+}));
+
+vi.mock('../call-handshake', () => ({
+  useCallHandshake: () => ({ startCall: mocks.startCall }),
+}));
+
+vi.mock('../../../shared/i18n', () => ({
+  useI18n: () => ({
+    t: (key, params) => {
+      if (key === 'call.unknown_caller') return 'Unknown Caller';
+      if (params?.name) return `${key}:${params.name}`;
+      return key;
+    },
+  }),
+}));
+
+describe('StartCallButton', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('uses the latest reactive call target when clicked', () => {
+    const { container, getByText, unmount } = render(() => {
+      const [calleeId, setCalleeId] = createSignal('contact-1');
+      const [calleeName, setCalleeName] = createSignal('Alice');
+
+      return (
+        <>
+          <button
+            type='button'
+            onClick={() => {
+              setCalleeId('contact-2');
+              setCalleeName('Bob');
+            }}
+          >
+            update target
+          </button>
+          <StartCallButton
+            calleeId={calleeId()}
+            calleeName={calleeName()}
+            audioOnly={false}
+          />
+        </>
+      );
+    });
+
+    getByText('update target').dispatchEvent(
+      new MouseEvent('click', { bubbles: true }),
+    );
+    container
+      .querySelector('.contact-call-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(mocks.startCall).toHaveBeenCalledWith({
+      calleeId: 'contact-2',
+      calleeName: 'Bob',
+      audioOnly: false,
+    });
+
+    unmount();
+  });
+});

--- a/src/features/call/components/CallControls.tsx
+++ b/src/features/call/components/CallControls.tsx
@@ -19,18 +19,16 @@ export function StartCallButton(props: StartCallButtonProps) {
   const { startCall } = useCallHandshake();
   const { t } = useI18n();
 
-  const {
-    calleeId,
-    calleeName = t('call.unknown_caller'),
-    audioOnly = false,
-    title = t('contact.action.call', { name: calleeName }),
-  } = props;
+  const calleeName = () => props.calleeName || t('call.unknown_caller');
+  const audioOnly = () => props.audioOnly ?? false;
+  const title = () =>
+    props.title || t('contact.action.call', { name: calleeName() });
 
   function onCall() {
     startCall({
-      calleeId,
-      calleeName,
-      audioOnly,
+      calleeId: props.calleeId,
+      calleeName: calleeName(),
+      audioOnly: audioOnly(),
     });
   }
 
@@ -39,10 +37,10 @@ export function StartCallButton(props: StartCallButtonProps) {
       class='contact-call-btn'
       type='button'
       onClick={onCall}
-      title={title}
-      aria-label={title}
+      title={title()}
+      aria-label={title()}
     >
-      {audioOnly ? <Phone /> : <Video />}
+      {audioOnly() ? <Phone /> : <Video />}
     </button>
   );
 }

--- a/src/features/contacts/components/ContactEntry.jsx
+++ b/src/features/contacts/components/ContactEntry.jsx
@@ -57,9 +57,17 @@ export default function ContactEntry(props) {
 
   return (
     <div class='contact-entry' ref={rootEl}>
-      <StartCallButton calleeId={props.id} audioOnly={true} />
+      <StartCallButton
+        calleeId={props.id}
+        calleeName={displayName()}
+        audioOnly={true}
+      />
 
-      <StartCallButton calleeId={props.id} audioOnly={false} />
+      <StartCallButton
+        calleeId={props.id}
+        calleeName={displayName()}
+        audioOnly={false}
+      />
 
       <button
         type='button'

--- a/src/features/contacts/components/ContactsList.test.jsx
+++ b/src/features/contacts/components/ContactsList.test.jsx
@@ -157,7 +157,11 @@ describe('SolidJS ContactsList PoC', { timeout: 60000 }, () => {
     firstCall?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(mocks.startCall).toHaveBeenCalledWith(
-      expect.objectContaining({ calleeId: 'contact-1' }),
+      expect.objectContaining({
+        calleeId: 'contact-1',
+        calleeName: 'Alice',
+        audioOnly: true,
+      }),
     );
 
     unmount();


### PR DESCRIPTION
## Summary
- Pass contact display names into contact-list call buttons.
- Keep StartCallButton props reactive so click handlers use the latest callee id/name.
- Add regression coverage for contact-row calls and stale Solid props.

## Root Cause
The outgoing dialog renders local pendingOutgoingCall.calleeName. Contact-row call buttons only passed calleeId, so StartCallButton fell back to Unknown Caller. StartCallButton also destructured Solid props once, which could leave toolbar calls with stale target data.

## Validation
- ./node_modules/.bin/vitest --run src/features/call/components/CallControls.test.jsx src/features/contacts/components/ContactsList.test.jsx
- ./node_modules/.bin/eslint "src/**/*.{js,jsx,ts,tsx}"
- ./node_modules/.bin/eslint --config eslint.boundaries.config.js "src/**/*.{js,jsx,ts,tsx}"
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build

Note: pnpm vitest --run and pnpm build were blocked before running by pnpm ignored-builds preflight in this checkout, so the underlying local binaries were run directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for call button functionality with parameter validation

* **Refactor**
  * Enhanced call button components to properly manage caller information during call initiation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->