### PR TITLE
fix(auth): make auth-ready signal trustworthy; never stall init

### DIFF
--- a/src/auth/auth-setup.js
+++ b/src/auth/auth-setup.js
@@ -51,6 +51,10 @@ export async function signInAsGuest() {
   return user.uid;
 }
 
+// Max wait for the Safari redirect-result check before proceeding to register
+// the auth listener. Prevents a hung check from pinning auth state at 'loading'.
+const REDIRECT_RESULT_TIMEOUT_MS = 4000;
+
 const isProd =
   typeof import.meta !== 'undefined' && Boolean(import.meta.env?.PROD);
 
@@ -90,7 +94,9 @@ async function _initAuthInternal() {
   // Signal that auth initialization is in progress
   setState({ status: 'loading' });
 
-  // 1. Set persistence with graceful fallback for Safari/iOS/private mode
+  // 1. Set persistence with graceful fallback for Safari/iOS/private mode.
+  // Must never throw: a rejection here would skip listener registration below
+  // and pin auth state at 'loading' forever (stuck UI).
   try {
     await setFirebaseAuthPersistence(
       persistenceBackends.indexedDBLocalPersistence,
@@ -101,13 +107,29 @@ async function _initAuthInternal() {
         persistenceBackends.browserLocalPersistence,
       );
     } catch {
-      await setFirebaseAuthPersistence(persistenceBackends.inMemoryPersistence);
+      try {
+        await setFirebaseAuthPersistence(
+          persistenceBackends.inMemoryPersistence,
+        );
+      } catch (e) {
+        // In-memory is the last resort; proceed without persistence rather
+        // than blocking auth initialization.
+        logAuthError('All persistence backends failed', e);
+      }
     }
   }
 
-  // 2. Process redirect results (Safari external fallback)
+  // 2. Process redirect results (Safari external fallback). Bounded by a
+  // timeout so a hung redirect check can't block listener registration and
+  // pin auth state at 'loading'. The auth listener below still reports any
+  // redirect sign-in once Firebase resolves it.
   try {
-    const result = await getFirebaseRedirectResult();
+    const result = await Promise.race([
+      getFirebaseRedirectResult(),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(null), REDIRECT_RESULT_TIMEOUT_MS),
+      ),
+    ]);
     if (result?.user) {
       devDebug('[AUTH] Sign-in completed (via Safari fallback)');
     }

--- a/src/auth/auth-setup.js
+++ b/src/auth/auth-setup.js
@@ -91,12 +91,9 @@ export function initAuth() {
 async function _initAuthInternal() {
   setupAuthCommandHandlers();
 
-  // Signal that auth initialization is in progress
-  setState({ status: 'loading' });
-
   // 1. Set persistence with graceful fallback for Safari/iOS/private mode.
-  // Must never throw: a rejection here would skip listener registration below
-  // and pin auth state at 'loading' forever (stuck UI).
+  // Must never throw: a rejection here would skip listener registration below,
+  // leaving auth state stuck at 'uninitialized' (never ready → stuck UI).
   try {
     await setFirebaseAuthPersistence(
       persistenceBackends.indexedDBLocalPersistence,
@@ -121,8 +118,8 @@ async function _initAuthInternal() {
 
   // 2. Process redirect results (Safari external fallback). Bounded by a
   // timeout so a hung redirect check can't block listener registration and
-  // pin auth state at 'loading'. The auth listener below still reports any
-  // redirect sign-in once Firebase resolves it.
+  // leave auth state stuck at 'uninitialized'. The auth listener below still
+  // reports any redirect sign-in once Firebase resolves it.
   try {
     const result = await Promise.race([
       getFirebaseRedirectResult(),

--- a/src/auth/auth-state.js
+++ b/src/auth/auth-state.js
@@ -4,8 +4,8 @@ import { getOrCreateGuestId } from './guest-user.js';
 import { publish, publishAndAwait } from '../shared/events/index.js';
 
 let state = {
-  status: 'idle', // 'idle' | 'loading' | 'authenticated' | 'unauthenticated'
-  // 'idle' = before initAuth() completes
+  status: 'uninitialized', // 'uninitialized' | 'loading' | 'authenticated' | 'unauthenticated'
+  // 'uninitialized' = auth not yet determined (pre first resolution); not ready
   // 'loading' = auth operation in flight (sign-in/out/delete)
   // 'authenticated' | 'unauthenticated' = stable login state
   user: null, // { uid, userName, email, photoURL } | null
@@ -57,15 +57,17 @@ export function setState(next) {
   const wasReadyResolved = hasResolvedReady;
 
   let patch = next;
-  if (patch?.status === 'idle' && state.status !== 'idle') {
+  if (patch?.status === 'uninitialized' && state.status !== 'uninitialized') {
     console.warn(
-      '[auth-state] Ignoring reset to idle after auth initialization',
+      '[auth-state] Ignoring reset to uninitialized after auth initialization',
     );
     patch = toStableAuthState(state);
   }
 
   state = { ...state, ...patch };
   const snap = snapshot();
+  import.meta.env.DEV && console.info('[AUTH] setState', snap);
+
   for (const fn of listeners) {
     try {
       fn(snap);

--- a/src/auth/solid-auth.tsx
+++ b/src/auth/solid-auth.tsx
@@ -10,7 +10,7 @@ import {
 import { getAuthState, onAuthStateChanged } from './auth-state.js';
 
 export type AuthStatus =
-  | 'idle'
+  | 'uninitialized'
   | 'loading'
   | 'authenticated'
   | 'unauthenticated';
@@ -57,7 +57,7 @@ export function AuthProvider(props: { children: JSX.Element }) {
 
   const user = createMemo(() => snapshot().user);
   const status = createMemo(() => snapshot().status);
-  const isAuthInitialized = createMemo(() => status() !== 'idle');
+  const isAuthInitialized = createMemo(() => status() !== 'uninitialized');
   const isLoading = createMemo(() => status() === 'loading');
   const isLoggedIn = createMemo(() => snapshot().isLoggedIn);
   const isLoggingIn = createMemo(() => isLoading() && !isLoggedIn());

--- a/src/auth/tests/auth-bus-events.test.js
+++ b/src/auth/tests/auth-bus-events.test.js
@@ -51,7 +51,7 @@ describe('auth-state shared auth events', () => {
           isLoggedIn: true,
         }),
         previousState: expect.objectContaining({
-          status: 'idle',
+          status: 'uninitialized',
           isLoggedIn: false,
         }),
         isInitialResolution: true,

--- a/src/auth/tests/auth-state.test.js
+++ b/src/auth/tests/auth-state.test.js
@@ -23,7 +23,7 @@ describe('waitForAuthReady', () => {
   it('waits for a stable auth state, not loading', async () => {
     const { setState, waitForAuthReady } = await import('../auth-state.js');
 
-    setState({ status: 'idle', isLoggedIn: false, user: null });
+    setState({ status: 'uninitialized', isLoggedIn: false, user: null });
 
     const ready = waitForAuthReady();
     const result = await Promise.race([
@@ -69,14 +69,14 @@ describe('onAuthStateChanged', () => {
 });
 
 describe('setState', () => {
-  it('guards against resetting to idle after auth has initialized', async () => {
+  it('guards against resetting to uninitialized after auth has initialized', async () => {
     const { setState, getAuthState } = await import('../auth-state.js');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
       setState({ status: 'unauthenticated', isLoggedIn: false, user: null });
       setState({ status: 'loading' });
-      setState({ status: 'idle' });
+      setState({ status: 'uninitialized' });
 
       expect(getAuthState()).toEqual({
         status: 'unauthenticated',
@@ -84,7 +84,7 @@ describe('setState', () => {
         user: null,
       });
       expect(warn).toHaveBeenCalledWith(
-        '[auth-state] Ignoring reset to idle after auth initialization',
+        '[auth-state] Ignoring reset to uninitialized after auth initialization',
       );
     } finally {
       warn.mockRestore();


### PR DESCRIPTION
## Summary

Hardens auth initialization so the "auth ready" signal can be trusted, fixing intermittent stuck-loading / missing-state on app open (observed on iOS after #539).

Two root causes, both about `status` getting stuck or being misleading:

### 1. Init could stall before the auth listener registers (`5616c299`)
`onFirebaseAuthStateChanged` is only registered *after* persistence setup and the Safari redirect-result check. Two paths could prevent that:
- The `inMemoryPersistence` fallback was unguarded — a throw rejected `initAuth()` before listener registration.
- `getFirebaseRedirectResult()` was awaited unbounded — a hung check blocked registration.

Both now fail safe: the persistence chain can't throw, and the redirect check is bounded by a 4s race. The listener always registers, so Firebase always reports the first state.

### 2. `status` left 'idle' prematurely, so `isAuthInitialized` lied (`2bd03069`)
Init forced `status: 'loading'` immediately, so `isAuthInitialized` (`status !== 'idle'`) was true before we knew anything — showing a "signing in…" indicator on passive page load and risking a login-button flash. Removed that premature transition: status stays uninitialized until the listener reports the first stable result.

Also renamed the state `'idle'` → `'uninitialized'` so `isAuthInitialized` is self-documenting. `'loading'` is now reserved for actual sign-in/out operations, matching the documented contract. `isAuthInitialized` becomes a correct latching signal — false until resolved, true after, never flipping back during later sign-in/out.

No new accessors; net fewer moving parts.

## Scope / non-goals
Auth is slated to migrate off Firebase, so this is deliberately minimal — no state-machine redesign. The unrelated p2p `'idle'` state is untouched.

## Validation
- `tsc` clean, eslint clean, 17/17 auth tests pass.
- Manual cold-load (logged-in) verified via console logs: `uninitialized → unauthenticated → loading → authenticated`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Authentication initialization now completes reliably and won't block if redirect handling is slow or unavailable
  * Improved fallback behavior when storage persistence backends fail—initialization proceeds safely with graceful error logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->