### PR TITLE
fix(messaging): stop scroll jumps in conversations with images

### DIFF
--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -691,6 +691,8 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                                     <img
                                       class={styles.filePreviewImg}
                                       src={attachmentUrl() ?? undefined}
+                                      width={file.width}
+                                      height={file.height}
                                       alt={file.fileName}
                                       onLoad={followIfPinned}
                                       role='button'

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -360,6 +360,9 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         flushDraftSave();
         setHistoryReady(false);
         suppressScroll = true;
+        // The messages container remounts on switch; drop the old position so
+        // the first scroll comparison isn't against the previous conversation.
+        lastScrollTop = 0;
 
         const selection = props.selection;
         if (!source || !selection) {

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -150,9 +150,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   let sendButtonCleanup: (() => void) | undefined;
   let suppressScroll = false;
   // True once the user scrolls away from the bottom to read earlier messages.
-  // While set, new messages do not yank the view back down. Updated only on user
-  // scroll, so content growth (new bubble, late-loading image) can't flip it.
+  // While set, new messages do not yank the view back down. Scroll events also
+  // fire on layout changes (clamping, scroll anchoring), so only upward
+  // movement may latch it — see onMessagesScroll.
   let userHasScrolledUp = false;
+  let lastScrollTop = 0;
   const pendingR2Loads = new Map<string, AbortController>();
   let draftSaveTimer: ReturnType<typeof setTimeout> | undefined;
   let pendingDraft:
@@ -186,7 +188,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   }
 
   function onMessagesScroll() {
-    userHasScrolledUp = !isNearBottom();
+    const scrollTop = messagesEl?.scrollTop ?? 0;
+    const movedUp = scrollTop < lastScrollTop;
+    lastScrollTop = scrollTop;
+    if (movedUp) userHasScrolledUp = !isNearBottom();
+    else if (isNearBottom()) userHasScrolledUp = false;
   }
 
   // Follow new/grown content to the bottom, unless the user has scrolled up to

--- a/src/features/messaging-next/conversation.actions.ts
+++ b/src/features/messaging-next/conversation.actions.ts
@@ -1,3 +1,4 @@
+import { reconcile } from 'solid-js/store';
 import type { ConversationStateStore } from './conversation.state.js';
 import type {
   ChatMessage,
@@ -55,13 +56,17 @@ export function createConversationActions(store: ConversationStateStore) {
   }
 
   function mergeLoadedMessages(messages: ChatMessage[]) {
-    setState('messages', (current) => {
-      const byId = new Map(current.map((msg) => [msg.id, msg]));
-      for (const msg of messages) {
-        byId.set(msg.id, msg);
-      }
-      return sortMessagesBySentAt([...byId.values()]);
-    });
+    const byId = new Map(state.messages.map((msg) => [msg.id, msg]));
+    for (const msg of messages) {
+      byId.set(msg.id, msg);
+    }
+    // Reconcile keyed by id so unchanged messages keep their store identity —
+    // otherwise every snapshot rebuilds the whole <For> list (and remounts
+    // every <img>, collapsing scroll layout).
+    setState(
+      'messages',
+      reconcile(sortMessagesBySentAt([...byId.values()]), { key: 'id' }),
+    );
   }
 
   function receiveMessage(msg: Omit<ChatMessage, 'status'>) {

--- a/src/features/messaging-next/interfaces.ts
+++ b/src/features/messaging-next/interfaces.ts
@@ -222,6 +222,10 @@ export type MessageAttachment = {
   fileName: string;
   mimeType: string;
   fileSize: number;
+  // Natural image dimensions. Optional: populated once upload/schema carry
+  // them; when present the renderer reserves layout space before load.
+  width?: number;
+  height?: number;
   storage: {
     provider: 'r2';
     bucket: string;


### PR DESCRIPTION
## Problem
Opening a long conversation with images, the view starts at the bottom but then jumps to a seemingly random position and stays there; after sending a message it jumps up again.

## Root cause
1. `mergeLoadedMessages` overwrote every message with a freshly created object on each RTDB `onValue` snapshot (fired on open, every send echo, every receive, every read-flag write). Solid's `<For>` keys rows by reference, so the entire message DOM was torn down and rebuilt each time — every `<img>` remounted at 0 height and re-decoded async, collapsing and regrowing `scrollHeight`.
2. Those layout changes fire scroll events (clamping, browser scroll anchoring). `onMessagesScroll` latched `userHasScrolledUp = true` from them with no user input, permanently disabling auto-follow — the view stuck wherever the scroll anchor landed.

## Fix
- `conversation.actions.ts`: apply the merged message list via `reconcile(..., { key: 'id' })` so unchanged messages keep their store identity and the DOM is patched, not rebuilt.
- `ConversationPanel.tsx`: only upward scroll movement may latch `userHasScrolledUp`; layout-driven scroll events (downward or at-bottom) can no longer disable following.

## Validation
- `pnpm ts` and eslint clean; `conversation.actions` tests pass (6/6).
- Manual check: open image-heavy conversation (settles pinned at bottom), send a message (stays at bottom).

## Deferred
Images still reserve no layout space until loaded (minor first-load shift now). Durable fix is storing image dimensions in attachment metadata + `aspect-ratio` — fits the upcoming D1 messages slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation scroll logic to avoid false "scrolled up" states and keep the view pinned reliably when layout changes occur.

* **Performance Improvements**
  * Reduced unnecessary remounts and re-rendering in the message list when messages load to provide smoother updates.

* **New Features**
  * Image attachments now include and use natural width/height to reserve space for previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->