### PR TITLE
fix(call): re-attach incoming-call listener on auth changes

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -11,7 +11,12 @@
 //   - Solid components → `useAuth()` from `./solid-auth` (reactive).
 //   - All other code   → the imperative getters/commands below.
 //   - Writes to auth state happen ONLY inside this module; external code reads
-//     via getters and subscribes to `evt:auth:state:changed`.
+//     via getters and subscribes to auth events:
+//       - `evt:auth:state:changed` — every status transition (incl. `loading`).
+//       - `evt:auth:session:logged-in` / `:logged-out` / `:ready` — login/logout
+//         lifecycle. Non-Solid auth-scoped listeners (e.g. `presence`,
+//         `wireAuthReactions`) (re)wire on these so they survive a login that
+//         completes after setup.
 //     See docs/WIP_Architecture/STATE_RULES.md.
 //
 // App-level cross-feature wiring lives in `app/auth-orchestration.js`

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -4,11 +4,7 @@ import {
   initCallService,
   getCallService,
 } from './call-service.js';
-import {
-  getLoggedInUserId,
-  getUser,
-  waitForAuthReady,
-} from '../../auth/index.js';
+import { getLoggedInUserId, getUser } from '../../auth/index.js';
 import type { SolidP2PRoom } from '@kidlib/p2p/solid';
 import { CallResponseType, type CallInvite } from './model/call-schema.js';
 import {
@@ -45,7 +41,6 @@ export class CallHandshakeController {
   private outgoingCallTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private unsubCalleeResponse: (() => void) | undefined;
-  private initAbortController: AbortController | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
 
   constructor({
@@ -69,15 +64,14 @@ export class CallHandshakeController {
     this.onCalleeBusy(busy);
   }
 
-  async init(): Promise<void> {
+  /**
+   * (Re)attach the incoming-call listener for the currently logged-in user.
+   * Driven reactively by the provider on auth changes, so it must be safe to
+   * call repeatedly: it tears down any prior subscription first. Callers gate
+   * on a logged-in user, but we re-read the uid defensively.
+   */
+  init(): void {
     this.cleanup();
-
-    const ac = new AbortController();
-    this.initAbortController = ac;
-
-    await waitForAuthReady();
-
-    if (ac.signal.aborted) return;
 
     const localUID = getLoggedInUserId();
     if (!localUID) return;
@@ -357,8 +351,6 @@ export class CallHandshakeController {
   }
 
   cleanup(): void {
-    this.initAbortController?.abort();
-    this.initAbortController = undefined;
     this.unsubscribeIncomingCall?.();
     this.unsubscribeIncomingCall = undefined;
     this.clearOutgoingCallTracking();

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createSignal } from 'solid-js';
+import { render, cleanup } from '@solidjs/testing-library';
+
+const mocks = vi.hoisted(() => ({
+  init: vi.fn(),
+  cleanup: vi.fn(),
+  user: () => null,
+}));
+
+vi.mock('./call-handshake-controller.js', () => ({
+  CallHandshakeController: vi.fn(function () {
+    return {
+      init: mocks.init,
+      cleanup: mocks.cleanup,
+      exitActiveRoom: vi.fn(),
+      cancelOutgoing: vi.fn(),
+      acceptIncoming: vi.fn(),
+      declineIncoming: vi.fn(),
+    };
+  }),
+}));
+vi.mock('../../shared/p2p-context.js', () => ({ useP2PContext: () => ({}) }));
+vi.mock('../../realtime/index.js', () => ({ createRoomSignaling: vi.fn() }));
+vi.mock('../../auth/solid-auth.js', () => ({
+  useAuth: () => ({ user: (...args) => mocks.user(...args) }),
+}));
+
+describe('CallHandshakeProvider', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.user = () => null;
+  });
+
+  it('attaches the incoming-call listener when auth becomes authenticated after mount', async () => {
+    const { CallHandshakeProvider } = await import('./call-handshake');
+    const [user, setUser] = createSignal(null);
+    mocks.user = user;
+
+    render(() => <CallHandshakeProvider>{null}</CallHandshakeProvider>);
+
+    // Logged out at mount: no listener attached.
+    expect(mocks.init).not.toHaveBeenCalled();
+
+    // Login completes after mount -> listener (re)attaches.
+    setUser({ uid: 'u1' });
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -1,13 +1,15 @@
 import {
   createContext,
+  createEffect,
+  createMemo,
   createSignal,
   onCleanup,
-  onMount,
   useContext,
   type Accessor,
   type ParentProps,
 } from 'solid-js';
 
+import { useAuth } from '../../auth/solid-auth.js';
 import { useP2PContext } from '../../shared/p2p-context.js';
 import { createRoomSignaling } from '../../realtime/index.js';
 import type { CallInvite } from './model/call-schema.js';
@@ -74,7 +76,20 @@ export function CallHandshakeProvider(props: ParentProps) {
     declineIncoming: controller.declineIncoming,
   };
 
-  onMount(() => controller.init());
+  // Re-attach the incoming-call listener whenever the logged-in user changes.
+  // A one-shot init at mount missed the common case where login completes
+  // AFTER mount (the listener never attached → no incoming-call dialog until a
+  // reload). Keying on the uid avoids tearing down an active call on unrelated
+  // auth-state updates (e.g. token refresh) that don't change the user.
+  const auth = useAuth();
+  const activeUid = createMemo(() => auth.user()?.uid ?? null);
+  createEffect(() => {
+    if (activeUid()) {
+      controller.init();
+    } else {
+      controller.cleanup();
+    }
+  });
 
   if (typeof window !== 'undefined') {
     const handleBeforeUnload = () => controller.cleanup();


### PR DESCRIPTION
## Problem

Incoming calls produced a push notification but **no in-app IncomingCall dialog**, and the caller just rang to timeout (no busy/reject). A page reload while ringing made the dialog appear.

## Root cause

`CallHandshakeProvider` attached the incoming-call RTDB listener once at mount via `controller.init()`, which `await waitForAuthReady()`. That resolves on the first *stable* auth state — including `unauthenticated`. So when login completed **after** mount (the normal fresh-login flow), `init()` hit `if (!localUID) return` and never re-ran. The callee had no `users/{uid}/calls/incoming` listener for the session: invites landed in RTDB but nothing read them live → no dialog, no response → caller rang to timeout.

A reload masked it (cached session ⇒ already `authenticated` at mount, so the listener attached). Push uses a separate subscription, so push worked while the in-app dialog didn't — exactly the reported symptom. Reproduced deterministically on desktop (fresh login, dialog only on reload-while-ringing).

## Fix

Drive (re)attachment reactively from the existing Solid auth surface (`useAuth().user()`) via a uid-keyed `createEffect`: attach on login, detach on logout, re-attach on account switch. Keying on the **uid** (via `createMemo`) avoids tearing down an active call on unrelated auth-state churn (e.g. token refresh). `init()` is now synchronous and no longer needs `waitForAuthReady()`/`AbortController`, since the effect only fires it when a user exists — also retiring an imperative auth-wait at this call site.

## Test

Tiny focused test: mounting the provider logged-out attaches nothing; a post-mount transition to authenticated attaches the listener (`controller.init` called once).

## Verification

- `pnpm ts` clean
- call + auth suites pass (32 tests)
- Manual: fresh login in a tab (no reload), call from the other user → dialog now appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the incoming-call listener lifecycle so it initializes after authentication and is torn down correctly on logout.
  * Updated call-handshake initialization/cleanup behavior to be safe to re-run when the active user changes.

* **Tests**
  * Added coverage ensuring the provider re-initializes the incoming-call listener when auth transitions from logged out to authenticated.

* **Documentation**
  * Clarified auth module event dependencies and listener rewiring during login/logout/ready lifecycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->