### PR TITLE
Wire per-peer presence data through DO signaling (p2p 0.1.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@kidlib/create-component": "^0.1.5",
-    "@kidlib/p2p": "^0.1.11",
+    "@kidlib/p2p": "^0.1.12",
     "@mediabunny/ac3": "^1.40.1",
     "@sentry/browser": "^10.49.0",
     "firebase": "^12.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       '@kidlib/p2p':
-        specifier: ^0.1.11
-        version: 0.1.11(solid-js@1.9.12)
+        specifier: ^0.1.12
+        version: 0.1.12(solid-js@1.9.12)
       '@mediabunny/ac3':
         specifier: ^1.40.1
         version: 1.40.1(mediabunny@1.41.0)
@@ -1395,8 +1395,8 @@ packages:
   '@kidlib/create-component@0.1.5':
     resolution: {integrity: sha512-viom5Q6hIMz13plwb6665OT+2N3OBLs+8T7dNT5G9+0UQFcCtOI0iFE0tq0PNf5nnkNsrhS/NkhkyFvclTbMKA==}
 
-  '@kidlib/p2p@0.1.11':
-    resolution: {integrity: sha512-L+p3Wc8B2izNeDuxG02kgBLRpPmj4HQp0d3msiH2Igvn3Sv1AoYp1r7fRfsm3cjrrAhd5AsQCGEn3lsNScf2SQ==}
+  '@kidlib/p2p@0.1.12':
+    resolution: {integrity: sha512-w1d9/9gq5os7KMTCUcnUEmbCCz9L04mQ76HsQqNlbhb/bT0g3YmAg4IaN8bVjedPZjTWfgRQiEGxSm92Ko1rNw==}
     peerDependencies:
       solid-js: '>=1.8.0'
     peerDependenciesMeta:
@@ -3997,6 +3997,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -5877,7 +5878,7 @@ snapshots:
 
   '@kidlib/create-component@0.1.5': {}
 
-  '@kidlib/p2p@0.1.11(solid-js@1.9.12)':
+  '@kidlib/p2p@0.1.12(solid-js@1.9.12)':
     optionalDependencies:
       solid-js: 1.9.12
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,3 +27,4 @@ overrides:
 
 minimumReleaseAgeExclude:
   - '@kidlib/p2p@0.1.11'
+  - '@kidlib/p2p@0.1.12'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,6 @@ overrides:
   'picomatch@>=4 <4.0.4': 4.0.4
   serialize-javascript: 7.0.5
 
+# First-party scope — our own packages, exempt from the release-age cooldown.
 minimumReleaseAgeExclude:
-  - '@kidlib/p2p@0.1.11'
-  - '@kidlib/p2p@0.1.12'
+  - '@kidlib/*'

--- a/shared/signaling/protocol.ts
+++ b/shared/signaling/protocol.ts
@@ -15,15 +15,29 @@ export type PeerId = string;
 /** Payload bucket for relayed messages. Add values to extend; never reshape. */
 export type RelayChannel = 'sdp' | 'ice';
 
+/**
+ * Opaque, self-asserted per-peer presence metadata (e.g. displayName, muted,
+ * camOff). The relay never inspects it. NEVER trust it for authorization —
+ * any peer asserts its own; authz-sensitive facts stay authoritative in D1/DO.
+ */
+export type PresenceData = Record<string, unknown>;
+
+/** A present peer and its self-asserted presence data. */
+export interface PresenceMember {
+  peerId: PeerId;
+  data?: PresenceData;
+}
+
 /** Client → Durable Object. */
 export type ClientMessage =
-  | { t: 'join'; peerId: PeerId }
+  | { t: 'join'; peerId: PeerId; data?: PresenceData }
   | { t: 'leave' }
+  | { t: 'presence'; data: PresenceData }
   | { t: 'relay'; to: PeerId; channel: RelayChannel; data: unknown };
 
 /** Durable Object → client. */
 export type ServerMessage =
-  | { t: 'peers'; peers: PeerId[] }
+  | { t: 'peers'; peers: PresenceMember[] }
   | { t: 'relay'; from: PeerId; channel: RelayChannel; data: unknown }
   | { t: 'error'; message: string };
 
@@ -32,9 +46,15 @@ export function isClientMessage(value: unknown): value is ClientMessage {
   const m = value as Record<string, unknown>;
   switch (m.t) {
     case 'join':
-      return typeof m.peerId === 'string' && m.peerId.length > 0;
+      return (
+        typeof m.peerId === 'string' &&
+        m.peerId.length > 0 &&
+        isPresenceDataOrAbsent(m.data)
+      );
     case 'leave':
       return true;
+    case 'presence':
+      return isPresenceData(m.data);
     case 'relay':
       return (
         typeof m.to === 'string' &&
@@ -45,4 +65,13 @@ export function isClientMessage(value: unknown): value is ClientMessage {
     default:
       return false;
   }
+}
+
+/** Presence data must be a plain object (never an array or primitive). */
+function isPresenceData(value: unknown): value is PresenceData {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPresenceDataOrAbsent(value: unknown): boolean {
+  return value === undefined || isPresenceData(value);
 }

--- a/src/realtime/signaling/do-room-signaling.test.js
+++ b/src/realtime/signaling/do-room-signaling.test.js
@@ -150,6 +150,20 @@ describe('createDoRoomSignaling', () => {
     expect(candidates).toEqual([{ candidate: 'c1' }]);
   });
 
+  it('does not re-join on reconnect after leave', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    signaling.join('peer-a');
+    socket.sent.length = 0;
+
+    signaling.leave('peer-a');
+    expect(socket.sent).toEqual([{ t: 'leave' }]);
+
+    // Local join state must be cleared so a reconnect doesn't re-assert it.
+    socket.sent.length = 0;
+    socket.open();
+    expect(socket.sent).toEqual([]);
+  });
+
   it('closes the socket on cleanup', () => {
     const signaling = createDoRoomSignaling({ roomId: 'room-1' });
     signaling.join('peer-a');

--- a/src/realtime/signaling/do-room-signaling.test.js
+++ b/src/realtime/signaling/do-room-signaling.test.js
@@ -51,13 +51,50 @@ describe('createDoRoomSignaling', () => {
     expect(socket.sent).toEqual([{ t: 'join', peerId: 'peer-a' }]);
   });
 
-  it('forwards presence to onPeers subscribers', () => {
+  it('maps presence members onto onPeers subscribers', () => {
     const signaling = createDoRoomSignaling({ roomId: 'room-1' });
     const seen = [];
-    signaling.onPeers((peers) => seen.push(peers));
+    signaling.onPeers((members) => seen.push(members));
 
-    socket.emit({ t: 'peers', peers: ['peer-a', 'peer-b'] });
-    expect(seen).toEqual([['peer-a', 'peer-b']]);
+    socket.emit({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a', data: { muted: true } }, { peerId: 'peer-b' }],
+    });
+    expect(seen).toEqual([
+      [
+        { memberId: 'peer-a', data: { muted: true } },
+        { memberId: 'peer-b', data: undefined },
+      ],
+    ]);
+  });
+
+  it('sends presence data on join and restores it on reconnect', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    signaling.join('peer-a', { muted: true });
+    expect(socket.sent).toEqual([
+      { t: 'join', peerId: 'peer-a', data: { muted: true } },
+    ]);
+
+    socket.sent.length = 0;
+    socket.open(); // reconnect re-asserts peerId + latest data
+    expect(socket.sent).toEqual([
+      { t: 'join', peerId: 'peer-a', data: { muted: true } },
+    ]);
+  });
+
+  it('updatePresenceData sends a presence message and is restored on reconnect', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    signaling.join('peer-a');
+    socket.sent.length = 0;
+
+    signaling.updatePresenceData('peer-a', { muted: true });
+    expect(socket.sent).toEqual([{ t: 'presence', data: { muted: true } }]);
+
+    socket.sent.length = 0;
+    socket.open(); // re-join carries the latest data set via updatePresenceData
+    expect(socket.sent).toEqual([
+      { t: 'join', peerId: 'peer-a', data: { muted: true } },
+    ]);
   });
 
   it('maps offer/answer/ICE onto addressed relay messages', () => {

--- a/src/realtime/signaling/do-room-signaling.ts
+++ b/src/realtime/signaling/do-room-signaling.ts
@@ -129,12 +129,13 @@ export function createDoRoomSignaling({
       return ack;
     },
 
-    leave(peerId) {
+    // Leave is socket-scoped — the worker clears presence for this connection
+    // regardless of peerId, so the arg is unused. Always reset local join state
+    // so a later reconnect doesn't re-assert presence we've already left.
+    leave() {
       socket.send({ t: 'leave' });
-      if (joinedPeerId === peerId) {
-        joinedPeerId = null;
-        localData = undefined;
-      }
+      joinedPeerId = null;
+      localData = undefined;
     },
 
     // Update our own presence data mid-session (e.g. mute toggle). The worker

--- a/src/realtime/signaling/do-room-signaling.ts
+++ b/src/realtime/signaling/do-room-signaling.ts
@@ -1,6 +1,8 @@
 import type {
   CreateRoomSignalingOptions,
   P2PRoomPeerSignalingOptions,
+  P2PRoomPresenceData,
+  P2PRoomPresenceMember,
   P2PRoomSignaling,
   RtcSignalingSource,
 } from '@kidlib/p2p';
@@ -52,14 +54,28 @@ export function createDoRoomSignaling({
   });
 
   let joinedPeerId: string | null = null;
-  const peersHandlers = new Set<(peerIds: string[]) => void>();
+  let localData: P2PRoomPresenceData | undefined;
+  const peersHandlers = new Set<(members: P2PRoomPresenceMember[]) => void>();
   const relaySubs = new Set<RelaySubscription>();
+
+  // Build the join message, omitting `data` when absent so the no-presence
+  // wire stays minimal.
+  const joinMessage = (peerId: string, data?: P2PRoomPresenceData) =>
+    data !== undefined
+      ? ({ t: 'join', peerId, data } as const)
+      : ({ t: 'join', peerId } as const);
 
   socket.onMessage((message: ServerMessage) => {
     switch (message.t) {
-      case 'peers':
-        peersHandlers.forEach((h) => h(message.peers));
+      case 'peers': {
+        // Wire `{ peerId, data }` → port `{ memberId, data }`.
+        const members: P2PRoomPresenceMember[] = message.peers.map((p) => ({
+          memberId: p.peerId,
+          data: p.data,
+        }));
+        peersHandlers.forEach((h) => h(members));
         return;
+      }
       case 'relay':
         for (const sub of relaySubs) {
           if (sub.from === message.from && sub.channel === message.channel) {
@@ -73,9 +89,9 @@ export function createDoRoomSignaling({
     }
   });
 
-  // Restore presence after every (re)connect.
+  // Restore presence (peerId + latest data) after every (re)connect.
   socket.onOpen(() => {
-    if (joinedPeerId) socket.send({ t: 'join', peerId: joinedPeerId });
+    if (joinedPeerId) socket.send(joinMessage(joinedPeerId, localData));
   });
 
   function subscribeRelay(
@@ -89,15 +105,16 @@ export function createDoRoomSignaling({
   }
 
   return {
-    join(peerId) {
+    join(peerId, data) {
       joinedPeerId = peerId;
+      localData = data;
       // Resolve once the server echoes a peers list containing us, so the
       // room's post-join capacity check runs against current occupancy
       // instead of a stale snapshot. Timeout fallback keeps a flaky server
       // from hanging the join forever (degrades to pre-ack behavior).
       const ack = new Promise<void>((resolve) => {
-        const handler = (peerIds: string[]) => {
-          if (!peerIds.includes(peerId)) return;
+        const handler = (members: P2PRoomPresenceMember[]) => {
+          if (!members.some((m) => m.memberId === peerId)) return;
           peersHandlers.delete(handler);
           clearTimeout(timeoutId);
           resolve();
@@ -108,13 +125,24 @@ export function createDoRoomSignaling({
         }, 5_000);
         peersHandlers.add(handler);
       });
-      socket.send({ t: 'join', peerId });
+      socket.send(joinMessage(peerId, data));
       return ack;
     },
 
     leave(peerId) {
       socket.send({ t: 'leave' });
-      if (joinedPeerId === peerId) joinedPeerId = null;
+      if (joinedPeerId === peerId) {
+        joinedPeerId = null;
+        localData = undefined;
+      }
+    },
+
+    // Update our own presence data mid-session (e.g. mute toggle). The worker
+    // derives identity from the socket, so peerId is unused on the wire; the
+    // change round-trips back through `onPeers` to reach the local Accessor.
+    updatePresenceData(_peerId, data) {
+      localData = data;
+      socket.send({ t: 'presence', data });
     },
 
     onPeers(callback) {

--- a/workers/signaling/src/signaling-room.ts
+++ b/workers/signaling/src/signaling-room.ts
@@ -3,6 +3,8 @@ import {
   isClientMessage,
   type ClientMessage,
   type PeerId,
+  type PresenceData,
+  type PresenceMember,
   type ServerMessage,
 } from '../../../shared/signaling/protocol';
 import type { Env } from './index';
@@ -10,14 +12,16 @@ import type { Env } from './index';
 /** Survives hibernation via ws.serializeAttachment(). */
 interface SocketState {
   peerId: PeerId | null;
+  data?: PresenceData;
 }
 
 /**
  * One instance per room (keyed by roomId). A dumb relay:
- *   - tracks presence (joined peers)
+ *   - tracks presence (joined peers + their self-asserted presence data)
  *   - forwards `relay` messages to the addressed peer
- * It never inspects SDP/ICE contents. State is derived from the live socket
- * set, so nothing is persisted — an empty room simply hibernates and evicts.
+ * It never inspects SDP/ICE contents, and treats presence `data` as opaque.
+ * State is derived from the live socket set, so nothing is persisted — an empty
+ * room simply hibernates and evicts.
  */
 export class SignalingRoom extends DurableObject<Env> {
   async fetch(request: Request): Promise<Response> {
@@ -37,7 +41,7 @@ export class SignalingRoom extends DurableObject<Env> {
     // Presence snapshot on connect. The P2PRoomSignaling contract requires
     // watchers (connected, not joined) to know current occupancy — the client
     // room checks capacity against it before and after joining.
-    this.send(server, { t: 'peers', peers: this.peerIds() });
+    this.send(server, { t: 'peers', peers: this.presenceMembers() });
 
     // Echo the auth subprotocol; browsers abort the handshake if the server
     // does not confirm one of the offered subprotocols.
@@ -65,13 +69,23 @@ export class SignalingRoom extends DurableObject<Env> {
     const message = parsed as ClientMessage;
     switch (message.t) {
       case 'join':
-        this.setSocketState(ws, { peerId: message.peerId });
+        this.setSocketState(ws, { peerId: message.peerId, data: message.data });
         this.broadcastPeers();
         return;
       case 'leave':
         this.setSocketState(ws, { peerId: null });
         this.broadcastPeers();
         return;
+      case 'presence': {
+        // Update self-asserted presence data; ignore until joined (no identity
+        // to attach it to). Re-broadcast so a data-only change (e.g. mute
+        // toggle) reaches every member, including the sender.
+        const { peerId } = this.getSocketState(ws);
+        if (!peerId) return this.sendError(ws, 'join before setting presence');
+        this.setSocketState(ws, { peerId, data: message.data });
+        this.broadcastPeers();
+        return;
+      }
       case 'relay':
         return this.relay(ws, message.to, message.channel, message.data);
     }
@@ -109,21 +123,22 @@ export class SignalingRoom extends DurableObject<Env> {
   }
 
   private broadcastPeers(): void {
-    const peers = this.peerIds();
-    const payload: ServerMessage = { t: 'peers', peers };
+    const payload: ServerMessage = { t: 'peers', peers: this.presenceMembers() };
     // All sockets, including watchers — see the connect-time snapshot note.
     for (const ws of this.ctx.getWebSockets()) {
       this.send(ws, payload);
     }
   }
 
-  private peerIds(): PeerId[] {
-    const ids: PeerId[] = [];
+  /** Joined peers with their presence data; the local peer is included (its own
+   * socket is in getWebSockets()), so self mute toggles round-trip back. */
+  private presenceMembers(): PresenceMember[] {
+    const members: PresenceMember[] = [];
     for (const ws of this.ctx.getWebSockets()) {
-      const { peerId } = this.getSocketState(ws);
-      if (peerId) ids.push(peerId);
+      const { peerId, data } = this.getSocketState(ws);
+      if (peerId) members.push(data ? { peerId, data } : { peerId });
     }
-    return ids;
+    return members;
   }
 
   private findSocket(peerId: PeerId): WebSocket | null {

--- a/workers/signaling/test/signaling-room.test.ts
+++ b/workers/signaling/test/signaling-room.test.ts
@@ -33,6 +33,11 @@ async function connect(roomId: string) {
   };
 }
 
+/** peerIds from a `peers` message, sorted (presence members → ids). */
+function memberIds(msg: ServerMessage): string[] {
+  return msg.t === 'peers' ? msg.peers.map((m) => m.peerId).sort() : [];
+}
+
 describe('SignalingRoom', () => {
   it('tracks presence and relays signaling between peers', async () => {
     const a = await connect('room-1');
@@ -42,21 +47,16 @@ describe('SignalingRoom', () => {
 
     a.send({ t: 'join', peerId: 'peer-a' });
     // Joins broadcast to every socket, watchers included.
-    expect(await a.next()).toEqual({ t: 'peers', peers: ['peer-a'] });
-    expect(await b.next()).toEqual({ t: 'peers', peers: ['peer-a'] });
+    expect(await a.next()).toEqual({ t: 'peers', peers: [{ peerId: 'peer-a' }] });
+    expect(await b.next()).toEqual({ t: 'peers', peers: [{ peerId: 'peer-a' }] });
 
     // A late watcher's connect-time snapshot reflects current occupancy.
     const c = await connect('room-1');
-    expect(await c.next()).toEqual({ t: 'peers', peers: ['peer-a'] });
+    expect(await c.next()).toEqual({ t: 'peers', peers: [{ peerId: 'peer-a' }] });
 
     b.send({ t: 'join', peerId: 'peer-b' });
     for (const peer of [a, b, c]) {
-      const msg = await peer.next();
-      expect(msg.t).toBe('peers');
-      expect(msg.t === 'peers' && [...msg.peers].sort()).toEqual([
-        'peer-a',
-        'peer-b',
-      ]);
+      expect(memberIds(await peer.next())).toEqual(['peer-a', 'peer-b']);
     }
 
     a.send({ t: 'relay', to: 'peer-b', channel: 'sdp', data: { sdp: 'offer' } });
@@ -65,6 +65,43 @@ describe('SignalingRoom', () => {
       from: 'peer-a',
       channel: 'sdp',
       data: { sdp: 'offer' },
+    });
+  });
+
+  it('carries presence data on join and re-broadcasts data-only updates', async () => {
+    const a = await connect('room-2');
+    expect(await a.next()).toEqual({ t: 'peers', peers: [] });
+
+    // Join with presence data — echoed back in the snapshot.
+    a.send({ t: 'join', peerId: 'peer-a', data: { muted: false } });
+    expect(await a.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a', data: { muted: false } }],
+    });
+
+    const b = await connect('room-2');
+    expect(await b.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a', data: { muted: false } }],
+    });
+
+    // Same members, only data changes (mute toggle) → both sockets re-notified.
+    a.send({ t: 'presence', data: { muted: true } });
+    for (const peer of [a, b]) {
+      expect(await peer.next()).toEqual({
+        t: 'peers',
+        peers: [{ peerId: 'peer-a', data: { muted: true } }],
+      });
+    }
+  });
+
+  it('rejects presence before join', async () => {
+    const a = await connect('room-3');
+    expect(await a.next()).toEqual({ t: 'peers', peers: [] });
+    a.send({ t: 'presence', data: { muted: true } });
+    expect(await a.next()).toEqual({
+      t: 'error',
+      message: 'join before setting presence',
     });
   });
 });


### PR DESCRIPTION
Adopts `@kidlib/p2p` 0.1.12's presence model so room members carry opaque, self-asserted metadata (displayName, muted, camOff, …) end to end. This is the realtime foundation for group-call rosters and in-call state — the in-call half of the call-invite slice.

Clean reshape, no rollout-compat shims (force-immediate SW update + tiny trusted user base; mixed-version window isn't worth protecting).

## Significant changes
- **Wire protocol** (`shared/signaling/protocol.ts`): reshaped `peers: PeerId[]` → `peers: PresenceMember[]` (`{ peerId, data? }`); `join` carries optional `data`; new `{ t: 'presence', data }` message; validator guards presence data is a plain object.
- **Signaling worker DO** (`workers/signaling/src/signaling-room.ts`): stores per-socket presence `data`; `presence` updates it and re-broadcasts so **data-only changes (e.g. mute toggle) reach every member, including self**; rejects `presence` before `join`. The local peer is inherently in snapshots (its own socket is in `getWebSockets()`).
- **DO client adapter** (`src/realtime/signaling/do-room-signaling.ts`): `join(peerId, data?)`; maps wire `{peerId,data}` → port `{memberId,data}` for `onPeers`; adds `updatePresenceData`; restores latest `data` on reconnect.
- **Dependency**: `@kidlib/p2p` `^0.1.11` → `^0.1.12`.
- **Untouched**: legacy `firebase-room-signaling.js` (rtdb fallback) still emits `string[]`, a valid `P2PRoomPresenceSnapshot` arm — no change needed.

## Verification
- Root `tsc` + worker `tsc`: clean.
- Client adapter tests: 7/7 (join-with-data, reconnect-restore, `updatePresenceData`).
- Signaling worker tests: 12/12 (data-on-join, data-only re-broadcast, reject-before-join).
- Note: `pnpm ts`/`pnpm test` are blocked by a pre-existing lockfile-policy failure (`pnpm-lock.yaml` dirtied before this work); ran `tsc`/`vitest` directly. Worth resolving the lockfile separately.

## Suggested next slice
- **Call-invite mailbox → DO** (the remaining half of this branch's goal): presence now covers the **in-call roster + live state**, but can't wake a callee who isn't watching the room. Build the DO mailbox + push to deliver the initial ring to an offline callee; on accept the callee joins/watches and presence takes over.
- **Decide N-party invite shape up front** — fan-out (invite N, track N responses) vs. ring-and-join (ring the group, anyone joins the shared room keyed by conversationId). This choice shapes the mailbox schema, so settle it before building.
- **App-side presence shape**: define the concrete call meta (displayName, muted, camOff, audioOnly) the client asserts via `join`/`updatePresenceData`, and surface it reactively from the Solid adapter's `memberPresence` Accessor. Keep authz-sensitive fields (host/role) authoritative in D1/DO — never trust presence for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom per-peer presence data included on join, occupancy updates, and mid-session updates.
  * Occupants now receive per-peer presence payloads (not just peer identifiers) in real time.

* **Improvements**
  * Presence state is preserved across reconnects and re-applied during re-join.

* **Bug Fixes / Hardening**
  * Presence updates sent before joining are rejected.  

* **Chores**
  * Updated the underlying peer-to-peer dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->