### PR TITLE
Fix/call invite wedge

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -36,7 +36,7 @@
         "calls": {
           "incoming": {
             ".read": "$userId === auth.uid",
-            ".write": "($userId === auth.uid && !newData.exists()) || (auth != null && !newData.exists() && data.child('callerId').val() === auth.uid) || (auth != null && newData.hasChildren(['roomId', 'callerId', 'startedAt']) && newData.child('roomId').isString() && newData.child('callerId').val() === auth.uid && newData.child('startedAt').isNumber() && (!newData.child('calleeId').exists() || newData.child('calleeId').val() === $userId) && (!newData.child('expiresAt').exists() || newData.child('expiresAt').isNumber()) && (!newData.child('callerName').exists() || newData.child('callerName').isString()) && (!newData.child('audioOnly').exists() || newData.child('audioOnly').isBoolean()))"
+            ".write": "($userId === auth.uid && !newData.exists()) || (auth != null && !newData.exists() && data.child('callerId').val() === auth.uid) || (auth != null && (!data.exists() || data.child('callerId').val() === auth.uid || (data.child('expiresAt').exists() && data.child('expiresAt').isNumber() && data.child('expiresAt').val() <= now)) && newData.hasChildren(['roomId', 'callerId', 'startedAt']) && newData.child('roomId').isString() && newData.child('callerId').val() === auth.uid && newData.child('startedAt').isNumber() && (!newData.child('calleeId').exists() || newData.child('calleeId').val() === $userId) && (!newData.child('expiresAt').exists() || newData.child('expiresAt').isNumber()) && (!newData.child('callerName').exists() || newData.child('callerName').isString()) && (!newData.child('audioOnly').exists() || newData.child('audioOnly').isBoolean()))"
           },
           "response": {
             ".read": "auth != null",

--- a/database.rules.json
+++ b/database.rules.json
@@ -36,7 +36,7 @@
         "calls": {
           "incoming": {
             ".read": "$userId === auth.uid",
-            ".write": "($userId === auth.uid && !newData.exists()) || (auth != null && !newData.exists() && data.child('callerId').val() === auth.uid) || (auth != null && !data.exists() && newData.hasChildren(['roomId', 'callerId', 'startedAt']) && newData.child('roomId').isString() && newData.child('callerId').val() === auth.uid && newData.child('startedAt').isNumber() && (!newData.child('calleeId').exists() || newData.child('calleeId').val() === $userId) && (!newData.child('expiresAt').exists() || newData.child('expiresAt').isNumber()) && (!newData.child('callerName').exists() || newData.child('callerName').isString()) && (!newData.child('audioOnly').exists() || newData.child('audioOnly').isBoolean()))"
+            ".write": "($userId === auth.uid && !newData.exists()) || (auth != null && !newData.exists() && data.child('callerId').val() === auth.uid) || (auth != null && newData.hasChildren(['roomId', 'callerId', 'startedAt']) && newData.child('roomId').isString() && newData.child('callerId').val() === auth.uid && newData.child('startedAt').isNumber() && (!newData.child('calleeId').exists() || newData.child('calleeId').val() === $userId) && (!newData.child('expiresAt').exists() || newData.child('expiresAt').isNumber()) && (!newData.child('callerName').exists() || newData.child('callerName').isString()) && (!newData.child('audioOnly').exists() || newData.child('audioOnly').isBoolean()))"
           },
           "response": {
             ".read": "auth != null",

--- a/scripts/migrate-d1-attachment-keys.mjs
+++ b/scripts/migrate-d1-attachment-keys.mjs
@@ -72,6 +72,7 @@ const rows = d1Select(
 );
 
 const pendingUpdates = [];
+const pendingDeletes = [];
 
 let scanned = 0;
 let aligned = 0;
@@ -111,10 +112,7 @@ for (const row of rows) {
     // Defer the D1 write: copies happen first, then one batched UPDATE.
     pendingUpdates.push({ id, newKey });
 
-    if (deleteOld) {
-      await deleteR2Object(config, oldKey);
-      deleted += 1;
-    }
+    if (deleteOld) pendingDeletes.push(oldKey);
   } catch (error) {
     failed += 1;
     console.error(`[failed] ${id} ${oldKey}: ${error?.message || error}`);
@@ -124,6 +122,17 @@ for (const row of rows) {
 if (pendingUpdates.length > 0) {
   d1ApplyUpdates(pendingUpdates);
   updated = pendingUpdates.length;
+}
+
+// Only sweep old objects once D1 points at the new keys — otherwise a failed
+// update would orphan rows whose source object is already gone (no re-run).
+for (const oldKey of pendingDeletes) {
+  try {
+    await deleteR2Object(config, oldKey);
+    deleted += 1;
+  } catch (error) {
+    console.error(`[delete failed] ${oldKey}: ${error?.message || error}`);
+  }
 }
 
 console.log(

--- a/scripts/migrate-d1-attachment-keys.mjs
+++ b/scripts/migrate-d1-attachment-keys.mjs
@@ -20,11 +20,10 @@
 // Old objects are kept (cheap rollback); pass --delete-old to remove them once
 // verified.
 //
-// Env (e.g. in .env.r2.local, same as migrate-rtdb-files-to-r2.js):
+// R2 creds (e.g. in .env.r2.local, same as migrate-rtdb-files-to-r2.js):
 //   R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET
-//   CLOUDFLARE_API_TOKEN            (D1 edit)
-//   D1_DATABASE_ID                  (hangvidu-data)
-//   CLOUDFLARE_ACCOUNT_ID           (defaults to R2_ACCOUNT_ID)
+// D1 goes through the wrangler CLI (must be `wrangler login`-ed with d1 write),
+// so no Cloudflare API token is required.
 //
 // Usage:
 //   node scripts/migrate-d1-attachment-keys.mjs                  # dry run
@@ -32,8 +31,10 @@
 //   node scripts/migrate-d1-attachment-keys.mjs --write
 //   node scripts/migrate-d1-attachment-keys.mjs --write --delete-old
 
+import { spawnSync } from 'node:child_process';
 import { createHash, createHmac } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -52,21 +53,25 @@ if (limitArg && (!Number.isFinite(limit) || limit <= 0)) {
 
 const PREFIX = 'conversation-files';
 
+// D1 goes through the already-authenticated wrangler CLI (same path as
+// `pnpm migrate:remote`), so no Cloudflare API token is needed.
+const D1_DATABASE = 'hangvidu-data';
+const D1_CONFIG = 'workers/data/wrangler.jsonc';
+
 const config = {
   accountId: requiredEnv('R2_ACCOUNT_ID'),
   accessKeyId: requiredEnv('R2_ACCESS_KEY_ID'),
   secretAccessKey: requiredEnv('R2_SECRET_ACCESS_KEY'),
   bucket: requiredEnv('R2_BUCKET'),
-  apiToken: requiredEnv('CLOUDFLARE_API_TOKEN'),
-  databaseId: requiredEnv('D1_DATABASE_ID'),
 };
-const cfAccountId = process.env.CLOUDFLARE_ACCOUNT_ID || config.accountId;
 
-const rows = await d1Query(
+const rows = d1Select(
   `SELECT a.id AS id, a.r2_key AS r2_key, m.conversation_id AS conversation_id
    FROM message_attachments a
    JOIN messages m ON m.id = a.message_id`,
 );
+
+const pendingUpdates = [];
 
 let scanned = 0;
 let aligned = 0;
@@ -103,12 +108,8 @@ for (const row of rows) {
   try {
     await copyR2Object(config, oldKey, newKey);
     copied += 1;
-
-    await d1Query(`UPDATE message_attachments SET r2_key = ? WHERE id = ?`, [
-      newKey,
-      id,
-    ]);
-    updated += 1;
+    // Defer the D1 write: copies happen first, then one batched UPDATE.
+    pendingUpdates.push({ id, newKey });
 
     if (deleteOld) {
       await deleteR2Object(config, oldKey);
@@ -118,6 +119,11 @@ for (const row of rows) {
     failed += 1;
     console.error(`[failed] ${id} ${oldKey}: ${error?.message || error}`);
   }
+}
+
+if (pendingUpdates.length > 0) {
+  d1ApplyUpdates(pendingUpdates);
+  updated = pendingUpdates.length;
 }
 
 console.log(
@@ -140,25 +146,46 @@ function rekey(key, conversationId) {
   return parts.join('/');
 }
 
-// --- D1 (HTTP API) -------------------------------------------------------
+// --- D1 (via wrangler) ---------------------------------------------------
 
-async function d1Query(sql, params = []) {
-  const res = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${cfAccountId}/d1/database/${config.databaseId}/query`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${config.apiToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ sql, params }),
-    },
+function wrangler(extraArgs) {
+  const result = spawnSync(
+    'npx',
+    ['wrangler', 'd1', 'execute', D1_DATABASE, '--remote', '--config', D1_CONFIG, ...extraArgs],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
   );
-  const body = await res.json();
-  if (!res.ok || !body.success) {
-    throw new Error(`D1 query failed: ${res.status} ${JSON.stringify(body.errors ?? body)}`);
+  if (result.status !== 0) {
+    throw new Error(`wrangler failed: ${result.stderr || result.stdout}`);
   }
-  return body.result?.[0]?.results ?? [];
+  return result.stdout;
+}
+
+function d1Select(sql) {
+  const out = wrangler(['--json', '--command', sql]);
+  // `--json` prints a JSON array of result sets, sometimes preceded by banner
+  // lines; slice from the first bracket.
+  const parsed = JSON.parse(out.slice(out.indexOf('[')));
+  return parsed?.[0]?.results ?? [];
+}
+
+function d1ApplyUpdates(updates) {
+  const sql = updates
+    .map(
+      ({ id, newKey }) =>
+        `UPDATE message_attachments SET r2_key='${sqlEscape(newKey)}' WHERE id='${sqlEscape(id)}';`,
+    )
+    .join('\n');
+  const file = path.join(tmpdir(), `attachment-key-updates-${Date.now()}.sql`);
+  writeFileSync(file, sql);
+  try {
+    wrangler(['--file', file]);
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function sqlEscape(value) {
+  return String(value).replaceAll("'", "''");
 }
 
 // --- R2 (S3 SigV4) -------------------------------------------------------
@@ -310,8 +337,9 @@ function loadEnvFile(file) {
   }
 }
 
-function requiredEnv(name) {
-  const value = process.env[name];
-  if (!value) throw new Error(`${name} is required`);
-  return value;
+function requiredEnv(name, ...fallbacks) {
+  for (const key of [name, ...fallbacks]) {
+    if (process.env[key]) return process.env[key];
+  }
+  throw new Error(`${[name, ...fallbacks].join(' or ')} is required`);
 }

--- a/scripts/migrate-d1-attachment-keys.mjs
+++ b/scripts/migrate-d1-attachment-keys.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+// One-off: realign D1 `message_attachments.r2_key` with the opaque
+// conversationId.
+//
+// The RTDB->D1 backfill (workers/data/scripts/backfill-rtdb-messages.mjs)
+// copied the legacy `conversation-files/<a_b>/<fileId>` key verbatim while the
+// conversation got a fresh opaque id. The files worker requires the key to be
+// prefixed with `conversation-files/<conversationId>/` (keyBelongsToConversation
+// in workers/files/src/index.ts), so every migrated image 400s.
+//
+// This script, per attachment whose key does not match its conversation:
+//   1. server-side-copies the R2 object  conversation-files/<old>/<fileId>
+//      -> conversation-files/<conversationId>/<fileId>  (S3 CopyObject; the
+//      default COPY metadata-directive preserves Content-Type and the
+//      `uploadedBy` custom metadata the worker's delete path needs), then
+//   2. UPDATEs message_attachments.r2_key to the new key.
+//
+// Dry-run by default; pass --write to mutate. Idempotent: already-aligned rows
+// are skipped, and a re-run after a partial failure simply re-copies + updates.
+// Old objects are kept (cheap rollback); pass --delete-old to remove them once
+// verified.
+//
+// Env (e.g. in .env.r2.local, same as migrate-rtdb-files-to-r2.js):
+//   R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET
+//   CLOUDFLARE_API_TOKEN            (D1 edit)
+//   D1_DATABASE_ID                  (hangvidu-data)
+//   CLOUDFLARE_ACCOUNT_ID           (defaults to R2_ACCOUNT_ID)
+//
+// Usage:
+//   node scripts/migrate-d1-attachment-keys.mjs                  # dry run
+//   node scripts/migrate-d1-attachment-keys.mjs --write --limit=1 # test one object end-to-end
+//   node scripts/migrate-d1-attachment-keys.mjs --write
+//   node scripts/migrate-d1-attachment-keys.mjs --write --delete-old
+
+import { createHash, createHmac } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_ENV_FILES = ['.env.r2.local', '.env.local', '.env'];
+for (const file of DEFAULT_ENV_FILES) loadEnvFile(file);
+
+const argv = process.argv.slice(2);
+const args = new Set(argv);
+const dryRun = !args.has('--write');
+const deleteOld = args.has('--delete-old');
+const limitArg = argv.find((a) => a.startsWith('--limit='));
+const limit = limitArg ? Number(limitArg.slice('--limit='.length)) : Infinity;
+if (limitArg && (!Number.isFinite(limit) || limit <= 0)) {
+  throw new Error('--limit must be a positive number');
+}
+
+const PREFIX = 'conversation-files';
+
+const config = {
+  accountId: requiredEnv('R2_ACCOUNT_ID'),
+  accessKeyId: requiredEnv('R2_ACCESS_KEY_ID'),
+  secretAccessKey: requiredEnv('R2_SECRET_ACCESS_KEY'),
+  bucket: requiredEnv('R2_BUCKET'),
+  apiToken: requiredEnv('CLOUDFLARE_API_TOKEN'),
+  databaseId: requiredEnv('D1_DATABASE_ID'),
+};
+const cfAccountId = process.env.CLOUDFLARE_ACCOUNT_ID || config.accountId;
+
+const rows = await d1Query(
+  `SELECT a.id AS id, a.r2_key AS r2_key, m.conversation_id AS conversation_id
+   FROM message_attachments a
+   JOIN messages m ON m.id = a.message_id`,
+);
+
+let scanned = 0;
+let aligned = 0;
+let copied = 0;
+let updated = 0;
+let deleted = 0;
+let skipped = 0;
+let failed = 0;
+
+for (const row of rows) {
+  scanned += 1;
+  const { id, r2_key: oldKey, conversation_id: conversationId } = row;
+
+  const expectedPrefix = `${PREFIX}/${conversationId}/`;
+  if (oldKey.startsWith(expectedPrefix)) {
+    aligned += 1;
+    continue;
+  }
+
+  const newKey = rekey(oldKey, conversationId);
+  if (!newKey) {
+    skipped += 1;
+    console.warn(`[skip] unexpected key shape: ${oldKey}`);
+    continue;
+  }
+
+  console.log(`${dryRun ? '[dry-run]' : '[migrate]'} ${oldKey} -> ${newKey}`);
+  if (dryRun) continue;
+  if (copied >= limit) {
+    skipped += 1;
+    continue;
+  }
+
+  try {
+    await copyR2Object(config, oldKey, newKey);
+    copied += 1;
+
+    await d1Query(`UPDATE message_attachments SET r2_key = ? WHERE id = ?`, [
+      newKey,
+      id,
+    ]);
+    updated += 1;
+
+    if (deleteOld) {
+      await deleteR2Object(config, oldKey);
+      deleted += 1;
+    }
+  } catch (error) {
+    failed += 1;
+    console.error(`[failed] ${id} ${oldKey}: ${error?.message || error}`);
+  }
+}
+
+console.log(
+  JSON.stringify(
+    { dryRun, scanned, alreadyAligned: aligned, copied, updated, deleted, skipped, failed },
+    null,
+    2,
+  ),
+);
+if (failed > 0) process.exitCode = 1;
+
+// --- key rewrite ---------------------------------------------------------
+
+// `conversation-files/<old>/<...fileId>` -> `conversation-files/<conv>/<...fileId>`.
+// Replaces only the conversation segment; keeps everything after it intact.
+function rekey(key, conversationId) {
+  const parts = key.split('/');
+  if (parts.length < 3 || parts[0] !== PREFIX || !parts[1]) return null;
+  parts[1] = conversationId;
+  return parts.join('/');
+}
+
+// --- D1 (HTTP API) -------------------------------------------------------
+
+async function d1Query(sql, params = []) {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${cfAccountId}/d1/database/${config.databaseId}/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ sql, params }),
+    },
+  );
+  const body = await res.json();
+  if (!res.ok || !body.success) {
+    throw new Error(`D1 query failed: ${res.status} ${JSON.stringify(body.errors ?? body)}`);
+  }
+  return body.result?.[0]?.results ?? [];
+}
+
+// --- R2 (S3 SigV4) -------------------------------------------------------
+
+async function copyR2Object(cfg, oldKey, newKey) {
+  // Default metadata-directive is COPY, preserving Content-Type + custom metadata.
+  const copySource = `/${cfg.bucket}/${oldKey.split('/').map(encodeRfc3986).join('/')}`;
+  const { url, headers } = signedR2Request({
+    ...cfg,
+    key: newKey,
+    method: 'PUT',
+    payloadHash: sha256Hex(''),
+    extraSignedHeaders: { 'x-amz-copy-source': copySource },
+  });
+  const res = await fetch(url, { method: 'PUT', headers });
+  if (!res.ok) {
+    throw new Error(`R2 copy failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function deleteR2Object(cfg, key) {
+  const { url, headers } = signedR2Request({
+    ...cfg,
+    key,
+    method: 'DELETE',
+    payloadHash: sha256Hex(''),
+  });
+  const res = await fetch(url, { method: 'DELETE', headers });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`R2 delete failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+function signedR2Request({
+  accountId,
+  accessKeyId,
+  secretAccessKey,
+  bucket,
+  key,
+  method,
+  payloadHash,
+  extraSignedHeaders = {},
+}) {
+  const host = `${accountId}.r2.cloudflarestorage.com`;
+  const canonicalUri = `/${encodeRfc3986(bucket)}/${key
+    .split('/')
+    .map(encodeRfc3986)
+    .join('/')}`;
+  const url = `https://${host}${canonicalUri}`;
+  const amzDate = toAmzDate(new Date());
+  const dateStamp = amzDate.slice(0, 8);
+
+  const baseHeaders = {
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+    ...Object.fromEntries(
+      Object.entries(extraSignedHeaders).map(([k, v]) => [k.toLowerCase(), v]),
+    ),
+  };
+  const signedHeaderNames = Object.keys(baseHeaders).sort();
+  const canonicalHeaders = signedHeaderNames
+    .map((name) => `${name}:${baseHeaders[name]}\n`)
+    .join('');
+  const signedHeaders = signedHeaderNames.join(';');
+
+  const canonicalRequest = [
+    method,
+    canonicalUri,
+    '',
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+
+  const credentialScope = `${dateStamp}/auto/s3/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join('\n');
+  const signingKey = getSignatureKey(secretAccessKey, dateStamp, 'auto', 's3');
+  const signature = hmac(signingKey, stringToSign, 'hex');
+
+  const headers = {
+    ...Object.fromEntries(
+      Object.entries(baseHeaders).map(([k, v]) => [headerCase(k), v]),
+    ),
+    Authorization:
+      `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+  return { url, headers };
+}
+
+function headerCase(name) {
+  return name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('-');
+}
+
+function encodeRfc3986(value) {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function toAmzDate(date) {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+}
+
+function sha256Hex(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmac(key, value, encoding) {
+  return createHmac('sha256', key).update(value).digest(encoding);
+}
+
+function getSignatureKey(secretAccessKey, dateStamp, regionName, serviceName) {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const dateRegionKey = hmac(dateKey, regionName);
+  const dateRegionServiceKey = hmac(dateRegionKey, serviceName);
+  return hmac(dateRegionServiceKey, 'aws4_request');
+}
+
+// --- env helpers ---------------------------------------------------------
+
+function loadEnvFile(file) {
+  const absolute = path.resolve(file);
+  if (!existsSync(absolute)) return;
+  for (const line of readFileSync(absolute, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const equals = trimmed.indexOf('=');
+    if (equals === -1) continue;
+    const key = trimmed.slice(0, equals).trim();
+    let value = trimmed.slice(equals + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] ??= value;
+  }
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/src/features/call/model/call-rtdb-adapter.test.js
+++ b/src/features/call/model/call-rtdb-adapter.test.js
@@ -123,7 +123,7 @@ describe('CallRTDBAdapter', () => {
       responseType: 'busy',
       by: 'callee-1',
       respondedAt: 123,
-      expiresAt: 456,
+      expiresAt: Date.now() + 60_000,
     };
     mocks.onValue.mockImplementation((_refArg, handler) => {
       handler(createSnapshot(response));
@@ -133,6 +133,27 @@ describe('CallRTDBAdapter', () => {
     adapter.onResponseReceived('callee-1', callback);
 
     expect(callback).toHaveBeenCalledWith(response);
+  });
+
+  it('ignores expired call responses so a stale accept cannot join a room', () => {
+    const callback = vi.fn();
+    const response = {
+      roomId: 'room-1',
+      responseType: 'accepted',
+      by: 'callee-1',
+      respondedAt: 123,
+      expiresAt: Date.now() - 1,
+    };
+    mocks.onValue.mockImplementation((_refArg, handler) => {
+      handler(createSnapshot(response));
+      return vi.fn();
+    });
+
+    adapter.onResponseReceived('callee-1', callback);
+
+    expect(callback).toHaveBeenCalledWith(null);
+    // The caller listens to the callee's node and cannot clear it.
+    expect(mocks.remove).not.toHaveBeenCalled();
   });
 
   it('removes expired incoming call data instead of showing a stale call', () => {

--- a/src/features/call/model/call-rtdb-adapter.ts
+++ b/src/features/call/model/call-rtdb-adapter.ts
@@ -108,7 +108,17 @@ export class CallRTDBAdapter {
           return;
         }
         try {
-          callback(parseCallResponse(snapshot.val()));
+          const response = parseCallResponse(snapshot.val());
+          // roomId is now the stable conversationId, so it no longer
+          // disambiguates call attempts — a leftover response carries the same
+          // roomId as a fresh call. Reject expired ones so a stale accept/busy
+          // can't trigger a room join. We only read here (the caller listens to
+          // the callee's node and can't clear it), so no remove().
+          if (response.expiresAt != null && response.expiresAt <= Date.now()) {
+            callback(null);
+            return;
+          }
+          callback(response);
         } catch (error) {
           console.error('Invalid call response data:', error);
           callback(null);

--- a/workers/data/scripts/backfill-rtdb-messages.mjs
+++ b/workers/data/scripts/backfill-rtdb-messages.mjs
@@ -145,8 +145,13 @@ for (const [convoId, convo] of Object.entries(conversations ?? {})) {
 
     if (m.attachment) {
       const at = m.attachment;
+      // The legacy RTDB key is `conversation-files/<a_b>/<fileId>`, but the
+      // conversation now has an opaque id. Rebuild the key from the resolved
+      // conversation_id so it matches what the files worker authorizes against
+      // (keyBelongsToConversation); copying at.key verbatim 400s every image.
+      const fileId = at.key.split('/').pop();
       lines.push(
-        `INSERT INTO message_attachments (id, message_id, r2_key, bucket, file_name, mime_type, file_size, width, height) SELECT ${s(randomUUID())}, ${s(m.key)}, ${s(at.key)}, ${s(at.bucket)}, ${s(at.fileName)}, ${s(at.mimeType)}, ${n(at.fileSize)}, NULL, NULL WHERE NOT EXISTS (SELECT 1 FROM message_attachments WHERE message_id=${s(m.key)});`,
+        `INSERT INTO message_attachments (id, message_id, r2_key, bucket, file_name, mime_type, file_size, width, height) SELECT ${s(randomUUID())}, msg.id, 'conversation-files/' || msg.conversation_id || ${s('/' + fileId)}, ${s(at.bucket)}, ${s(at.fileName)}, ${s(at.mimeType)}, ${n(at.fileSize)}, NULL, NULL FROM messages msg WHERE msg.id=${s(m.key)} AND NOT EXISTS (SELECT 1 FROM message_attachments WHERE message_id=${s(m.key)});`,
       );
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Call responses are now rejected once `expiresAt` has passed, preventing stale “accepted” responses from being handled.

* **Chores**
  * Updated database security rules for incoming call writes to allow structured writes under specific authenticated conditions.
  * Added a one-off migration script to realign attachment R2 keys in D1.
  * Updated message attachment backfill logic to rebuild legacy `r2_key` values using the resolved conversation ID.

* **Tests**
  * Expanded test coverage to verify expired call responses are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->