### PR TITLE
Show conversation timestamps and improve composer behavior

### DIFF
--- a/src/features/messaging-next/ConversationPanel.module.css
+++ b/src/features/messaging-next/ConversationPanel.module.css
@@ -37,6 +37,15 @@
   pointer-events: none;
 }
 
+.messageTimestamp {
+  align-self: center;
+  margin: 0.25em 0 0;
+  color: #c0c0c0;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  text-align: center;
+}
+
 .skeletonBubble {
   width: min(68%, 18rem);
   height: 2.25rem;

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -178,7 +178,10 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   function attachSendButton(el: HTMLButtonElement) {
     sendButtonCleanup?.();
     sendButtonCleanup = isIOSOrAndroidDevice()
-      ? keepVirtualKeyboardOpenOnTap(el, () => el.form?.requestSubmit())
+      ? keepVirtualKeyboardOpenOnTap(el, (event) => {
+          event.preventDefault();
+          el.form?.requestSubmit();
+        })
       : undefined;
   }
 

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -15,6 +15,7 @@ import { useI18n } from '../../shared/i18n';
 import { LoadBoundary } from '../../components/app/LoadBoundary';
 import { showImagePreview } from '../../components/base-legacy/imagePreview.js';
 import { downloadUrl } from '@lib/utils/download-url.js';
+import { isIOSOrAndroidDevice } from '@lib/utils/detect-device.js';
 
 import { createMessagingRuntime } from './messaging-runtime.js';
 
@@ -34,6 +35,7 @@ import styles from './ConversationPanel.module.css';
 
 const runtime = createMessagingRuntime();
 const DRAFT_SAVE_DELAY_MS = 250;
+const TIMESTAMP_THRESHOLD_MS = 5 * 60 * 1000;
 
 function dataUrlMimeType(url: string) {
   const match = /^data:([^;,]+)[;,]/i.exec(url);
@@ -71,6 +73,33 @@ function formatFileSize(bytes: number) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function isSameLocalDate(a: Date, b: Date) {
+  return (
+    a.getDate() === b.getDate() &&
+    a.getMonth() === b.getMonth() &&
+    a.getFullYear() === b.getFullYear()
+  );
+}
+
+function formatTimestamp(timestamp: number, locale: string) {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const time = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+
+  if (isSameLocalDate(date, now)) return time;
+
+  const day = new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+
+  return `${day} - ${time}`;
+}
+
 function MessageHistorySkeleton() {
   return (
     <div
@@ -104,7 +133,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   const store = createConversationState();
   const actions = createConversationActions(store);
   const { state } = store;
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
 
   let messagesEl: HTMLDivElement | undefined;
   let inputTextAreaEl: HTMLTextAreaElement | undefined;
@@ -166,6 +195,13 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   const [historyLoading, setHistoryLoading] = createSignal(false);
   const [historyError, setHistoryError] = createSignal<unknown>(null);
   const [historyReady, setHistoryReady] = createSignal(false);
+
+  function shouldShowTimestamp(message: ChatMessage, index: number) {
+    const previous = state.messages[index - 1];
+    return (
+      !previous || message.sentAt - previous.sentAt > TIMESTAMP_THRESHOLD_MS
+    );
+  }
 
   createEffect(
     on(
@@ -293,6 +329,15 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     void send();
   }
 
+  function onDraftKeyDown(
+    e: KeyboardEvent & { currentTarget: HTMLTextAreaElement },
+  ) {
+    if (e.key !== 'Enter' || e.shiftKey || isIOSOrAndroidDevice()) return;
+
+    e.preventDefault();
+    e.currentTarget.form?.requestSubmit();
+  }
+
   return (
     <div class={styles.panel}>
       <Show
@@ -315,126 +360,140 @@ export default function ConversationPanel(props: ConversationPanelProps) {
           >
             <div class={styles.messages} ref={messagesEl}>
               <For each={state.messages}>
-                {(msg) => (
-                  <Switch>
-                    <Match when={msg.source === 'system'}>
-                      <div class={`${styles.msg} ${styles.msgSystem}`}>
-                        <span>{msg.text}</span>
-                        <Show when={msg.actions?.length}>
-                          <span class={styles.msgActions}>
-                            <For each={msg.actions}>
-                              {(action) => (
-                                <button
-                                  type='button'
-                                  class={styles.msgActionBtn}
-                                  onClick={action.onClick}
-                                >
-                                  {action.label}
-                                </button>
-                              )}
-                            </For>
-                          </span>
-                        </Show>
-                      </div>
-                    </Match>
-                    <Match when={msg.source !== 'system'}>
-                      <div
-                        class={styles.msg}
-                        classList={{
-                          [styles.msgOwn]: msg.senderId === state.myUserId,
-                          [styles.msgFailed]: msg.status === 'failed',
-                        }}
+                {(msg, index) => (
+                  <>
+                    <Show when={shouldShowTimestamp(msg, index())}>
+                      <time
+                        class={styles.messageTimestamp}
+                        dateTime={new Date(msg.sentAt).toISOString()}
                       >
-                        <span class={styles.msgText}>{msg.text}</span>
-                        <Show when={msg.attachment}>
-                          {(attachment) => {
-                            const file = attachment();
-                            const attachmentUrl = getAttachmentUrl(file);
-                            const allowedDataUrl = hasAllowedDataUrl(file);
-                            const canPreview =
-                              Boolean(attachmentUrl) &&
-                              (allowedDataUrl ||
-                                isAllowedRemoteUrl(attachmentUrl)) &&
-                              isImageAttachment(file);
-                            const canDownload =
-                              Boolean(attachmentUrl) &&
-                              (allowedDataUrl ||
-                                attachmentUrl?.startsWith('blob:') ||
-                                isAllowedRemoteUrl(attachmentUrl));
+                        {formatTimestamp(msg.sentAt, locale())}
+                      </time>
+                    </Show>
+                    <Switch>
+                      <Match when={msg.source === 'system'}>
+                        <div class={`${styles.msg} ${styles.msgSystem}`}>
+                          <span>{msg.text}</span>
+                          <Show when={msg.actions?.length}>
+                            <span class={styles.msgActions}>
+                              <For each={msg.actions}>
+                                {(action) => (
+                                  <button
+                                    type='button'
+                                    class={styles.msgActionBtn}
+                                    onClick={action.onClick}
+                                  >
+                                    {action.label}
+                                  </button>
+                                )}
+                              </For>
+                            </span>
+                          </Show>
+                        </div>
+                      </Match>
+                      <Match when={msg.source !== 'system'}>
+                        <div
+                          class={styles.msg}
+                          data-timestamp={msg.sentAt}
+                          classList={{
+                            [styles.msgOwn]: msg.senderId === state.myUserId,
+                            [styles.msgFailed]: msg.status === 'failed',
+                          }}
+                        >
+                          <span class={styles.msgText}>{msg.text}</span>
+                          <Show when={msg.attachment}>
+                            {(attachment) => {
+                              const file = attachment();
+                              const attachmentUrl = getAttachmentUrl(file);
+                              const allowedDataUrl = hasAllowedDataUrl(file);
+                              const canPreview =
+                                Boolean(attachmentUrl) &&
+                                (allowedDataUrl ||
+                                  isAllowedRemoteUrl(attachmentUrl)) &&
+                                isImageAttachment(file);
+                              const canDownload =
+                                Boolean(attachmentUrl) &&
+                                (allowedDataUrl ||
+                                  attachmentUrl?.startsWith('blob:') ||
+                                  isAllowedRemoteUrl(attachmentUrl));
 
-                            return (
-                              <span class={styles.fileMessage}>
-                                <Show when={canPreview}>
-                                  <img
-                                    class={styles.filePreviewImg}
-                                    src={attachmentUrl ?? undefined}
-                                    alt={file.fileName}
-                                    role='button'
-                                    tabIndex={0}
-                                    aria-label={`Open preview for ${file.fileName}`}
-                                    onClick={() =>
-                                      attachmentUrl &&
-                                      showImagePreview(
-                                        attachmentUrl,
-                                        file.fileName,
-                                      )
-                                    }
-                                    onKeyDown={(e) => {
-                                      if (e.key !== 'Enter' && e.key !== ' ') {
-                                        return;
-                                      }
-                                      e.preventDefault();
-                                      if (attachmentUrl) {
+                              return (
+                                <span class={styles.fileMessage}>
+                                  <Show when={canPreview}>
+                                    <img
+                                      class={styles.filePreviewImg}
+                                      src={attachmentUrl ?? undefined}
+                                      alt={file.fileName}
+                                      role='button'
+                                      tabIndex={0}
+                                      aria-label={`Open preview for ${file.fileName}`}
+                                      onClick={() =>
+                                        attachmentUrl &&
                                         showImagePreview(
                                           attachmentUrl,
                                           file.fileName,
-                                        );
+                                        )
                                       }
-                                    }}
-                                  />
-                                </Show>
-                                <span class={styles.fileMessageMeta}>
-                                  <Show
-                                    when={canDownload}
-                                    fallback={
-                                      <span class={styles.fileMessageName}>
-                                        {file.fileName}
-                                      </span>
-                                    }
-                                  >
-                                    <a
-                                      href={attachmentUrl ?? undefined}
-                                      download={file.fileName}
-                                      class={styles.fileMessageName}
-                                      onClick={(event) => {
-                                        if (!attachmentUrl) return;
-                                        event.preventDefault();
-                                        void downloadUrl(
-                                          attachmentUrl,
-                                          file.fileName,
-                                        );
+                                      onKeyDown={(e) => {
+                                        if (
+                                          e.key !== 'Enter' &&
+                                          e.key !== ' '
+                                        ) {
+                                          return;
+                                        }
+                                        e.preventDefault();
+                                        if (attachmentUrl) {
+                                          showImagePreview(
+                                            attachmentUrl,
+                                            file.fileName,
+                                          );
+                                        }
                                       }}
-                                    >
-                                      {file.fileName}
-                                    </a>
+                                    />
                                   </Show>
-                                  <span class={styles.fileMessageSize}>
-                                    ({formatFileSize(file.fileSize)})
+                                  <span class={styles.fileMessageMeta}>
+                                    <Show
+                                      when={canDownload}
+                                      fallback={
+                                        <span class={styles.fileMessageName}>
+                                          {file.fileName}
+                                        </span>
+                                      }
+                                    >
+                                      <a
+                                        href={attachmentUrl ?? undefined}
+                                        download={file.fileName}
+                                        class={styles.fileMessageName}
+                                        onClick={(event) => {
+                                          if (!attachmentUrl) return;
+                                          event.preventDefault();
+                                          void downloadUrl(
+                                            attachmentUrl,
+                                            file.fileName,
+                                          );
+                                        }}
+                                      >
+                                        {file.fileName}
+                                      </a>
+                                    </Show>
+                                    <span class={styles.fileMessageSize}>
+                                      ({formatFileSize(file.fileSize)})
+                                    </span>
                                   </span>
                                 </span>
-                              </span>
-                            );
-                          }}
-                        </Show>
-                        <Show when={msg.status === 'sending'}>
-                          <span class={styles.msgStatus}>…</span>
-                        </Show>
-                        <Show when={msg.status === 'failed'}>
-                          <span class={styles.msgStatus}>!</span>
-                        </Show>
-                      </div>
-                    </Match>
-                  </Switch>
+                              );
+                            }}
+                          </Show>
+                          <Show when={msg.status === 'sending'}>
+                            <span class={styles.msgStatus}>…</span>
+                          </Show>
+                          <Show when={msg.status === 'failed'}>
+                            <span class={styles.msgStatus}>!</span>
+                          </Show>
+                        </div>
+                      </Match>
+                    </Switch>
+                  </>
                 )}
               </For>
             </div>
@@ -453,6 +512,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               actions.setDraft(text);
               queueDraftSave(text);
             }}
+            onKeyDown={onDraftKeyDown}
             disabled={state.sending}
           />
           <button

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -88,6 +88,7 @@ function formatTimestamp(timestamp: number, locale: string) {
   const time = new Intl.DateTimeFormat(locale, {
     hour: 'numeric',
     minute: '2-digit',
+    // Product choice: keep message timestamps in 24-hour time for now.
     hour12: false,
   }).format(date);
 

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -16,6 +16,7 @@ import { LoadBoundary } from '../../components/app/LoadBoundary';
 import { showImagePreview } from '../../components/base-legacy/imagePreview.js';
 import { downloadUrl } from '@lib/utils/download-url.js';
 import { isIOSOrAndroidDevice } from '@lib/utils/detect-device.js';
+import { keepVirtualKeyboardOpenOnTap } from '@shared/utils/ui-utils/keepVirtualKeyboardOpenOnTap.js';
 
 import { createMessagingRuntime } from './messaging-runtime.js';
 
@@ -137,6 +138,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
   let messagesEl: HTMLDivElement | undefined;
   let inputTextAreaEl: HTMLTextAreaElement | undefined;
+  let sendButtonCleanup: (() => void) | undefined;
   let suppressScroll = false;
   let draftSaveTimer: ReturnType<typeof setTimeout> | undefined;
   let pendingDraft:
@@ -149,6 +151,13 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
   function focusInput() {
     inputTextAreaEl?.focus();
+  }
+
+  function attachSendButton(el: HTMLButtonElement) {
+    sendButtonCleanup?.();
+    sendButtonCleanup = isIOSOrAndroidDevice()
+      ? keepVirtualKeyboardOpenOnTap(el, () => el.form?.requestSubmit())
+      : undefined;
   }
 
   function clearDraftSaveTimer() {
@@ -316,10 +325,13 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
   onCleanup(() => {
     flushDraftSave();
+    sendButtonCleanup?.();
   });
 
   function onSubmit(e: SubmitEvent) {
     e.preventDefault();
+    if (state.sending) return;
+
     const { conversationId, myUserId } = state;
     if (conversationId && myUserId && state.draft.trim()) {
       clearDraftSaveTimer();
@@ -335,6 +347,8 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     if (e.key !== 'Enter' || e.shiftKey || isIOSOrAndroidDevice()) return;
 
     e.preventDefault();
+    if (state.sending) return;
+
     e.currentTarget.form?.requestSubmit();
   }
 
@@ -513,9 +527,9 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               queueDraftSave(text);
             }}
             onKeyDown={onDraftKeyDown}
-            disabled={state.sending}
           />
           <button
+            ref={attachSendButton}
             class={styles.send}
             type='submit'
             disabled={!state.draft.trim() || state.sending}

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -38,6 +38,13 @@ const runtime = createMessagingRuntime();
 const DRAFT_SAVE_DELAY_MS = 250;
 const TIMESTAMP_THRESHOLD_MS = 5 * 60 * 1000;
 
+type TimestampFormatters = {
+  time: Intl.DateTimeFormat;
+  day: Intl.DateTimeFormat;
+};
+
+const timestampFormattersByLocale = new Map<string, TimestampFormatters>();
+
 function dataUrlMimeType(url: string) {
   const match = /^data:([^;,]+)[;,]/i.exec(url);
   return match?.[1]?.toLowerCase() ?? 'text/plain';
@@ -82,22 +89,36 @@ function isSameLocalDate(a: Date, b: Date) {
   );
 }
 
+function getTimestampFormatters(locale: string) {
+  const cached = timestampFormattersByLocale.get(locale);
+  if (cached) return cached;
+
+  const formatters = {
+    time: new Intl.DateTimeFormat(locale, {
+      hour: 'numeric',
+      minute: '2-digit',
+      // Product choice: keep message timestamps in 24-hour time for now.
+      hour12: false,
+    }),
+    day: new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      day: 'numeric',
+    }),
+  };
+
+  timestampFormattersByLocale.set(locale, formatters);
+  return formatters;
+}
+
 function formatTimestamp(timestamp: number, locale: string) {
   const date = new Date(timestamp);
   const now = new Date();
-  const time = new Intl.DateTimeFormat(locale, {
-    hour: 'numeric',
-    minute: '2-digit',
-    // Product choice: keep message timestamps in 24-hour time for now.
-    hour12: false,
-  }).format(date);
+  const formatters = getTimestampFormatters(locale);
+  const time = formatters.time.format(date);
 
   if (isSameLocalDate(date, now)) return time;
 
-  const day = new Intl.DateTimeFormat(locale, {
-    month: 'short',
-    day: 'numeric',
-  }).format(date);
+  const day = formatters.day.format(date);
 
   return `${day} - ${time}`;
 }

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -345,7 +345,13 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   function onDraftKeyDown(
     e: KeyboardEvent & { currentTarget: HTMLTextAreaElement },
   ) {
-    if (e.key !== 'Enter' || e.shiftKey || isIOSOrAndroidDevice()) return;
+    if (
+      e.isComposing ||
+      e.key !== 'Enter' ||
+      e.shiftKey ||
+      isIOSOrAndroidDevice()
+    )
+      return;
 
     e.preventDefault();
     if (state.sending) return;

--- a/src/shared/utils/ui-utils/keepVirtualKeyboardOpenOnTap.js
+++ b/src/shared/utils/ui-utils/keepVirtualKeyboardOpenOnTap.js
@@ -29,6 +29,7 @@ export function keepVirtualKeyboardOpenOnTap(buttonEl, onTap) {
 
   const clickHandler = (event) => {
     if (event.detail !== 0) return; // pointer activation already handled above
+    event.preventDefault();
     onTap(event);
   };
 

--- a/src/shared/utils/ui-utils/keepVirtualKeyboardOpenOnTap.test.js
+++ b/src/shared/utils/ui-utils/keepVirtualKeyboardOpenOnTap.test.js
@@ -57,6 +57,7 @@ describe('keepVirtualKeyboardOpenOnTap', () => {
     button.dispatchEvent(event);
 
     expect(onTap).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it('does not double-trigger onTap for pointer-driven clicks', () => {


### PR DESCRIPTION
## Summary
- show timestamp separators in the conversation panel using the previous 5-minute grouping behavior
- send desktop messages with Enter while preserving Shift+Enter newlines and mobile native return behavior
- keep the mobile virtual keyboard open after tapping Send

## Verification
- pnpm ts
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message timestamps now appear between message groups with locale-aware formatting.
  * Improved mobile send behavior and keyboard handling for a smoother typing/send experience.
  * Message composition prevents duplicate submissions while a send is in progress.

* **Style**
  * Added styling for timestamp display.

* **Tests**
  * Added assertion ensuring keyboard-preserving tap/click prevents the default activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->