### PR TITLE
[codex] Allow small message attachments

### DIFF
--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -9,7 +9,7 @@ import {
   on,
   onCleanup,
 } from 'solid-js';
-import { ImagePlus } from 'lucide-solid';
+import { Paperclip } from 'lucide-solid';
 import { getUserName } from '../../auth/index.js';
 
 import { useI18n } from '../../shared/i18n';
@@ -22,7 +22,7 @@ import { keepVirtualKeyboardOpenOnTap } from '@shared/utils/ui-utils/keepVirtual
 import {
   createConversationFileObjectUrl,
   deleteConversationFile,
-  uploadConversationImage,
+  uploadConversationFile,
 } from '../../stores/filesStore.js';
 
 import { createMessagingRuntime } from './messaging-runtime.js';
@@ -58,8 +58,12 @@ function isImageAttachment(attachment: MessageAttachment) {
   return attachment.mimeType.trim().toLowerCase().startsWith('image/');
 }
 
-function isR2ImageAttachment(attachment: MessageAttachment) {
-  return isImageAttachment(attachment) && attachment.storage.provider === 'r2';
+function isR2FileAttachment(attachment: MessageAttachment) {
+  return attachment.storage.provider === 'r2';
+}
+
+function isImageFile(file: File) {
+  return file.type.trim().toLowerCase().startsWith('image/');
 }
 
 /**
@@ -165,7 +169,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
   let messagesEl: HTMLDivElement | undefined;
   let inputTextAreaEl: HTMLTextAreaElement | undefined;
-  let imageInputEl: HTMLInputElement | undefined;
+  let fileInputEl: HTMLInputElement | undefined;
   let sendButtonCleanup: (() => void) | undefined;
   let suppressScroll = false;
   // True once the user scrolls away from the bottom to read earlier messages.
@@ -279,7 +283,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   const [historyLoading, setHistoryLoading] = createSignal(false);
   const [historyError, setHistoryError] = createSignal<unknown>(null);
   const [historyReady, setHistoryReady] = createSignal(false);
-  const [imagePreparing, setImagePreparing] = createSignal(false);
+  const [filePreparing, setFilePreparing] = createSignal(false);
   const [r2AttachmentUrls, setR2AttachmentUrls] = createSignal<
     Record<string, string>
   >({});
@@ -300,7 +304,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
     for (const msg of state.messages) {
       const attachment = msg.attachment;
-      if (!conversationId || !attachment || !isR2ImageAttachment(attachment)) {
+      if (!conversationId || !attachment || !isR2FileAttachment(attachment)) {
         continue;
       }
 
@@ -323,7 +327,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               (message) =>
                 message.id === msg.id &&
                 message.attachment &&
-                isR2ImageAttachment(message.attachment),
+                isR2FileAttachment(message.attachment),
             );
 
           if (!stillNeeded) {
@@ -507,7 +511,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
   function onSubmit(e: SubmitEvent) {
     e.preventDefault();
-    if (state.sending || imagePreparing()) return;
+    if (state.sending || filePreparing()) return;
 
     clearPersistedDraftIfNeeded();
     void send();
@@ -516,23 +520,17 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     inputTextAreaEl?.focus();
   }
 
-  async function onImageInput(e: Event & { currentTarget: HTMLInputElement }) {
+  async function onFileInput(e: Event & { currentTarget: HTMLInputElement }) {
     const file = e.currentTarget.files?.[0];
     e.currentTarget.value = '';
-    if (!file || state.sending || imagePreparing()) return;
+    if (!file || state.sending || filePreparing()) return;
 
     const conversationId = state.conversationId;
     if (!conversationId) return;
     const uploadConversationId = conversationId;
 
-    const mimeType = file.type.trim().toLowerCase();
-    if (!mimeType.startsWith('image/')) {
-      window.alert('Choose an image file.');
-      return;
-    }
-
     let uploadedStorage:
-      | Awaited<ReturnType<typeof uploadConversationImage>>
+      | Awaited<ReturnType<typeof uploadConversationFile>>
       | undefined;
     function cleanupUploadedImage() {
       if (!uploadedStorage) return;
@@ -547,23 +545,32 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       );
     }
 
-    setImagePreparing(true);
+    setFilePreparing(true);
     try {
-      let image = file;
-      if (file.size > IMAGE_COMPRESSION_THRESHOLD_BYTES) {
+      let attachmentFile = file;
+      const shouldReadImageMetadata = isImageFile(file);
+      if (
+        shouldReadImageMetadata &&
+        file.size > IMAGE_COMPRESSION_THRESHOLD_BYTES
+      ) {
         const compressed = await compressImage(file, {
           maxBytes: IMAGE_COMPRESSION_THRESHOLD_BYTES,
         });
-        if (compressed) image = compressed;
+        if (compressed) attachmentFile = compressed;
       }
 
-      if (image.size > MAX_IMAGE_UPLOAD_BYTES) {
-        window.alert('Choose a smaller image.');
+      if (attachmentFile.size > MAX_IMAGE_UPLOAD_BYTES) {
+        window.alert('Choose a smaller file.');
         return;
       }
 
-      const dimensions = await readImageDimensions(image);
-      uploadedStorage = await uploadConversationImage(conversationId, image);
+      const dimensions = shouldReadImageMetadata
+        ? await readImageDimensions(attachmentFile)
+        : undefined;
+      uploadedStorage = await uploadConversationFile(
+        conversationId,
+        attachmentFile,
+      );
       if (state.conversationId !== conversationId) {
         cleanupUploadedImage();
         return;
@@ -573,9 +580,9 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       clearPersistedDraftIfNeeded();
       const sent = await send({
         type: 'file',
-        fileName: image.name || file.name || 'image',
-        mimeType: image.type || file.type || 'image/*',
-        fileSize: image.size,
+        fileName: attachmentFile.name || file.name || 'attachment',
+        mimeType: attachmentFile.type || file.type || 'application/octet-stream',
+        fileSize: attachmentFile.size,
         width: dimensions?.width,
         height: dimensions?.height,
         storage: uploadedStorage,
@@ -583,14 +590,14 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       });
       if (!sent) {
         cleanupUploadedImage();
-        window.alert('Image send failed.');
+        window.alert('File send failed.');
       }
     } catch (error) {
       cleanupUploadedImage();
-      console.warn('[conversation] failed to send image attachment', error);
-      window.alert('Image send failed.');
+      console.warn('[conversation] failed to send file attachment', error);
+      window.alert('File send failed.');
     } finally {
-      setImagePreparing(false);
+      setFilePreparing(false);
       inputTextAreaEl?.focus();
     }
   }
@@ -607,7 +614,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       return;
 
     e.preventDefault();
-    if (state.sending || imagePreparing()) return;
+    if (state.sending || filePreparing()) return;
 
     e.currentTarget.form?.requestSubmit();
   }
@@ -789,21 +796,20 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         <form class={styles.form} onSubmit={onSubmit}>
           <input
             title='Attach file'
-            ref={imageInputEl}
+            ref={fileInputEl}
             class={styles.fileInput}
             type='file'
-            accept='image/*'
-            onChange={onImageInput}
+            onChange={onFileInput}
           />
           <button
             class={styles.attach}
             type='button'
-            aria-label='Attach image'
-            title='Attach image'
-            disabled={state.sending || imagePreparing()}
-            onClick={() => imageInputEl?.click()}
+            aria-label='Attach file'
+            title='Attach file'
+            disabled={state.sending || filePreparing()}
+            onClick={() => fileInputEl?.click()}
           >
-            <ImagePlus size={20} aria-hidden='true' />
+            <Paperclip size={20} aria-hidden='true' />
           </button>
           <textarea
             autofocus
@@ -822,7 +828,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
             ref={attachSendButton}
             class={styles.send}
             type='submit'
-            disabled={!state.draft.trim() || state.sending || imagePreparing()}
+            disabled={!state.draft.trim() || state.sending || filePreparing()}
           >
             Send
           </button>

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -44,7 +44,8 @@ import styles from './ConversationPanel.module.css';
 const runtime = createMessagingRuntime();
 const DRAFT_SAVE_DELAY_MS = 250;
 const TIMESTAMP_THRESHOLD_MS = 5 * 60 * 1000;
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGE_UPLOAD_BYTES = 5 * 1024 * 1024;
+const IMAGE_COMPRESSION_THRESHOLD_BYTES = Math.round(1.5 * 1024 * 1024);
 
 type TimestampFormatters = {
   time: Intl.DateTimeFormat;
@@ -525,8 +526,8 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     const uploadConversationId = conversationId;
 
     const mimeType = file.type.trim().toLowerCase();
-    if (!mimeType.startsWith('image/') || mimeType === 'image/svg+xml') {
-      window.alert('Choose a PNG, JPEG, GIF, WebP, or similar image.');
+    if (!mimeType.startsWith('image/')) {
+      window.alert('Choose an image file.');
       return;
     }
 
@@ -549,18 +550,14 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     setImagePreparing(true);
     try {
       let image = file;
-      if (file.size > MAX_IMAGE_BYTES) {
+      if (file.size > IMAGE_COMPRESSION_THRESHOLD_BYTES) {
         const compressed = await compressImage(file, {
-          maxBytes: MAX_IMAGE_BYTES,
+          maxBytes: IMAGE_COMPRESSION_THRESHOLD_BYTES,
         });
-        if (!compressed) {
-          window.alert('Choose a smaller image.');
-          return;
-        }
-        image = compressed;
+        if (compressed) image = compressed;
       }
 
-      if (image.size > MAX_IMAGE_BYTES) {
+      if (image.size > MAX_IMAGE_UPLOAD_BYTES) {
         window.alert('Choose a smaller image.');
         return;
       }

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -304,7 +304,12 @@ export default function ConversationPanel(props: ConversationPanelProps) {
 
     for (const msg of state.messages) {
       const attachment = msg.attachment;
-      if (!conversationId || !attachment || !isR2FileAttachment(attachment)) {
+      if (
+        !conversationId ||
+        !attachment ||
+        !isR2FileAttachment(attachment) ||
+        !isImageAttachment(attachment)
+      ) {
         continue;
       }
 
@@ -327,7 +332,8 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               (message) =>
                 message.id === msg.id &&
                 message.attachment &&
-                isR2FileAttachment(message.attachment),
+                isR2FileAttachment(message.attachment) &&
+                isImageAttachment(message.attachment),
             );
 
           if (!stillNeeded) {
@@ -706,14 +712,31 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                                   isImageAttachment(file)
                                 );
                               };
-                              const canDownload = () => {
-                                const url = attachmentUrl();
-                                return Boolean(url) && url?.startsWith('blob:');
-                              };
                               function openPreview(url: string) {
                                 showImagePreview(url, file.fileName, null, {
                                   revokeOnClose: false,
                                 });
+                              }
+                              async function downloadAttachment() {
+                                const url = attachmentUrl();
+                                if (url?.startsWith('blob:')) {
+                                  await downloadUrl(url, file.fileName);
+                                  return;
+                                }
+
+                                const conversationId = state.conversationId;
+                                if (!conversationId) return;
+
+                                const objectUrl =
+                                  await createConversationFileObjectUrl(
+                                    conversationId,
+                                    file.storage,
+                                  );
+                                try {
+                                  await downloadUrl(objectUrl, file.fileName);
+                                } finally {
+                                  URL.revokeObjectURL(objectUrl);
+                                }
                               }
 
                               return (
@@ -747,28 +770,24 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                                     />
                                   </Show>
                                   <span class={styles.fileMessageMeta}>
-                                    <Show
-                                      when={canDownload()}
-                                      fallback={
-                                        <span class={styles.fileMessageName}>
-                                          {file.fileName}
-                                        </span>
-                                      }
+                                    <a
+                                      href={attachmentUrl() ?? '#'}
+                                      download={file.fileName}
+                                      class={styles.fileMessageName}
+                                      onClick={(event) => {
+                                        event.preventDefault();
+                                        void downloadAttachment().catch(
+                                          (error) => {
+                                            console.warn(
+                                              '[conversation] failed to download attachment',
+                                              error,
+                                            );
+                                          },
+                                        );
+                                      }}
                                     >
-                                      <a
-                                        href={attachmentUrl() ?? undefined}
-                                        download={file.fileName}
-                                        class={styles.fileMessageName}
-                                        onClick={(event) => {
-                                          const url = attachmentUrl();
-                                          if (!url) return;
-                                          event.preventDefault();
-                                          void downloadUrl(url, file.fileName);
-                                        }}
-                                      >
-                                        {file.fileName}
-                                      </a>
-                                    </Show>
+                                      {file.fileName}
+                                    </a>
                                     <span class={styles.fileMessageSize}>
                                       ({formatFileSize(file.fileSize)})
                                     </span>

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -538,11 +538,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     let uploadedStorage:
       | Awaited<ReturnType<typeof uploadConversationFile>>
       | undefined;
-    function cleanupUploadedImage() {
+    function cleanupUploadedFile() {
       if (!uploadedStorage) return;
       void deleteConversationFile(uploadConversationId, uploadedStorage).catch(
         (error) => {
-          console.warn('[conversation] failed to clean up orphaned image', {
+          console.warn('[conversation] failed to clean up orphaned file', {
             conversationId: uploadConversationId,
             key: uploadedStorage?.key,
             error,
@@ -578,7 +578,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         attachmentFile,
       );
       if (state.conversationId !== conversationId) {
-        cleanupUploadedImage();
+        cleanupUploadedFile();
         return;
       }
 
@@ -595,11 +595,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
         text: caption || undefined,
       });
       if (!sent) {
-        cleanupUploadedImage();
+        cleanupUploadedFile();
         window.alert('File send failed.');
       }
     } catch (error) {
-      cleanupUploadedImage();
+      cleanupUploadedFile();
       console.warn('[conversation] failed to send file attachment', error);
       window.alert('File send failed.');
     } finally {

--- a/src/stores/filesStore.ts
+++ b/src/stores/filesStore.ts
@@ -54,6 +54,13 @@ export function uploadConversationImage(
   return client.uploadImage(conversationId, file);
 }
 
+export function uploadConversationFile(
+  conversationId: ConversationId,
+  file: File,
+) {
+  return uploadConversationImage(conversationId, file);
+}
+
 export function createConversationFileObjectUrl(
   conversationId: ConversationId,
   storage: R2StorageDescriptor,

--- a/workers/files/src/index.ts
+++ b/workers/files/src/index.ts
@@ -257,7 +257,7 @@ async function handleUpload(
     );
   }
   if (body.byteLength === 0) {
-    return json(request, env, { error: 'empty image' }, { status: 400 });
+    return json(request, env, { error: 'empty file' }, { status: 400 });
   }
 
   const key = objectKey(conversationId, crypto.randomUUID());

--- a/workers/files/src/index.ts
+++ b/workers/files/src/index.ts
@@ -86,10 +86,10 @@ function json(
   });
 }
 
-function isImageMimeType(value: string | null): value is string {
+function isSupportedFileMimeType(value: string | null): value is string {
   if (!value) return false;
   const baseType = value.split(';')[0].trim().toLowerCase();
-  return baseType.startsWith('image/');
+  return /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/.test(baseType);
 }
 
 function objectKey(conversationId: string, objectId: string) {
@@ -238,11 +238,11 @@ async function handleUpload(
   identity: Identity,
 ) {
   const mimeType = request.headers.get('Content-Type');
-  if (!isImageMimeType(mimeType)) {
+  if (!isSupportedFileMimeType(mimeType)) {
     return json(
       request,
       env,
-      { error: 'unsupported image type' },
+      { error: 'unsupported file type' },
       { status: 415 },
     );
   }
@@ -252,7 +252,7 @@ async function handleUpload(
     return json(
       request,
       env,
-      { error: 'image too large or empty' },
+      { error: 'file too large or empty' },
       { status: 413 },
     );
   }

--- a/workers/files/src/index.ts
+++ b/workers/files/src/index.ts
@@ -89,7 +89,7 @@ function json(
 function isImageMimeType(value: string | null): value is string {
   if (!value) return false;
   const baseType = value.split(';')[0].trim().toLowerCase();
-  return baseType.startsWith('image/') && baseType !== 'image/svg+xml';
+  return baseType.startsWith('image/');
 }
 
 function objectKey(conversationId: string, objectId: string) {

--- a/workers/files/src/index.ts
+++ b/workers/files/src/index.ts
@@ -292,6 +292,12 @@ async function handleDownload(request: Request, env: Env, key: string) {
   );
   headers.set('Content-Length', String(object.size));
   headers.set('ETag', object.etag);
+  // Defense-in-depth for user-supplied files (e.g. SVG): neutralize any
+  // embedded scripts and prevent inline rendering if the URL is ever opened
+  // top-level. Clients fetch this as a blob, so these never hinder normal use.
+  headers.set('Content-Security-Policy', "default-src 'none'; sandbox");
+  headers.set('X-Content-Type-Options', 'nosniff');
+  headers.set('Content-Disposition', 'attachment');
   return response(request, env, object.body, { headers });
 }
 

--- a/workers/files/test/worker.test.ts
+++ b/workers/files/test/worker.test.ts
@@ -306,6 +306,19 @@ describe('files worker routing + auth', () => {
     expect(res.status).toBe(201);
   });
 
+  it('accepts small non-image file uploads', async () => {
+    const token = await signToken(validClaims());
+    await allowMember('user-a_user-b', 'user-a');
+    const res = await request('/conversations/user-a_user-b/files/images', {
+      method: 'POST',
+      token,
+      contentType: 'application/pdf',
+      body: '%PDF-1.7',
+    });
+
+    expect(res.status).toBe(201);
+  });
+
   it('rejects oversized uploads before storing', async () => {
     const token = await signToken(validClaims());
     await allowMember('user-a_user-b', 'user-a');
@@ -319,13 +332,13 @@ describe('files worker routing + auth', () => {
     expect(res.status).toBe(413);
   });
 
-  it('rejects non-image uploads', async () => {
+  it('rejects uploads without a supported MIME type', async () => {
     const token = await signToken(validClaims());
     await allowMember('user-a_user-b', 'user-a');
     const res = await request('/conversations/user-a_user-b/files/images', {
       method: 'POST',
       token,
-      contentType: 'text/plain',
+      contentType: 'not-a-mime',
       body: 'image',
     });
 

--- a/workers/files/test/worker.test.ts
+++ b/workers/files/test/worker.test.ts
@@ -204,6 +204,13 @@ describe('files worker routing + auth', () => {
 
     expect(download.status).toBe(200);
     expect(download.headers.get('Content-Type')).toBe('image/png');
+    // Hardening for user-supplied files (e.g. SVG): scripts can't execute and
+    // the type can't be sniffed even if the URL is opened top-level.
+    expect(download.headers.get('Content-Security-Policy')).toBe(
+      "default-src 'none'; sandbox",
+    );
+    expect(download.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(download.headers.get('Content-Disposition')).toBe('attachment');
     expect(new Uint8Array(await download.arrayBuffer())).toEqual(
       new Uint8Array([1, 2, 3]),
     );

--- a/workers/files/test/worker.test.ts
+++ b/workers/files/test/worker.test.ts
@@ -293,6 +293,19 @@ describe('files worker routing + auth', () => {
     expect(upload.status).toBe(201);
   });
 
+  it('accepts svg image uploads', async () => {
+    const token = await signToken(validClaims());
+    await allowMember('user-a_user-b', 'user-a');
+    const res = await request('/conversations/user-a_user-b/files/images', {
+      method: 'POST',
+      token,
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1" />',
+    });
+
+    expect(res.status).toBe(201);
+  });
+
   it('rejects oversized uploads before storing', async () => {
     const token = await signToken(validClaims());
     await allowMember('user-a_user-b', 'user-a');


### PR DESCRIPTION
## Summary

- Allows small message attachments to reuse the existing R2-backed file path under the current 5 MiB cap.
- Keeps image-specific behavior for image files: preview, dimensions, and compression above 1.5 MiB.
- Switches the composer control from image-only to a generic attachment button.
- Allows SVG and other typed small files through the files worker, with tests for SVG and non-image uploads.

## Notes

This intentionally stays on the existing small-file path. Large file support remains a separate transport/storage slice.

## Validation

- `pnpm -C workers/files run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now support sending any file type as attachments (not just images), with image resizing only when large.
  * Added support for SVG attachments.

* **Bug Fixes**
  * Improved attachment upload validation for supported MIME types, including clearer errors for empty/oversized files.
  * Hardened attachment downloads with stronger security headers.
  * Improved attachment picker/send behavior while a file is uploading, and updated failure messaging for file sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->