### PR TITLE
[codex] Enable image messages

### DIFF
--- a/src/features/messaging-next/ConversationPanel.module.css
+++ b/src/features/messaging-next/ConversationPanel.module.css
@@ -197,6 +197,39 @@
   margin-inline: 0.5rem;
 }
 
+.fileInput {
+  display: none;
+}
+
+.attach {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  padding: 0;
+  border: 1px solid #606060;
+  border-radius: 0.25rem;
+  background-color: #3e3e3e;
+  color: white;
+  cursor: pointer;
+}
+
+.attach:hover:not(:disabled) {
+  background-color: #4a4a4a;
+}
+
+.attach:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.attach:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+
 .growableTextArea {
   font-family: inherit;
   font-size: inherit;

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -9,12 +9,15 @@ import {
   on,
   onCleanup,
 } from 'solid-js';
+import { ImagePlus } from 'lucide-solid';
 import { getUserName } from '../../auth/index.js';
 
 import { useI18n } from '../../shared/i18n';
 import { LoadBoundary } from '../../components/app/LoadBoundary';
 import { showImagePreview } from '../../components/base-legacy/imagePreview.js';
+import { compressImage } from '@lib/media/image-compress.js';
 import { downloadUrl } from '@lib/utils/download-url.js';
+import { fileToBase64 } from '@lib/utils/file-to-base64.js';
 import { isIOSOrAndroidDevice } from '@lib/utils/detect-device.js';
 import { keepVirtualKeyboardOpenOnTap } from '@shared/utils/ui-utils/keepVirtualKeyboardOpenOnTap.js';
 
@@ -37,6 +40,11 @@ import styles from './ConversationPanel.module.css';
 const runtime = createMessagingRuntime();
 const DRAFT_SAVE_DELAY_MS = 250;
 const TIMESTAMP_THRESHOLD_MS = 5 * 60 * 1000;
+const MAX_INLINE_IMAGE_DATA_URL_CHARS = 700_000;
+const DATA_URL_METADATA_CHARS = 128;
+const MAX_INLINE_IMAGE_BINARY_BYTES = Math.floor(
+  ((MAX_INLINE_IMAGE_DATA_URL_CHARS - DATA_URL_METADATA_CHARS) * 3) / 4,
+);
 
 type TimestampFormatters = {
   time: Intl.DateTimeFormat;
@@ -160,6 +168,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
   let messagesEl: HTMLDivElement | undefined;
   let inputTextAreaEl: HTMLTextAreaElement | undefined;
+  let imageInputEl: HTMLInputElement | undefined;
   let sendButtonCleanup: (() => void) | undefined;
   let suppressScroll = false;
   let draftSaveTimer: ReturnType<typeof setTimeout> | undefined;
@@ -229,6 +238,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   const [historyLoading, setHistoryLoading] = createSignal(false);
   const [historyError, setHistoryError] = createSignal<unknown>(null);
   const [historyReady, setHistoryReady] = createSignal(false);
+  const [imagePreparing, setImagePreparing] = createSignal(false);
 
   function shouldShowTimestamp(message: ChatMessage, index: number) {
     const previous = state.messages[index - 1];
@@ -353,17 +363,76 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     sendButtonCleanup?.();
   });
 
+  function clearPersistedDraftIfNeeded() {
+    const { conversationId, myUserId } = state;
+    if (!conversationId || !myUserId || !state.draft.trim()) return;
+
+    clearDraftSaveTimer();
+    pendingDraft = undefined;
+    clearLocalDraft(myUserId, conversationId);
+  }
+
   function onSubmit(e: SubmitEvent) {
     e.preventDefault();
-    if (state.sending) return;
+    if (state.sending || imagePreparing()) return;
 
-    const { conversationId, myUserId } = state;
-    if (conversationId && myUserId && state.draft.trim()) {
-      clearDraftSaveTimer();
-      pendingDraft = undefined;
-      clearLocalDraft(myUserId, conversationId);
-    }
+    clearPersistedDraftIfNeeded();
     void send();
+  }
+
+  async function onImageInput(
+    e: Event & { currentTarget: HTMLInputElement },
+  ) {
+    const file = e.currentTarget.files?.[0];
+    e.currentTarget.value = '';
+    if (!file || state.sending || imagePreparing()) return;
+
+    const mimeType = file.type.toLowerCase();
+    if (!mimeType.startsWith('image/') || mimeType === 'image/svg+xml') {
+      window.alert('Choose a PNG, JPEG, GIF, WebP, or similar image.');
+      return;
+    }
+
+    setImagePreparing(true);
+    try {
+      const compressed = await compressImage(file, {
+        maxBytes: MAX_INLINE_IMAGE_BINARY_BYTES,
+      });
+      const image =
+        compressed ??
+        (file.size <= MAX_INLINE_IMAGE_BINARY_BYTES ? file : null);
+
+      if (!image) {
+        window.alert('Choose a smaller image for this browser test.');
+        return;
+      }
+
+      const data = await fileToBase64(image);
+      if (typeof data !== 'string') {
+        throw new Error('image data URL conversion failed');
+      }
+      if (data.length > MAX_INLINE_IMAGE_DATA_URL_CHARS) {
+        window.alert('Choose a smaller image for this browser test.');
+        return;
+      }
+
+      const caption = state.draft.trim();
+      clearPersistedDraftIfNeeded();
+      await send({
+        type: 'file',
+        fileName: image.name || file.name || 'image',
+        mimeType: image.type || file.type || 'image/*',
+        fileSize: image.size,
+        data,
+        text: caption || undefined,
+      });
+    } catch (error) {
+      console.warn('[conversation] failed to send image attachment', error);
+      window.alert('Image send failed.');
+    } finally {
+      setImagePreparing(false);
+      inputTextAreaEl?.focus();
+    }
   }
 
   function onDraftKeyDown(
@@ -378,7 +447,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       return;
 
     e.preventDefault();
-    if (state.sending) return;
+    if (state.sending || imagePreparing()) return;
 
     e.currentTarget.form?.requestSubmit();
   }
@@ -546,6 +615,23 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         </LoadBoundary>
 
         <form class={styles.form} onSubmit={onSubmit}>
+          <input
+            ref={imageInputEl}
+            class={styles.fileInput}
+            type='file'
+            accept='image/*'
+            onChange={onImageInput}
+          />
+          <button
+            class={styles.attach}
+            type='button'
+            aria-label='Attach image'
+            title='Attach image'
+            disabled={state.sending || imagePreparing()}
+            onClick={() => imageInputEl?.click()}
+          >
+            <ImagePlus size={20} aria-hidden='true' />
+          </button>
           <textarea
             autofocus
             ref={inputTextAreaEl}
@@ -563,7 +649,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
             ref={attachSendButton}
             class={styles.send}
             type='submit'
-            disabled={!state.draft.trim() || state.sending}
+            disabled={!state.draft.trim() || state.sending || imagePreparing()}
           >
             Send
           </button>

--- a/src/features/messaging-next/adapters/rtdb.test.js
+++ b/src/features/messaging-next/adapters/rtdb.test.js
@@ -69,6 +69,67 @@ describe('messaging-next RTDB adapter', () => {
     );
   });
 
+  it('writes legacy-compatible file message rows', async () => {
+    const repository = createRTDBMessageRepository();
+
+    await repository.send({
+      messageId: 'file-1',
+      conversationId: 'user-a_user-b',
+      senderId: 'user-a',
+      senderName: 'User A',
+      sentAt: 10,
+      delivery: 'persistent',
+      payload: {
+        type: 'file',
+        fileName: 'demo.webp',
+        mimeType: 'image/webp',
+        fileSize: 123,
+        data: 'data:image/webp;base64,abc',
+        text: 'caption',
+      },
+    });
+
+    expect(set).toHaveBeenCalledWith(
+      { path: 'conversations/user-a_user-b/messages/file-1' },
+      {
+        from: 'user-a',
+        fromName: 'User A',
+        type: 'file',
+        fileName: 'demo.webp',
+        mimeType: 'image/webp',
+        fileSize: 123,
+        data: 'data:image/webp;base64,abc',
+        url: null,
+        storage: null,
+        text: 'caption',
+        sentAt: serverTimestamp(),
+        read: false,
+      },
+    );
+  });
+
+  it('rejects file messages without data, url, or storage', async () => {
+    const repository = createRTDBMessageRepository();
+
+    await expect(
+      repository.send({
+        messageId: 'file-1',
+        conversationId: 'user-a_user-b',
+        senderId: 'user-a',
+        senderName: 'User A',
+        sentAt: 10,
+        delivery: 'persistent',
+        payload: {
+          type: 'file',
+          fileName: 'demo.webp',
+          mimeType: 'image/webp',
+          fileSize: 123,
+        },
+      }),
+    ).rejects.toThrow('file message payload requires data, url, or storage');
+    expect(set).not.toHaveBeenCalled();
+  });
+
   it('reserves RTDB push keys before optimistic rendering', () => {
     const repository = createRTDBMessageRepository();
 

--- a/src/features/messaging-next/adapters/rtdb.ts
+++ b/src/features/messaging-next/adapters/rtdb.ts
@@ -25,7 +25,6 @@ import { ConversationNodeSchema } from '../schema.js';
 import type {
   ConversationId,
   ConversationNode,
-  MessageEnvelope,
   UserId,
 } from '../types.js';
 
@@ -132,15 +131,6 @@ function toIncoming(
   };
 }
 
-function requireTextPayload(message: MessageEnvelope) {
-  if (message.payload.type !== 'text') {
-    throw new Error(
-      'RTDB legacy adapter currently supports text payloads only',
-    );
-  }
-  return message.payload;
-}
-
 function toConversationNode(raw: unknown): ConversationNode | null {
   const parsed = ConversationNodeSchema.safeParse(raw);
   return parsed.success ? parsed.data : null;
@@ -202,15 +192,42 @@ export function createRTDBMessageRepository(): MessageRepository {
     },
 
     async send(message) {
-      const payload = requireTextPayload(message);
-      await set(msgRef(message.conversationId, message.messageId), {
+      const base = {
         from: message.senderId,
         fromName: message.senderName ?? 'Guest User',
-        text: payload.text,
-        type: 'text',
         sentAt: serverTimestamp(),
         read: false,
-      });
+      };
+      const hasFileContent =
+        message.payload.type === 'file' &&
+        (Boolean(message.payload.data?.trim()) ||
+          Boolean(message.payload.url?.trim()) ||
+          Boolean(message.payload.storage));
+
+      if (message.payload.type === 'file' && !hasFileContent) {
+        throw new Error('file message payload requires data, url, or storage');
+      }
+
+      const payload: Record<string, unknown> =
+        message.payload.type === 'file'
+          ? {
+              ...base,
+              type: 'file',
+              fileName: message.payload.fileName,
+              mimeType: message.payload.mimeType,
+              fileSize: message.payload.fileSize,
+              data: message.payload.data ?? null,
+              url: message.payload.url ?? null,
+              storage: message.payload.storage ?? null,
+              text: message.payload.text ?? '',
+            }
+          : {
+              ...base,
+              type: 'text',
+              text: message.payload.text,
+            };
+
+      await set(msgRef(message.conversationId, message.messageId), payload);
       return { id: message.messageId, sentAt: Date.now() };
     },
 

--- a/src/features/messaging-next/interfaces.ts
+++ b/src/features/messaging-next/interfaces.ts
@@ -7,20 +7,25 @@ import type {
   ConversationNode,
   ConversationParticipant,
   DeliveryPolicy,
+  FileMessagePayload,
   MessageEnvelope,
+  TextMessagePayload,
   UserId,
 } from './types.js';
 
 // ─── Wire types ───────────────────────────────────────────────────────────────
 
 export type IncomingMessage = MessageEnvelope;
-export type OutgoingMessage = MessageEnvelope;
+export type OutgoingMessagePayload = TextMessagePayload | FileMessagePayload;
+export type OutgoingMessage = Omit<MessageEnvelope, 'payload'> & {
+  payload: OutgoingMessagePayload;
+};
 
 /** Wire format for chat messages sent over a datachannel (private mode). */
 export type P2PChatEnvelope = {
   protocol: 'hangvidu.messaging.v1';
   type: 'message';
-  message: MessageEnvelope;
+  message: OutgoingMessage;
 };
 
 // ─── Persistent backend ───────────────────────────────────────────────────────
@@ -65,6 +70,10 @@ export type MessageRepository = {
 
   /**
    * Persist a message envelope using msg.messageId as its canonical identity.
+   * Only user-authored text and file payloads are persistable through this
+   * boundary. File payloads must include at least one content pointer
+   * (data, url, or storage), matching FileMessagePayloadSchema, so adapters
+   * remain interchangeable and do not persist rows that cannot be read back.
    * Resolves with the same id and the backend-acknowledged timestamp metadata.
    */
   send(

--- a/src/features/messaging-next/tests/use-conversation.test.js
+++ b/src/features/messaging-next/tests/use-conversation.test.js
@@ -137,4 +137,59 @@ describe('messaging-next useConversation', () => {
     ]);
     expect(store.state.messages[0].status).toBe('sent');
   });
+
+  it('sends file payloads with optimistic attachment metadata', async () => {
+    const store = createConversationState();
+    const actions = createConversationActions(store);
+    actions.startConversation({ conversationId: 'conversation-1' }, 'me');
+    actions.setDraft('caption');
+
+    const repository = {
+      createMessageId: vi.fn(() => 'reserved-file-1'),
+      subscribeReactions: vi.fn(() => () => {}),
+      send: vi.fn(() => ({ id: 'reserved-file-1', sentAt: 10 })),
+    };
+
+    await useConversation({
+      repository,
+      store,
+      actions,
+    }).send({
+      type: 'file',
+      fileName: 'demo.webp',
+      mimeType: 'image/webp',
+      fileSize: 123,
+      data: 'data:image/webp;base64,abc',
+      text: 'caption',
+    });
+
+    expect(repository.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 'reserved-file-1',
+        conversationId: 'conversation-1',
+        senderId: 'me',
+        payload: {
+          type: 'file',
+          fileName: 'demo.webp',
+          mimeType: 'image/webp',
+          fileSize: 123,
+          data: 'data:image/webp;base64,abc',
+          text: 'caption',
+        },
+      }),
+    );
+    expect(store.state.draft).toBe('');
+    expect(store.state.messages[0]).toMatchObject({
+      id: 'reserved-file-1',
+      text: 'caption',
+      status: 'sent',
+      attachment: {
+        type: 'file',
+        fileName: 'demo.webp',
+        mimeType: 'image/webp',
+        fileSize: 123,
+        data: 'data:image/webp;base64,abc',
+      },
+    });
+  });
 });

--- a/src/features/messaging-next/use-conversation.ts
+++ b/src/features/messaging-next/use-conversation.ts
@@ -10,7 +10,9 @@ import type {
 import type {
   ConversationId,
   DeliveryPolicy,
+  FileMessagePayload,
   MessageEnvelope,
+  TextMessagePayload,
   UserId,
 } from './types.js';
 import type { ConversationStateStore } from './conversation.state.js';
@@ -26,6 +28,8 @@ type UseConversationOptions = {
   /** Optional datachannel transport for private mode. Without it, private sends fail. */
   privateTransport?: PrivateMessageTransport;
 };
+
+type SendPayload = TextMessagePayload | FileMessagePayload;
 
 export function envelopeToChatMessage(
   message: MessageEnvelope,
@@ -171,10 +175,12 @@ export function useConversation({
     });
   });
 
-  async function send() {
+  async function send(payloadOverride?: SendPayload) {
     const { conversationId, myUserId, draft, transportMode } = state;
     const text = draft.trim();
-    if (!conversationId || !myUserId || !text) return;
+    const payload: SendPayload = payloadOverride ?? { type: 'text', text };
+    if (!conversationId || !myUserId) return;
+    if (payload.type === 'text' && !payload.text.trim()) return;
 
     const delivery: DeliveryPolicy =
       transportMode === 'private' ? 'private' : 'persistent';
@@ -186,11 +192,26 @@ export function useConversation({
         : repository.createMessageId(conversationId);
     const sentAt = Date.now();
     const senderName = getSenderName?.() ?? undefined;
+    const optimisticText =
+      payload.type === 'text' ? payload.text : (payload.text?.trim() ?? '');
+    const attachment =
+      payload.type === 'file'
+        ? {
+            type: 'file' as const,
+            fileName: payload.fileName,
+            mimeType: payload.mimeType,
+            fileSize: payload.fileSize,
+            data: payload.data,
+            url: payload.url,
+            storage: payload.storage,
+          }
+        : undefined;
 
     actions.addOptimisticMessage({
       id: tempId,
       conversationId,
-      text,
+      text: optimisticText,
+      attachment,
       senderId: myUserId,
       sentAt,
       status: 'sending',
@@ -217,10 +238,7 @@ export function useConversation({
             senderName,
             sentAt,
             delivery,
-            payload: {
-              type: 'text',
-              text,
-            },
+            payload,
           },
         };
         privateTransport.send(JSON.stringify(envelope));
@@ -233,10 +251,7 @@ export function useConversation({
           senderName,
           sentAt,
           delivery,
-          payload: {
-            type: 'text',
-            text,
-          },
+          payload,
         });
         actions.markSent(tempId, saved.id);
       }

--- a/src/lib/media/image-compress.js
+++ b/src/lib/media/image-compress.js
@@ -6,7 +6,7 @@
  *
  * @param {File} file - The image file to compress
  * @param {object} [opts]
- * @param {number} [opts.maxBytes=700_000] - Target max file size in bytes (accounts for base64 overhead)
+ * @param {number} [opts.maxBytes=700_000] - Target max compressed Blob size in bytes
  * @param {number} [opts.maxDimension=1280] - Starting max width or height in px
  * @returns {Promise<File|null>}
  */


### PR DESCRIPTION
## Reference-only note

This PR is kept only as a reference implementation/spike for browser image send UI and inline RTDB file-message plumbing. It should be deleted/closed once PR #529 lands the intended R2-backed file implementation. Do not merge this PR as the production files path.

---

## Summary

- Adds an image attachment button to the messaging composer for browser image send testing.
- Sends image attachments as legacy-compatible RTDB file rows using inline data URLs for this minimal slice.
- Reuses the existing read-side attachment rendering so received images preview and download in the conversation.

## Validation

- Manual browser verification passed for sending and receiving images.
- `pnpm vitest --run src/features/messaging-next/tests/use-conversation.test.js src/features/messaging-next/adapters/rtdb.test.js`
- `pnpm build`
- `git diff --check`

## Notes

This intentionally keeps the implementation narrow: image-only picker, inline data URLs, compression/downscale where supported, no storage backend, no multi-file queue, and no drag/drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach and send raster image files inline with optional captions, client-side compression, and size/format validation (SVG rejected).

* **UI**
  * Attachment button styling and focus states; attach/send buttons disabled while an image is preparing and Enter-to-send respects preparing state.

* **Bug Fixes / UX**
  * Drafts reliably cleared when sending messages with attachments.

* **Tests**
  * Added tests for optimistic sending, persistence, and rejection of file messages.

* **Documentation**
  * Clarified image compression parameter in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
