### PR TITLE
[codex] Move call invites to data mailbox

### DIFF
--- a/docs/WIP_Architecture/FOLLOWUP_CALL_RESPONSE_RETENTION.md
+++ b/docs/WIP_Architecture/FOLLOWUP_CALL_RESPONSE_RETENTION.md
@@ -1,0 +1,89 @@
+# Follow-up: retain call responses across a caller reconnect
+
+**Status:** deferred from the call-invite mailbox slice ([SLICE_B_CALL_INVITE_MAILBOX.md](./SLICE_B_CALL_INVITE_MAILBOX.md)). Not started.
+
+## Intent
+
+Close the one asymmetric gap in the DO mailbox model: **invites are retained and
+replayed on reconnect, responses are not.**
+
+Scenario (the "lost accept"): caller A is ringing callee B. A's mailbox WebSocket
+briefly drops (network blip, tab throttle) in the ~30s ring window. B taps accept;
+the worker delivers `{t:'response', responseType:'accepted'}` to A's mailbox — but
+A has no live socket and the response is fan-out-only, so it is dropped. A never
+learns of the accept, times out at 30s; B joins the room and sits alone.
+
+Today this degrades safely (it is **not** stuck): B detects it is alone via
+`onMemberLeft` (`memberCount === 1`) and auto-exits, A shows "no answer". The
+follow-up upgrades that to "A actually joins."
+
+## Why this was deferred (read before implementing)
+
+You cannot just mirror invite retention. An invite is a *standing offer* — replaying
+it re-shows a dialog, which is idempotent and harmless. A retained `accepted`
+response is an *action trigger* — replaying it makes A **join the room**. If a
+stored accept replays after A already acted (joined, the call ended, A reconnects
+while the response is still within TTL), A phantom-rejoins a dead room.
+
+This is the exact bug class fixed earlier (commit `9a26876a` "Fix call resume
+playback and signaling races"; the call-invite-wedge phantom-join note). So the
+response must be **consumed-once**, not merely TTL-bounded.
+
+## Chosen approach: consumed-once retention with an ack
+
+1. On `POST /calls/response`, in addition to delivering to A's mailbox, **store** the
+   response in A's mailbox DO keyed by `roomId` (same per-key prefix style as
+   invites — see "store per-key" in `user-mailbox.ts`). Only worth storing
+   `accepted` (the action-bearing type); `rejected`/`busy` can stay transient since
+   losing them only delays A's dialog dismiss until the 30s timeout, which is
+   harmless.
+2. On mailbox connect, replay fresh stored responses just like invites (in
+   `UserMailbox.fetch`).
+3. Add `POST /calls/response/ack { conversationId }`. The client calls it from
+   `onCalleeResponse` **after** it has acted on the response (joined or moved on).
+   The worker calls a new `UserMailbox.clearPendingResponse(roomId)` on the
+   **caller's own** mailbox. TTL (`CALLING_TTL_MS`) is only a backstop; the ack is
+   the real clear, which is what prevents the phantom re-join.
+
+Edge to handle: A reconnects, replays `accepted`, joins — then the ack must fire so
+a *second* reconnect does not replay-and-rejoin. Keep the ack on the success path of
+`onCalleeResponse`, mirroring how invites are cleared on cancel/response.
+
+## Files to read for full context
+
+Server (Cloudflare data worker):
+- `workers/data/src/user-mailbox.ts` — the DO. Mirror the per-key invite storage
+  (`PENDING_INVITE_PREFIX`, `inviteKey`, `getFreshPendingInvites`, `clearPendingInvite`)
+  for responses. Add `storePendingResponse` / `getFreshPendingResponses` /
+  `clearPendingResponse`. `deliver()` is where invite store/clear already hooks in.
+- `workers/data/src/index.ts` — routes. See `POST /calls/response` (stores + delivers;
+  already clears the responder's own pending *invite*) and `POST /calls/cancel`. Add
+  the `POST /calls/response/ack` route with the same D1-membership authz pattern.
+- `shared/call-mailbox/protocol.ts` — the `MailboxResponse` / `MailboxEnvelope` union
+  and `isMailboxEnvelope` guard. Responses already carry `expiresAt`; no shape change
+  needed unless you add an ack envelope (you don't — ack is REST-only, no DO→client
+  message).
+- `shared/constants/index.ts` — `CALLING_TTL_MS` (TTL backstop).
+
+Client:
+- `src/features/call/call-service.ts` — `onCalleeResponse` (where A consumes the
+  response; add the ack call here) and the `post()` helper. Add an
+  `ackCallResponse({ roomId })` method calling `POST /calls/response/ack`.
+- `src/features/call/call-handshake-controller.ts` — `sendOutgoingCallInvite`'s
+  `svc.onCalleeResponse(...)` handler (lines ~189-216): the accept path calls
+  `enterRoom`; the ack should fire once that resolves (and on the non-accept paths
+  too, so the stored accept — if any — is cleared).
+
+Tests:
+- `workers/data/test/worker.test.ts` — `describe('call invite retention')` is the
+  pattern to copy. Add a `call response retention` block: store-accept →
+  reconnect-replays; ack → no replay; expiry → no replay. Helpers `connectMailbox`,
+  `nextOrNoMessage`, `NO_MESSAGE`, `jsonPost` are reusable as-is.
+
+## Checklist (when picked up)
+
+- [ ] DO: per-key response store + replay + `clearPendingResponse` (accepted only)
+- [ ] Worker: `POST /calls/response` stores the accept; new `POST /calls/response/ack`
+- [ ] Client: `ackCallResponse`; call it from the controller's response handler on all paths
+- [ ] Tests: response-retention replay / ack-clears / expiry-clears
+- [ ] Manual e2e: kill caller WS mid-ring, accept on callee, confirm caller joins on reconnect; then confirm a later reconnect does NOT rejoin

--- a/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
+++ b/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
@@ -48,5 +48,10 @@ members of `conversationId`.
 
 - Delete unwired RTDB files: `call-rtdb-adapter.ts`, `room-access-rtdb-adapter.ts`,
   `call-repository.ts` (+ tests).
-- Group-call handshake UI (N responses).
+- Group-call handshake UI (N responses). Mailbox already retains one pending invite
+  per room (per-key `invite:<roomId>` storage), so multiple concurrent incoming
+  calls already replay on reconnect; this item is UI only.
+- Retain call responses across a caller reconnect (the "lost accept" gap) —
+  consumed-once with an ack endpoint. Scoped in
+  [FOLLOWUP_CALL_RESPONSE_RETENTION.md](./FOLLOWUP_CALL_RESPONSE_RETENTION.md).
 - `ALLOWED_ORIGINS` already shared across workers — no new origin needed.

--- a/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
+++ b/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
@@ -15,8 +15,8 @@ decide refinements.
 - **Host in `workers/data`.** Reuses `auth.ts`, origin allowlist, D1 membership
   authz, deploy target. New DO class, existing worker.
 - **Clean swap, no flag/shim.** Replace the RTDB transport outright (tiny user
-  base, force-immediate SW). RTDB adapter files left unwired for a one-commit
-  revert window, deleted after manual verify.
+  base, force-immediate SW). RTDB adapter files are left unwired for now so prod
+  testing can compare/switch back quickly if the DO mailbox has issues.
 - **Drop dead `room-access` RTDB write.** Only `call-service` referenced it; the
   DO signaling worker authorizes by token identity and never reads it.
 
@@ -33,22 +33,20 @@ members of `conversationId`.
 ## Checklist — minimal core
 
 - [x] `shared/call-mailbox/protocol.ts` — envelope union + `isMailboxEnvelope` guard (plain TS, no deps)
-- [x] `workers/data/src/user-mailbox.ts` — `UserMailbox` DO (hibernatable WS, broadcast-only `deliver(envelope)`)
+- [x] `workers/data/src/user-mailbox.ts` — `UserMailbox` DO (hibernatable WS, one pending invite with TTL replay, live `deliver(envelope)`)
 - [x] `workers/data/src/index.ts` — Env binding, export, `GET /users/me/mailbox/ws`, `POST /calls/{invite,response,cancel}` with D1 authz
 - [x] `workers/data/wrangler.jsonc` — `USER_MAILBOX` binding + migration `v2`
 - [x] `src/realtime/mailbox-channel.ts` — WS transport to own mailbox (reconnect/backoff, bearer subprotocol; mirrors conversation-channel)
 - [x] `src/features/call/call-service.ts` — rewrite onto mailbox (drop rtdb, roomAccess, CallRepository); ctor takes `{localUID, baseUrl, getToken}`
 - [x] `src/features/call/call-handshake-controller.ts` — wire `{localUID, baseUrl, getToken}`; thread `callerId` into respond path
+- [x] Pending-invite retention: replay on connect while caller is still ringing; clear on cancel/response/expiry
+- [x] Cancel correlation + worker cancel/retention tests
 - [x] `tsc` (app + worker) + boundaries lint clean; data-worker `wrangler deploy --dry-run` builds with both DO bindings + migration v2; updated singleton test passes
 - [ ] **Manual e2e**: two accounts, app open both sides — invite, accept→join, decline, busy, cancel, timeout
 
 ## Refinements to weigh AFTER manual verify (do not pre-build)
 
-- Pending-invite **retention w/ TTL** in the DO (replay on connect) so a callee
-  whose socket is mid-reconnect / opens a moment late still gets rung. Broadcast-
-  only covers the both-apps-open happy path; this covers reconnect races.
 - Delete unwired RTDB files: `call-rtdb-adapter.ts`, `room-access-rtdb-adapter.ts`,
   `call-repository.ts` (+ tests).
-- Mailbox unit/integration tests.
 - Group-call handshake UI (N responses).
 - `ALLOWED_ORIGINS` already shared across workers — no new origin needed.

--- a/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
+++ b/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
@@ -1,0 +1,54 @@
+# Slice B: Call-invite mailbox → Durable Object
+
+Migrate the call-invite mailbox off Firebase RTDB to a per-user DO mailbox in the
+**existing data worker**. Last RTDB dependency in the conversation/realtime spine
+on the call side. Goal: minimal functional core first, manual e2e verify, then
+decide refinements.
+
+## Decisions (locked)
+
+- **Per-user mailbox + fan-out.** DO keyed by `userId` (`getByName`). Each
+  logged-in client keeps one WS to its own mailbox (receive-only). Caller
+  delivers an invite envelope to each callee's mailbox; responses go to the
+  caller's mailbox. Envelope carries `roomId` (= conversationId) as the room to
+  join. Group-ready (write to N mailboxes); UI stays 1:1 for now.
+- **Host in `workers/data`.** Reuses `auth.ts`, origin allowlist, D1 membership
+  authz, deploy target. New DO class, existing worker.
+- **Clean swap, no flag/shim.** Replace the RTDB transport outright (tiny user
+  base, force-immediate SW). RTDB adapter files left unwired for a one-commit
+  revert window, deleted after manual verify.
+- **Drop dead `room-access` RTDB write.** Only `call-service` referenced it; the
+  DO signaling worker authorizes by token identity and never reads it.
+
+## Wire model
+
+Caller A → callee B in conversation C (roomId === conversationId):
+1. A `POST /calls/invite {conversationId:C, calleeId:B, ...}` → B's mailbox `{t:'invite', invite:{roomId:C, callerId:A, ...}}`
+2. A listens own mailbox for `{t:'response'}` filtered by `roomId===C`
+3. B `POST /calls/response {conversationId:C, callerId:A, responseType}` → A's mailbox `{t:'response', response:{roomId:C, responseType, by:B}}`
+4. Cancel/timeout: A `POST /calls/cancel {conversationId:C, calleeId:B}` → B's mailbox `{t:'cancel', roomId:C, by:A}` → B dialog dismiss
+Authz on every POST: authenticated sender AND the target user must both be D1
+members of `conversationId`.
+
+## Checklist — minimal core
+
+- [x] `shared/call-mailbox/protocol.ts` — envelope union + `isMailboxEnvelope` guard (plain TS, no deps)
+- [x] `workers/data/src/user-mailbox.ts` — `UserMailbox` DO (hibernatable WS, broadcast-only `deliver(envelope)`)
+- [x] `workers/data/src/index.ts` — Env binding, export, `GET /users/me/mailbox/ws`, `POST /calls/{invite,response,cancel}` with D1 authz
+- [x] `workers/data/wrangler.jsonc` — `USER_MAILBOX` binding + migration `v2`
+- [x] `src/realtime/mailbox-channel.ts` — WS transport to own mailbox (reconnect/backoff, bearer subprotocol; mirrors conversation-channel)
+- [x] `src/features/call/call-service.ts` — rewrite onto mailbox (drop rtdb, roomAccess, CallRepository); ctor takes `{localUID, baseUrl, getToken}`
+- [x] `src/features/call/call-handshake-controller.ts` — wire `{localUID, baseUrl, getToken}`; thread `callerId` into respond path
+- [x] `tsc` (app + worker) + boundaries lint clean; data-worker `wrangler deploy --dry-run` builds with both DO bindings + migration v2; updated singleton test passes
+- [ ] **Manual e2e**: two accounts, app open both sides — invite, accept→join, decline, busy, cancel, timeout
+
+## Refinements to weigh AFTER manual verify (do not pre-build)
+
+- Pending-invite **retention w/ TTL** in the DO (replay on connect) so a callee
+  whose socket is mid-reconnect / opens a moment late still gets rung. Broadcast-
+  only covers the both-apps-open happy path; this covers reconnect races.
+- Delete unwired RTDB files: `call-rtdb-adapter.ts`, `room-access-rtdb-adapter.ts`,
+  `call-repository.ts` (+ tests).
+- Mailbox unit/integration tests.
+- Group-call handshake UI (N responses).
+- `ALLOWED_ORIGINS` already shared across workers — no new origin needed.

--- a/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
+++ b/docs/WIP_Architecture/SLICE_B_CALL_INVITE_MAILBOX.md
@@ -25,7 +25,7 @@ decide refinements.
 Caller A → callee B in conversation C (roomId === conversationId):
 1. A `POST /calls/invite {conversationId:C, calleeId:B, ...}` → B's mailbox `{t:'invite', invite:{roomId:C, callerId:A, ...}}`
 2. A listens own mailbox for `{t:'response'}` filtered by `roomId===C`
-3. B `POST /calls/response {conversationId:C, callerId:A, responseType}` → A's mailbox `{t:'response', response:{roomId:C, responseType, by:B}}`
+3. B `POST /calls/response {conversationId:C, callerId:A, responseType}` → A's mailbox `{t:'response', response:{roomId:C, responseType, by:B}}`; B's mailbox receives `{t:'handled', roomId:C, by:B}` so B's other tabs/devices dismiss the invite
 4. Cancel/timeout: A `POST /calls/cancel {conversationId:C, calleeId:B}` → B's mailbox `{t:'cancel', roomId:C, by:A}` → B dialog dismiss
 Authz on every POST: authenticated sender AND the target user must both be D1
 members of `conversationId`.
@@ -40,7 +40,7 @@ members of `conversationId`.
 - [x] `src/features/call/call-service.ts` — rewrite onto mailbox (drop rtdb, roomAccess, CallRepository); ctor takes `{localUID, baseUrl, getToken}`
 - [x] `src/features/call/call-handshake-controller.ts` — wire `{localUID, baseUrl, getToken}`; thread `callerId` into respond path
 - [x] Pending-invite retention: replay on connect while caller is still ringing; clear on cancel/response/expiry
-- [x] Cancel correlation + worker cancel/retention tests
+- [x] Cancel/handled correlation + worker cancel/retention/fan-out tests
 - [x] `tsc` (app + worker) + boundaries lint clean; data-worker `wrangler deploy --dry-run` builds with both DO bindings + migration v2; updated singleton test passes
 - [ ] **Manual e2e**: two accounts, app open both sides — invite, accept→join, decline, busy, cancel, timeout
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "@kidlib/create-component": "^0.1.5",
-    "@kidlib/p2p": "^0.1.12",
+    "@kidlib/p2p": "^0.2.0",
     "@mediabunny/ac3": "^1.40.1",
     "@sentry/browser": "^10.49.0",
     "firebase": "^12.12.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "@kidlib/create-component": "^0.1.5",
-    "@kidlib/p2p": "^0.2.0",
+    "@kidlib/p2p": "^0.2.2",
     "@mediabunny/ac3": "^1.40.1",
     "@sentry/browser": "^10.49.0",
     "firebase": "^12.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       '@kidlib/p2p':
-        specifier: ^0.2.0
-        version: 0.2.0(solid-js@1.9.12)
+        specifier: ^0.2.2
+        version: 0.2.2(solid-js@1.9.12)
       '@mediabunny/ac3':
         specifier: ^1.40.1
         version: 1.40.1(mediabunny@1.41.0)
@@ -1395,8 +1395,8 @@ packages:
   '@kidlib/create-component@0.1.5':
     resolution: {integrity: sha512-viom5Q6hIMz13plwb6665OT+2N3OBLs+8T7dNT5G9+0UQFcCtOI0iFE0tq0PNf5nnkNsrhS/NkhkyFvclTbMKA==}
 
-  '@kidlib/p2p@0.2.0':
-    resolution: {integrity: sha512-tzjEtJr1sEVZSTBvmKDpR92vtXemIU43Cxip2bg78X4ThA529WOswThV0WsgipNlV6sLon3LqCjbFUXZp4utjg==}
+  '@kidlib/p2p@0.2.2':
+    resolution: {integrity: sha512-MHyRKBWtnvXHVEeBXsjAINJcaZkdutEbTP9SAO1rmk7+rR0FVLERHL+vO+SVuGP7cswtMhGrDY5sUIH047sZKA==}
     peerDependencies:
       solid-js: '>=1.8.0'
     peerDependenciesMeta:
@@ -5663,7 +5663,7 @@ snapshots:
   '@google-cloud/promisify@4.0.0':
     optional: true
 
-  '@google-cloud/storage@7.19.0':
+  '@google-cloud/storage@7.19.0(supports-color@10.2.2)':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
@@ -5672,7 +5672,7 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 5.5.7
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       google-auth-library: 9.15.1
       html-entities: 2.6.0
       mime: 3.0.0
@@ -5878,7 +5878,7 @@ snapshots:
 
   '@kidlib/create-component@0.1.5': {}
 
-  '@kidlib/p2p@0.2.0(solid-js@1.9.12)':
+  '@kidlib/p2p@0.2.2(solid-js@1.9.12)':
     optionalDependencies:
       solid-js: 1.9.12
 
@@ -7251,7 +7251,7 @@ snapshots:
       uuid: 11.1.0
     optionalDependencies:
       '@google-cloud/firestore': 7.11.6
-      '@google-cloud/storage': 7.19.0
+      '@google-cloud/storage': 7.19.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7374,10 +7374,10 @@ snapshots:
 
   fuzzy-search@3.2.1: {}
 
-  gaxios@6.7.1:
+  gaxios@6.7.1(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-stream: 2.0.1
       node-fetch: 2.7.0
       uuid: 9.0.1
@@ -7389,14 +7389,14 @@ snapshots:
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@6.1.1:
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -7492,7 +7492,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       gcp-metadata: 6.1.1
       gtoken: 7.1.0
       jws: 4.0.1
@@ -7531,7 +7531,7 @@ snapshots:
 
   gtoken@7.1.0:
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -7601,7 +7601,7 @@ snapshots:
       - supports-color
     optional: true
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       '@kidlib/p2p':
-        specifier: ^0.1.12
-        version: 0.1.12(solid-js@1.9.12)
+        specifier: ^0.2.0
+        version: 0.2.0(solid-js@1.9.12)
       '@mediabunny/ac3':
         specifier: ^1.40.1
         version: 1.40.1(mediabunny@1.41.0)
@@ -1395,8 +1395,8 @@ packages:
   '@kidlib/create-component@0.1.5':
     resolution: {integrity: sha512-viom5Q6hIMz13plwb6665OT+2N3OBLs+8T7dNT5G9+0UQFcCtOI0iFE0tq0PNf5nnkNsrhS/NkhkyFvclTbMKA==}
 
-  '@kidlib/p2p@0.1.12':
-    resolution: {integrity: sha512-w1d9/9gq5os7KMTCUcnUEmbCCz9L04mQ76HsQqNlbhb/bT0g3YmAg4IaN8bVjedPZjTWfgRQiEGxSm92Ko1rNw==}
+  '@kidlib/p2p@0.2.0':
+    resolution: {integrity: sha512-tzjEtJr1sEVZSTBvmKDpR92vtXemIU43Cxip2bg78X4ThA529WOswThV0WsgipNlV6sLon3LqCjbFUXZp4utjg==}
     peerDependencies:
       solid-js: '>=1.8.0'
     peerDependenciesMeta:
@@ -5663,7 +5663,7 @@ snapshots:
   '@google-cloud/promisify@4.0.0':
     optional: true
 
-  '@google-cloud/storage@7.19.0(supports-color@10.2.2)':
+  '@google-cloud/storage@7.19.0':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
@@ -5672,7 +5672,7 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 5.5.7
-      gaxios: 6.7.1(supports-color@10.2.2)
+      gaxios: 6.7.1
       google-auth-library: 9.15.1
       html-entities: 2.6.0
       mime: 3.0.0
@@ -5878,7 +5878,7 @@ snapshots:
 
   '@kidlib/create-component@0.1.5': {}
 
-  '@kidlib/p2p@0.1.12(solid-js@1.9.12)':
+  '@kidlib/p2p@0.2.0(solid-js@1.9.12)':
     optionalDependencies:
       solid-js: 1.9.12
 
@@ -7251,7 +7251,7 @@ snapshots:
       uuid: 11.1.0
     optionalDependencies:
       '@google-cloud/firestore': 7.11.6
-      '@google-cloud/storage': 7.19.0(supports-color@10.2.2)
+      '@google-cloud/storage': 7.19.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7374,10 +7374,10 @@ snapshots:
 
   fuzzy-search@3.2.1: {}
 
-  gaxios@6.7.1(supports-color@10.2.2):
+  gaxios@6.7.1:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
       uuid: 9.0.1
@@ -7389,14 +7389,14 @@ snapshots:
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@6.1.1:
     dependencies:
-      gaxios: 6.7.1(supports-color@10.2.2)
+      gaxios: 6.7.1
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -7492,7 +7492,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(supports-color@10.2.2)
+      gaxios: 6.7.1
       gcp-metadata: 6.1.1
       gtoken: 7.1.0
       jws: 4.0.1
@@ -7531,7 +7531,7 @@ snapshots:
 
   gtoken@7.1.0:
     dependencies:
-      gaxios: 6.7.1(supports-color@10.2.2)
+      gaxios: 6.7.1
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -7601,7 +7601,7 @@ snapshots:
       - supports-color
     optional: true
 
-  https-proxy-agent@7.0.6(supports-color@10.2.2):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)

--- a/shared/call-mailbox/protocol.ts
+++ b/shared/call-mailbox/protocol.ts
@@ -1,0 +1,71 @@
+/**
+ * Call-mailbox wire protocol — single source of truth shared by the client
+ * transport (`src/realtime/mailbox-channel.ts`) and the Durable Object
+ * (`workers/data/src/user-mailbox.ts`).
+ *
+ * Transport-agnostic and side-agnostic: no D1, Firebase, DOM, or Workers types.
+ * The mailbox is per-user and broadcast-only within that user's connections: the
+ * worker authenticates the WebSocket upgrade (you can only open your OWN mailbox)
+ * and authorizes every delivery against D1 conversation membership, then the DO
+ * fans the envelope to every connected socket for that user. Clients receive
+ * only; they send invites/responses/cancels over REST.
+ *
+ * `roomId` is the opaque conversationId — the room to join on accept. All
+ * envelopes are addressed by delivery (which user's mailbox), so they carry no
+ * recipient field.
+ */
+
+export interface MailboxInvite {
+  roomId: string;
+  callerId: string;
+  calleeId: string;
+  callerName?: string;
+  audioOnly?: boolean;
+  startedAt: number;
+  expiresAt?: number;
+}
+
+export interface MailboxResponse {
+  roomId: string;
+  responseType: 'accepted' | 'rejected' | 'busy';
+  by: string;
+  respondedAt: number;
+  expiresAt?: number;
+}
+
+/** DO → client. Delivered to every socket of the addressed user's mailbox. */
+export type MailboxEnvelope =
+  | { t: 'invite'; invite: MailboxInvite }
+  | { t: 'response'; response: MailboxResponse }
+  | { t: 'cancel'; roomId: string; by: string };
+
+export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
+  if (!value || typeof value !== 'object') return false;
+  const e = value as Record<string, unknown>;
+  if (e.t === 'invite') {
+    const i = e.invite as Record<string, unknown> | undefined;
+    return (
+      !!i &&
+      typeof i.roomId === 'string' &&
+      typeof i.callerId === 'string' &&
+      typeof i.calleeId === 'string' &&
+      typeof i.startedAt === 'number'
+    );
+  }
+  if (e.t === 'response') {
+    const r = e.response as Record<string, unknown> | undefined;
+    return (
+      !!r &&
+      typeof r.roomId === 'string' &&
+      (r.responseType === 'accepted' ||
+        r.responseType === 'rejected' ||
+        r.responseType === 'busy') &&
+      typeof r.by === 'string' &&
+      typeof r.respondedAt === 'number'
+    );
+  }
+  if (e.t === 'cancel') {
+    return typeof e.roomId === 'string' && typeof e.by === 'string';
+  }
+  return false;
+}

--- a/shared/call-mailbox/protocol.ts
+++ b/shared/call-mailbox/protocol.ts
@@ -33,11 +33,19 @@ export interface MailboxResponse {
   expiresAt?: number;
 }
 
-/** DO → client. Delivered to every socket of the addressed user's mailbox. */
+/**
+ * DO → client. Delivered to every socket of the addressed user's mailbox.
+ *
+ * `cancel` vs `handled` both retire a pending invite and dismiss its dialog, but
+ * are distinct on purpose: `cancel` is the caller withdrawing (hang-up/timeout),
+ * `handled` is the callee responding on one device, fanned to their OWN other
+ * devices so the dialog clears everywhere. `by` is whoever retired it.
+ */
 export type MailboxEnvelope =
   | { t: 'invite'; invite: MailboxInvite }
   | { t: 'response'; response: MailboxResponse }
-  | { t: 'cancel'; roomId: string; by: string };
+  | { t: 'cancel'; roomId: string; by: string }
+  | { t: 'handled'; roomId: string; by: string };
 
 export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
   if (!value || typeof value !== 'object') return false;
@@ -64,7 +72,7 @@ export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
       typeof r.respondedAt === 'number'
     );
   }
-  if (e.t === 'cancel') {
+  if (e.t === 'cancel' || e.t === 'handled') {
     return typeof e.roomId === 'string' && typeof e.by === 'string';
   }
   return false;

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Cross-cutting constants shared by the client and the Workers.
+ *
+ * Barrel file. Keep it small; if it grows, split into focused modules under
+ * `shared/constants/` and re-export them here so import sites stay stable.
+ */
+
+/** Seconds a call invite/response stays valid before it is treated as stale. */
+export const CALLING_TTL_SECONDS = 60;
+
+/**
+ * Milliseconds form of {@link CALLING_TTL_SECONDS}. Call signaling works in ms
+ * (`Date.now()` deadlines), so this is the value most call code wants.
+ */
+export const CALLING_TTL_MS = CALLING_TTL_SECONDS * 1000;

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -5,8 +5,13 @@
  * `shared/constants/` and re-export them here so import sites stay stable.
  */
 
-/** Seconds a call invite/response stays valid before it is treated as stale. */
-export const CALLING_TTL_SECONDS = 60;
+/**
+ * Single duration governing a call's whole live window: how long the caller rings
+ * before giving up AND how long an invite/response is treated as valid. These are
+ * the same thing — an invite is meaningless once the caller has stopped ringing —
+ * so the ring timeout and the envelope TTL share this one value.
+ */
+export const CALLING_TTL_SECONDS = 45;
 
 /**
  * Milliseconds form of {@link CALLING_TTL_SECONDS}. Call signaling works in ms

--- a/src/components/media/VideoStream.module.css
+++ b/src/components/media/VideoStream.module.css
@@ -24,3 +24,24 @@
     z-index: 1;
   }
 }
+
+.playbackPrompt {
+  position: fixed;
+  z-index: 1000;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(64, 172, 59, 0.788);
+  color: rgba(246, 246, 246, 0.947);
+  text-shadow: var(--text-shadow-medium);
+  font: inherit;
+  font-size: large;
+  letter-spacing: 0.05em;
+  font-weight: 550;
+  box-shadow: 0 8px 28px rgb(0 0 0 / 30%);
+  cursor: pointer;
+}

--- a/src/components/media/VideoStream.test.jsx
+++ b/src/components/media/VideoStream.test.jsx
@@ -3,9 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import VideoStream from './VideoStream';
 
-function createStreamWithVideo() {
+function createStreamWithVideo({ audio = true } = {}) {
   return {
     getVideoTracks: () => [{ kind: 'video' }],
+    getAudioTracks: () => (audio ? [{ kind: 'audio' }] : []),
   };
 }
 

--- a/src/components/media/VideoStream.tsx
+++ b/src/components/media/VideoStream.tsx
@@ -1,4 +1,5 @@
 import { createEffect, createSignal, onCleanup, Show } from 'solid-js';
+import { createMediaPlayback } from '@kidlib/p2p/solid';
 import styles from './VideoStream.module.css';
 
 type Props = {
@@ -35,36 +36,45 @@ export default function VideoStream(props: Props) {
     props.preview ??
     (props.stream?.getAudioTracks().length === 0);
 
+  // Library-owned attach + autoplay/resume core. Surfaces blocked playback
+  // through the shared "Continue call" prompt below.
+  const playback = createMediaPlayback({
+    playsInline: true,
+    onPlaybackBlocked: (err) => {
+      if (import.meta.env.DEV) {
+        const e = err as { name?: string; message?: string };
+        console.warn('[VideoStream] play() rejected', {
+          isLocal: !!props.local,
+          name: e?.name,
+          message: e?.message,
+        });
+      }
+      requestPlaybackPrompt(video);
+    },
+  });
+
   createEffect(() => {
     const stream = props.stream;
     if (!video) return;
 
     // Set playback-affecting flags before assigning the stream. Some browsers
-    // evaluate autoplay eligibility as soon as srcObject changes.
+    // evaluate autoplay eligibility as soon as srcObject changes. attach() sets
+    // muted/playsInline (as properties); the attribute forms below are iOS
+    // belt-and-suspenders the library does not set.
     const muted = shouldMute();
-    video.muted = muted;
     video.defaultMuted = muted;
     if (muted) video.setAttribute('muted', '');
     else video.removeAttribute('muted');
     video.autoplay = true;
-    video.playsInline = true;
     video.setAttribute('playsinline', 'true');
-    video.srcObject = stream ?? null;
-    video.muted = muted;
-    const play = () => {
-      if (!stream || !video.paused) return;
-      video.play().catch((err) => {
-        if (import.meta.env.DEV) {
-          console.warn('[VideoStream] play() rejected', {
-            isLocal: !!props.local,
-            name: err?.name,
-            message: err?.message,
-          });
-        }
-        requestPlaybackPrompt(video);
-      });
+
+    // Attaches the stream and runs the initial play() (autoplay defaults on).
+    playback.attach(video, stream ?? null, { muted });
+
+    // Re-attempt playback once the stream produces frames / on spurious pause.
+    const replay = () => {
+      if (stream && video.paused) playback.resumePlayback();
     };
-    play();
 
     function debugVideoResize() {
       {
@@ -79,21 +89,21 @@ export default function VideoStream(props: Props) {
     }
 
     import.meta.env.DEV && video.addEventListener('resize', debugVideoResize);
-    video.addEventListener('loadedmetadata', play);
-    video.addEventListener('canplay', play);
-    video.addEventListener('pause', play);
+    video.addEventListener('loadedmetadata', replay);
+    video.addEventListener('canplay', replay);
+    video.addEventListener('pause', replay);
 
     onCleanup(() => {
       if (playbackPromptOwner === video) {
         playbackPromptOwner = null;
         setShowPlaybackPrompt(false);
       }
-      video.srcObject = null;
+      playback.detach();
       import.meta.env.DEV &&
         video.removeEventListener('resize', debugVideoResize);
-      video.removeEventListener('loadedmetadata', play);
-      video.removeEventListener('canplay', play);
-      video.removeEventListener('pause', play);
+      video.removeEventListener('loadedmetadata', replay);
+      video.removeEventListener('canplay', replay);
+      video.removeEventListener('pause', replay);
     });
   });
 

--- a/src/components/media/VideoStream.tsx
+++ b/src/components/media/VideoStream.tsx
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup, Show } from 'solid-js';
+import { createEffect, createSignal, onCleanup, Show } from 'solid-js';
 import styles from './VideoStream.module.css';
 
 type Props = {
@@ -11,22 +11,60 @@ type Props = {
   preview?: boolean;
 };
 
+const [showPlaybackPrompt, setShowPlaybackPrompt] = createSignal(false);
+let playbackPromptOwner: HTMLVideoElement | null = null;
+
+function requestPlaybackPrompt(video: HTMLVideoElement) {
+  if (!playbackPromptOwner) playbackPromptOwner = video;
+  setShowPlaybackPrompt(true);
+}
+
+function retryCallPlayback() {
+  setShowPlaybackPrompt(false);
+  playbackPromptOwner = null;
+  document
+    .querySelectorAll<HTMLVideoElement>('video')
+    .forEach((video) => video.play().catch(() => {}));
+}
+
 export default function VideoStream(props: Props) {
   let video!: HTMLVideoElement;
-  const shouldMute = () => props.muted ?? props.local ?? props.preview ?? false;
+  const shouldMute = () =>
+    props.muted ??
+    props.local ??
+    props.preview ??
+    (props.stream?.getAudioTracks().length === 0);
 
   createEffect(() => {
     const stream = props.stream;
     if (!video) return;
 
-    video.srcObject = stream ?? null;
-    video.muted = shouldMute();
-    if (stream) {
-      video.play().catch(() => {});
-    }
-
-    // set programmatically for Firefox compatibility
+    // Set playback-affecting flags before assigning the stream. Some browsers
+    // evaluate autoplay eligibility as soon as srcObject changes.
+    const muted = shouldMute();
+    video.muted = muted;
+    video.defaultMuted = muted;
+    if (muted) video.setAttribute('muted', '');
+    else video.removeAttribute('muted');
+    video.autoplay = true;
+    video.playsInline = true;
     video.setAttribute('playsinline', 'true');
+    video.srcObject = stream ?? null;
+    video.muted = muted;
+    const play = () => {
+      if (!stream || !video.paused) return;
+      video.play().catch((err) => {
+        if (import.meta.env.DEV) {
+          console.warn('[VideoStream] play() rejected', {
+            isLocal: !!props.local,
+            name: err?.name,
+            message: err?.message,
+          });
+        }
+        requestPlaybackPrompt(video);
+      });
+    };
+    play();
 
     function debugVideoResize() {
       {
@@ -41,28 +79,49 @@ export default function VideoStream(props: Props) {
     }
 
     import.meta.env.DEV && video.addEventListener('resize', debugVideoResize);
+    video.addEventListener('loadedmetadata', play);
+    video.addEventListener('canplay', play);
+    video.addEventListener('pause', play);
 
     onCleanup(() => {
+      if (playbackPromptOwner === video) {
+        playbackPromptOwner = null;
+        setShowPlaybackPrompt(false);
+      }
       video.srcObject = null;
       import.meta.env.DEV &&
         video.removeEventListener('resize', debugVideoResize);
+      video.removeEventListener('loadedmetadata', play);
+      video.removeEventListener('canplay', play);
+      video.removeEventListener('pause', play);
     });
   });
 
   return (
     <Show when={props.stream && props.stream.getVideoTracks().length > 0}>
-      <video
-        id={props.id}
-        class={props.baseClass ?? styles.videoStream}
-        classList={{
-          [styles.local]: props.local,
-          [styles.preview]: props.preview,
-          ...props.classList,
-        }}
-        ref={video}
-        autoplay
-        muted={shouldMute()}
-      />
+      <>
+        <video
+          id={props.id}
+          class={props.baseClass ?? styles.videoStream}
+          classList={{
+            [styles.local]: props.local,
+            [styles.preview]: props.preview,
+            ...props.classList,
+          }}
+          ref={video}
+          autoplay
+          muted={shouldMute()}
+        />
+        <Show when={showPlaybackPrompt() && playbackPromptOwner === video}>
+          <button
+            type="button"
+            class={styles.playbackPrompt}
+            onClick={retryCallPlayback}
+          >
+            Continue call
+          </button>
+        </Show>
+      </>
     </Show>
   );
 }

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  incomingCallback: undefined,
+  initCallService: vi.fn(),
+  getCallService: vi.fn(),
+  cleanupCallService: vi.fn(),
+  onIncomingCall: vi.fn((callback) => {
+    mocks.incomingCallback = callback;
+    return vi.fn();
+  }),
+  respondToIncomingCallInvite: vi.fn(),
+  getLoggedInUserId: vi.fn(() => 'callee-id'),
+  getLoggedInUserToken: vi.fn(async () => 'token'),
+  getUser: vi.fn(() => ({ userName: 'Callee' })),
+  sendIncomingCallPushNotification: vi.fn(),
+  sendMissedCallPushNotification: vi.fn(),
+  resolveDirectConversationId: vi.fn(),
+}));
+
+vi.mock('./call-service.js', () => ({
+  initCallService: mocks.initCallService,
+  getCallService: mocks.getCallService,
+  cleanupCallService: mocks.cleanupCallService,
+}));
+
+vi.mock('../../auth/index.js', () => ({
+  getLoggedInUserId: mocks.getLoggedInUserId,
+  getLoggedInUserToken: mocks.getLoggedInUserToken,
+  getUser: mocks.getUser,
+}));
+
+vi.mock('./call-notifications.js', () => ({
+  sendIncomingCallPushNotification: mocks.sendIncomingCallPushNotification,
+  sendMissedCallPushNotification: mocks.sendMissedCallPushNotification,
+}));
+
+vi.mock('../../stores/conversations-client.js', () => ({
+  resolveDirectConversationId: mocks.resolveDirectConversationId,
+}));
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const { CallHandshakeController } = await import(
+  './call-handshake-controller.js'
+);
+
+describe('CallHandshakeController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.incomingCallback = undefined;
+    const service = {
+      onIncomingCall: mocks.onIncomingCall,
+      respondToIncomingCallInvite: mocks.respondToIncomingCallInvite,
+    };
+    mocks.initCallService.mockReturnValue(service);
+    mocks.getCallService.mockReturnValue(service);
+    mocks.respondToIncomingCallInvite.mockResolvedValue(undefined);
+  });
+
+  it('joins the room before notifying the caller that an incoming call was accepted', async () => {
+    const join = deferred();
+    const p2p = {
+      join: vi.fn(() => join.promise),
+      close: vi.fn(),
+      state: vi.fn(() => 'idle'),
+      room: vi.fn(),
+    };
+    const controller = new CallHandshakeController({
+      p2p,
+      createSignaling: vi.fn(),
+      onStateChange: vi.fn(),
+      onCalleeBusy: vi.fn(),
+    });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+
+    controller.acceptIncoming();
+
+    expect(p2p.join).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        peerId: 'callee-id',
+        memberCapacity: 2,
+        dataChannel: true,
+      }),
+    );
+    expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+
+    join.resolve({ roomId: 'room-1', members: ['callee-id'] });
+    await flushPromises();
+
+    expect(mocks.respondToIncomingCallInvite).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      callerId: 'caller-id',
+      responseType: 'accepted',
+    });
+  });
+
+  it('does not notify accepted when joining the room fails', async () => {
+    const p2p = {
+      join: vi.fn(() => Promise.reject(new Error('camera blocked'))),
+      close: vi.fn(),
+      state: vi.fn(() => 'idle'),
+      room: vi.fn(),
+    };
+    const controller = new CallHandshakeController({
+      p2p,
+      createSignaling: vi.fn(),
+      onStateChange: vi.fn(),
+      onCalleeBusy: vi.fn(),
+    });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+
+    controller.acceptIncoming();
+    await flushPromises();
+
+    expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+    expect(p2p.close).toHaveBeenCalled();
+  });
+});

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -71,6 +71,39 @@ describe('CallHandshakeController', () => {
     mocks.respondToIncomingCallInvite.mockResolvedValue(undefined);
   });
 
+  it("dismisses a matching incoming call when another device handles it", () => {
+    const onStateChange = vi.fn();
+    const controller = new CallHandshakeController({
+      p2p: {
+        close: vi.fn(),
+        state: vi.fn(() => 'idle'),
+        room: vi.fn(),
+      },
+      createSignaling: vi.fn(),
+      onStateChange,
+      onCalleeBusy: vi.fn(),
+    });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+    mocks.incomingCallback?.({
+      type: 'handled',
+      roomId: 'room-1',
+      by: 'callee-id',
+    });
+
+    expect(onStateChange).toHaveBeenLastCalledWith(null);
+  });
+
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {
     const join = deferred();
     const p2p = {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -9,6 +9,10 @@ import {
   getUser,
 } from '../../auth/index.js';
 import type { SolidP2PRoom } from '@kidlib/p2p/solid';
+import type {
+  CreateRoomSignalingOptions,
+  P2PRoomSignaling,
+} from '@kidlib/p2p';
 import { CallResponseType, type CallInvite } from './model/call-schema.js';
 import {
   sendIncomingCallPushNotification,
@@ -31,16 +35,21 @@ const DATA_URL =
   (import.meta.env.VITE_DATA_URL as string | undefined) ??
   'http://localhost:8788';
 
+/** Lazy room-signaling factory passed to `p2p.join` — see `src/realtime/signaling`. */
+type CreateRoomSignaling = (
+  options: CreateRoomSignalingOptions,
+) => P2PRoomSignaling | Promise<P2PRoomSignaling>;
+
 type CallHandshakeControllerOptions = {
   p2p: SolidP2PRoom;
-  createSignaling: any; // TODO: Type
+  createSignaling: CreateRoomSignaling;
   onStateChange: (state: CallHandshakeState) => void;
   onCalleeBusy: (busy: boolean) => void;
 };
 
 export class CallHandshakeController {
   private readonly p2p: SolidP2PRoom;
-  private readonly createSignaling: any;
+  private readonly createSignaling: CreateRoomSignaling;
   private readonly onStateChange: (state: CallHandshakeState) => void;
   private readonly onCalleeBusy: (busy: boolean) => void;
 

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -71,6 +71,12 @@ export class CallHandshakeController {
     this.onCalleeBusy(busy);
   }
 
+  private alertCallStartFailed(): void {
+    if (typeof window !== 'undefined') {
+      window.alert('Could not start call. Please try again.');
+    }
+  }
+
   /**
    * (Re)attach the incoming-call listener for the currently logged-in user.
    * Driven reactively by the provider on auth changes, so it must be safe to
@@ -89,16 +95,18 @@ export class CallHandshakeController {
       getToken: getLoggedInUserToken,
     });
 
-    this.unsubscribeIncomingCall = callService.onIncomingCall((call) => {
-      if (!call) {
+    this.unsubscribeIncomingCall = callService.onIncomingCall((event) => {
+      if (event.type === 'cancel') {
         if (
           this._handshakeState &&
-          this._handshakeState.direction === 'incoming'
+          this._handshakeState.direction === 'incoming' &&
+          this._handshakeState.call.roomId === event.roomId
         ) {
           this.setHandshakeState(null);
         }
         return;
       }
+      const { invite: call } = event;
       if (this.isBusyForIncomingCall(call)) {
         callService
           .respondToIncomingCallInvite({
@@ -146,6 +154,7 @@ export class CallHandshakeController {
         '[CallHandshake] Cannot start call: failed to resolve conversationId:',
         err,
       );
+      this.alertCallStartFailed();
       return;
     }
 
@@ -167,6 +176,7 @@ export class CallHandshakeController {
       });
     } catch (err) {
       console.error('Error sending outgoing call invite:', err);
+      this.alertCallStartFailed();
       return;
     }
 

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -28,8 +28,7 @@ import type {
   StartCallDetails,
 } from './call-types.js';
 import { resolveDirectConversationId } from '../../stores/conversations-client.js';
-
-const OUTGOING_CALL_TIMEOUT_MS = 30_000;
+import { CALLING_TTL_MS } from '../../../shared/constants';
 
 const DATA_URL =
   (import.meta.env.VITE_DATA_URL as string | undefined) ??
@@ -305,7 +304,7 @@ export class CallHandshakeController {
           ),
         );
       sendMissedCallPushNotification(call);
-    }, OUTGOING_CALL_TIMEOUT_MS);
+    }, CALLING_TTL_MS);
   }
 
   cancelOutgoing = (): void => {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -1,10 +1,13 @@
-import { rtdb } from '../../infra/firebase-rtdb.js';
 import {
   cleanupCallService,
   initCallService,
   getCallService,
 } from './call-service.js';
-import { getLoggedInUserId, getUser } from '../../auth/index.js';
+import {
+  getLoggedInUserId,
+  getLoggedInUserToken,
+  getUser,
+} from '../../auth/index.js';
 import type { SolidP2PRoom } from '@kidlib/p2p/solid';
 import { CallResponseType, type CallInvite } from './model/call-schema.js';
 import {
@@ -23,6 +26,10 @@ import type {
 import { resolveDirectConversationId } from '../../stores/conversations-client.js';
 
 const OUTGOING_CALL_TIMEOUT_MS = 30_000;
+
+const DATA_URL =
+  (import.meta.env.VITE_DATA_URL as string | undefined) ??
+  'http://localhost:8788';
 
 type CallHandshakeControllerOptions = {
   p2p: SolidP2PRoom;
@@ -76,7 +83,11 @@ export class CallHandshakeController {
     const localUID = getLoggedInUserId();
     if (!localUID) return;
 
-    const callService = initCallService({ localUID, rtdb });
+    const callService = initCallService({
+      localUID,
+      baseUrl: DATA_URL,
+      getToken: getLoggedInUserToken,
+    });
 
     this.unsubscribeIncomingCall = callService.onIncomingCall((call) => {
       if (!call) {
@@ -92,6 +103,7 @@ export class CallHandshakeController {
         callService
           .respondToIncomingCallInvite({
             roomId: call.roomId,
+            callerId: call.callerId,
             responseType: CallResponseType.BUSY,
           })
           .catch((err) =>
@@ -120,7 +132,11 @@ export class CallHandshakeController {
       console.warn('Cannot start outgoing call before login is ready');
       return;
     }
-    const svc = initCallService({ localUID, rtdb });
+    const svc = initCallService({
+      localUID,
+      baseUrl: DATA_URL,
+      getToken: getLoggedInUserToken,
+    });
 
     const { calleeId, calleeName, audioOnly } = details;
     const callerName = getUser()?.userName || 'Unknown';
@@ -260,7 +276,7 @@ export class CallHandshakeController {
       this.setHandshakeState(null);
       this.clearOutgoingCallTracking();
       callService
-        .timeoutOutgoingCall({ recipientUID: call.calleeId })
+        .timeoutOutgoingCall({ recipientUID: call.calleeId, roomId: call.roomId })
         .catch((err) =>
           console.warn(
             '[CallHandshake] Failed to clear callee invite on timeout — callee dialog may not dismiss:',
@@ -279,7 +295,10 @@ export class CallHandshakeController {
     this.setHandshakeState(null);
     this.setCalleeBusy(false);
     svc
-      .cancelOutgoingCall({ recipientUID: state.call.calleeId })
+      .cancelOutgoingCall({
+        recipientUID: state.call.calleeId,
+        roomId: state.call.roomId,
+      })
       .catch((err) =>
         console.warn(
           '[CallHandshake] Failed to clear callee invite on cancel — callee dialog may not dismiss:',
@@ -299,6 +318,7 @@ export class CallHandshakeController {
     svc
       .respondToIncomingCallInvite({
         roomId: state.call.roomId,
+        callerId: state.call.callerId,
         responseType: CallResponseType.ACCEPTED,
       })
       .then(() =>
@@ -323,6 +343,7 @@ export class CallHandshakeController {
     svc
       .respondToIncomingCallInvite({
         roomId: state.call.roomId,
+        callerId: state.call.callerId,
         responseType: CallResponseType.REJECTED,
       })
       .catch((err) => console.error('Error declining incoming call:', err));

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -260,11 +260,9 @@ export class CallHandshakeController {
           })),
       memberCapacity,
       dataChannel: true,
-      onMemberLeft: (detail) => {
-        console.debug('Member left room:', { detail });
-        if (autoExitOnEmpty && this.p2p.room()?.memberCount === 1) {
-          this.exitActiveRoom();
-        }
+      onAlone: (detail) => {
+        console.debug('Room is alone:', { detail });
+        if (autoExitOnEmpty) this.exitActiveRoom();
       },
     });
 

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -124,9 +124,7 @@ export class CallHandshakeController {
     return state !== null || this.p2p.state() !== 'idle';
   }
 
-  async sendOutgoingCallInvite(
-    details: StartCallDetails,
-  ): Promise<void> {
+  async sendOutgoingCallInvite(details: StartCallDetails): Promise<void> {
     const localUID = getLoggedInUserId();
     if (!localUID) {
       console.warn('Cannot start outgoing call before login is ready');
@@ -140,7 +138,16 @@ export class CallHandshakeController {
 
     const { calleeId, calleeName, audioOnly } = details;
     const callerName = getUser()?.userName || 'Unknown';
-    const roomId = await this.resolveCallRoomId(calleeId);
+    let roomId: string;
+    try {
+      roomId = await this.resolveCallRoomId(calleeId);
+    } catch (err) {
+      console.error(
+        '[CallHandshake] Cannot start call: failed to resolve conversationId:',
+        err,
+      );
+      return;
+    }
 
     const nextOutgoingCall: pendingOutgoingCall = {
       calleeId,
@@ -206,19 +213,11 @@ export class CallHandshakeController {
   /**
    * The call room handle is the opaque conversationId from the D1 registry,
    * so every interaction between the same participants shares one id.
-   * The registry is not a hard dependency of calling: if it is unreachable,
-   * fall back to a one-off random room id (pre-registry behavior).
+   * The data worker authorizes call mailbox writes against that conversation's
+   * D1 membership, so there is no valid random-room fallback.
    */
   private async resolveCallRoomId(calleeId: string): Promise<string> {
-    try {
-      return await resolveDirectConversationId(calleeId);
-    } catch (err) {
-      console.warn(
-        '[CallHandshake] Failed to resolve conversationId — falling back to one-off room id:',
-        err,
-      );
-      return crypto.randomUUID();
-    }
+    return resolveDirectConversationId(calleeId);
   }
 
   private async enterRoom(
@@ -276,7 +275,10 @@ export class CallHandshakeController {
       this.setHandshakeState(null);
       this.clearOutgoingCallTracking();
       callService
-        .timeoutOutgoingCall({ recipientUID: call.calleeId, roomId: call.roomId })
+        .timeoutOutgoingCall({
+          recipientUID: call.calleeId,
+          roomId: call.roomId,
+        })
         .catch((err) =>
           console.warn(
             '[CallHandshake] Failed to clear callee invite on timeout — callee dialog may not dismiss:',

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -9,10 +9,7 @@ import {
   getUser,
 } from '../../auth/index.js';
 import type { SolidP2PRoom } from '@kidlib/p2p/solid';
-import type {
-  CreateRoomSignalingOptions,
-  P2PRoomSignaling,
-} from '@kidlib/p2p';
+import type { CreateRoomSignalingOptions, P2PRoomSignaling } from '@kidlib/p2p';
 import { CallResponseType, type CallInvite } from './model/call-schema.js';
 import {
   sendIncomingCallPushNotification,
@@ -79,6 +76,7 @@ export class CallHandshakeController {
     this.onCalleeBusy(busy);
   }
 
+  // TODO: Proper in-app notification
   private alertCallStartFailed(): void {
     if (typeof window !== 'undefined') {
       window.alert('Could not start call. Please try again.');
@@ -104,7 +102,7 @@ export class CallHandshakeController {
     });
 
     this.unsubscribeIncomingCall = callService.onIncomingCall((event) => {
-      if (event.type === 'cancel') {
+      if (event.type === 'cancel' || event.type === 'handled') {
         if (
           this._handshakeState &&
           this._handshakeState.direction === 'incoming' &&

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -327,18 +327,13 @@ export class CallHandshakeController {
     if (!svc || !localUID) return;
     this.clearOutgoingCallTracking();
     this.setHandshakeState(null);
-    svc
-      .respondToIncomingCallInvite({
-        roomId: state.call.roomId,
-        callerId: state.call.callerId,
-        responseType: CallResponseType.ACCEPTED,
-      })
+    this.enterRoom(state.call.roomId, localUID, state.call.audioOnly ?? false)
       .then(() =>
-        this.enterRoom(
-          state.call.roomId,
-          localUID,
-          state.call.audioOnly ?? false,
-        ),
+        svc.respondToIncomingCallInvite({
+          roomId: state.call.roomId,
+          callerId: state.call.callerId,
+          responseType: CallResponseType.ACCEPTED,
+        }),
       )
       .catch((err) => {
         console.error('Error accepting incoming call:', err);

--- a/src/features/call/call-service.test.js
+++ b/src/features/call/call-service.test.js
@@ -25,4 +25,14 @@ describe('initCallService', () => {
     expect(second.localUID).toBe('firebase-auth-uid');
     expect(cleanup).toHaveBeenCalledOnce();
   });
+
+  it('normalizes a trailing slash from the data worker base URL', () => {
+    const service = initCallService({
+      localUID: 'firebase-auth-uid',
+      baseUrl: 'http://localhost:8788/',
+      getToken: async () => null,
+    });
+
+    expect(service.baseUrl).toBe('http://localhost:8788');
+  });
 });

--- a/src/features/call/call-service.test.js
+++ b/src/features/call/call-service.test.js
@@ -1,5 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const mocks = vi.hoisted(() => ({
+  envelopeCallback: undefined,
+  close: vi.fn(),
+}));
+
+vi.mock('../../realtime/mailbox-channel', () => ({
+  createMailboxChannel: vi.fn(() => ({
+    onEnvelope(callback) {
+      mocks.envelopeCallback = callback;
+      return vi.fn();
+    },
+    close: mocks.close,
+  })),
+}));
+
 import { cleanupCallService, initCallService } from './call-service.js';
 
 describe('initCallService', () => {
@@ -34,5 +49,27 @@ describe('initCallService', () => {
     });
 
     expect(service.baseUrl).toBe('http://localhost:8788');
+  });
+
+  it("surfaces a 'handled' mailbox envelope as an incoming-call event", () => {
+    const service = initCallService({
+      localUID: 'callee-id',
+      baseUrl: 'http://localhost:8788',
+      getToken: async () => null,
+    });
+    const callback = vi.fn();
+
+    service.onIncomingCall(callback);
+    mocks.envelopeCallback?.({
+      t: 'handled',
+      roomId: 'room-1',
+      by: 'callee-id',
+    });
+
+    expect(callback).toHaveBeenCalledWith({
+      type: 'handled',
+      roomId: 'room-1',
+      by: 'callee-id',
+    });
   });
 });

--- a/src/features/call/call-service.test.js
+++ b/src/features/call/call-service.test.js
@@ -10,13 +10,15 @@ describe('initCallService', () => {
   it('replaces a stale singleton when the authenticated UID changes', () => {
     const first = initCallService({
       localUID: 'guest-id',
-      rtdb: {},
+      baseUrl: 'http://localhost:8788',
+      getToken: async () => null,
     });
     const cleanup = vi.spyOn(first, 'cleanup');
 
     const second = initCallService({
       localUID: 'firebase-auth-uid',
-      rtdb: {},
+      baseUrl: 'http://localhost:8788',
+      getToken: async () => null,
     });
 
     expect(second).not.toBe(first);

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -3,6 +3,7 @@ import {
   type MailboxChannel,
 } from '../../realtime/mailbox-channel';
 import type { CallInvite, CallResponse } from './model/call-schema';
+import { CALLING_TTL_MS } from '../../../shared/constants';
 
 export type IncomingCallEvent =
   | { type: 'invite'; invite: CallInvite }
@@ -15,8 +16,6 @@ interface CallServiceOptions {
   /** Fresh Firebase ID token provider, or null when logged out. */
   getToken: () => Promise<string | null>;
 }
-
-const CALL_SIGNAL_TTL_MS = 60_000;
 
 let callServiceInstance: CallService | null = null;
 
@@ -119,7 +118,7 @@ export class CallService {
       calleeId,
       callerName,
       audioOnly,
-      expiresAt: Date.now() + CALL_SIGNAL_TTL_MS,
+      expiresAt: Date.now() + CALLING_TTL_MS,
     });
   }
 
@@ -136,7 +135,7 @@ export class CallService {
       conversationId: roomId,
       callerId,
       responseType,
-      expiresAt: Date.now() + CALL_SIGNAL_TTL_MS,
+      expiresAt: Date.now() + CALLING_TTL_MS,
     });
   }
 

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -7,7 +7,8 @@ import { CALLING_TTL_MS } from '../../../shared/constants';
 
 export type IncomingCallEvent =
   | { type: 'invite'; invite: CallInvite }
-  | { type: 'cancel'; roomId: string; by: string };
+  | { type: 'cancel'; roomId: string; by: string }
+  | { type: 'handled'; roomId: string; by: string };
 
 interface CallServiceOptions {
   localUID: string;
@@ -86,15 +87,15 @@ export class CallService {
     }
   }
 
-  /** Incoming invites and cancel events for this user. */
+  /** Incoming invites and dismiss events for this user. */
   onIncomingCall(callback: (event: IncomingCallEvent) => void): () => void {
     return this.channel.onEnvelope((envelope) => {
       if (envelope.t === 'invite') {
         if (!notExpired(envelope.invite.expiresAt)) return;
         callback({ type: 'invite', invite: envelope.invite as CallInvite });
-      } else if (envelope.t === 'cancel') {
+      } else if (envelope.t === 'cancel' || envelope.t === 'handled') {
         callback({
-          type: 'cancel',
+          type: envelope.t,
           roomId: envelope.roomId,
           by: envelope.by,
         });

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -1,18 +1,15 @@
-import type { Database } from 'firebase/database';
 import {
-  createCallRepository,
-  type CallRepository,
-} from './model/call-repository';
-import { createCallRTDBAdapter } from './model/call-rtdb-adapter';
-import {
-  createRoomAccessRTDBAdapter,
-  type RoomAccessRTDBAdapter,
-} from './model/room-access-rtdb-adapter';
+  createMailboxChannel,
+  type MailboxChannel,
+} from '../../realtime/mailbox-channel';
 import type { CallInvite, CallResponse } from './model/call-schema';
 
 interface CallServiceOptions {
   localUID: string;
-  rtdb: Database;
+  /** Data worker base URL (VITE_DATA_URL). */
+  baseUrl: string;
+  /** Fresh Firebase ID token provider, or null when logged out. */
+  getToken: () => Promise<string | null>;
 }
 
 const CALL_SIGNAL_TTL_MS = 60_000;
@@ -41,24 +38,61 @@ export function cleanupCallService(): void {
   }
 }
 
-export class CallService {
-  private callRepo: CallRepository;
-  private roomAccess: RoomAccessRTDBAdapter;
-  readonly localUID: string;
+function notExpired(expiresAt: number | undefined): boolean {
+  return expiresAt == null || expiresAt > Date.now();
+}
 
-  constructor({ localUID, rtdb }: CallServiceOptions) {
-    if (!localUID || !rtdb) {
-      throw new TypeError('[CallService] init(): localUID and rtdb required');
+/**
+ * Call-invite transport over the per-user DO mailbox in the data worker.
+ * Receiving (invites + responses) rides one WebSocket to the user's own mailbox;
+ * sending (invite/response/cancel) is REST with the worker enforcing D1
+ * membership. roomId is the opaque conversationId. Replaces the former RTDB
+ * `users/{uid}/calls/*` mailbox; the dead room-access write went with it.
+ */
+export class CallService {
+  private channel: MailboxChannel;
+  readonly localUID: string;
+  private readonly baseUrl: string;
+  private readonly getToken: () => Promise<string | null>;
+
+  constructor({ localUID, baseUrl, getToken }: CallServiceOptions) {
+    if (!localUID || !baseUrl || !getToken) {
+      throw new TypeError(
+        '[CallService] init(): localUID, baseUrl and getToken required',
+      );
     }
-    this.callRepo = createCallRepository(
-      createCallRTDBAdapter({ database: rtdb }),
-    );
-    this.roomAccess = createRoomAccessRTDBAdapter({ database: rtdb });
     this.localUID = localUID;
+    this.baseUrl = baseUrl;
+    this.getToken = getToken;
+    this.channel = createMailboxChannel({ baseUrl, getToken });
   }
 
+  private async post(path: string, body: unknown): Promise<void> {
+    const token = await this.getToken();
+    if (!token) throw new Error('[CallService] not authenticated');
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(`[CallService] ${path} failed: ${res.status}`);
+    }
+  }
+
+  /** Incoming invites for this user; emits null when an invite is cancelled. */
   onIncomingCall(callback: (call: CallInvite | null) => void): () => void {
-    return this.callRepo.onInviteReceived(this.localUID, callback);
+    return this.channel.onEnvelope((envelope) => {
+      if (envelope.t === 'invite') {
+        if (!notExpired(envelope.invite.expiresAt)) return;
+        callback(envelope.invite as CallInvite);
+      } else if (envelope.t === 'cancel') {
+        callback(null);
+      }
+    });
   }
 
   async sendOutgoingCallInvite({
@@ -72,78 +106,70 @@ export class CallService {
     callerName: string;
     audioOnly: boolean;
   }): Promise<void> {
-    const startedAt = Date.now();
-    await this.roomAccess.createRoomAccess({
-      roomId,
-      createdBy: this.localUID,
-      participants: [calleeId],
-      createdAt: startedAt,
+    await this.post('/calls/invite', {
+      conversationId: roomId,
+      calleeId,
+      callerName,
+      audioOnly,
+      expiresAt: Date.now() + CALL_SIGNAL_TTL_MS,
     });
-    try {
-      await this.callRepo.sendInvite(calleeId, {
-        roomId,
-        callerId: this.localUID,
-        calleeId,
-        callerName,
-        audioOnly,
-        startedAt,
-        expiresAt: startedAt + CALL_SIGNAL_TTL_MS,
-      });
-    } catch (err) {
-      // Rollback orphaned room access; best-effort, TTL covers leftover state.
-      this.roomAccess.clearRoomAccess(roomId).catch((cleanupErr) =>
-        console.warn(
-          '[CallService] Failed to rollback room access after invite failure:',
-          cleanupErr,
-        ),
-      );
-      throw err;
-    }
   }
 
   async respondToIncomingCallInvite({
     roomId,
+    callerId,
     responseType,
   }: {
     roomId: string;
+    callerId: string;
     responseType: CallResponse['responseType'];
   }): Promise<void> {
-    await this.callRepo.respondToInvite({
-      roomId,
-      by: this.localUID,
+    await this.post('/calls/response', {
+      conversationId: roomId,
+      callerId,
       responseType,
+      expiresAt: Date.now() + CALL_SIGNAL_TTL_MS,
     });
-    // Invite-clear is best-effort cleanup; the response is what unblocks the caller.
-    this.callRepo.clearInvite(this.localUID).catch((err) =>
-      console.warn(
-        '[CallService] Failed to clear invite after responding:',
-        err,
-      ),
-    );
   }
 
-  cancelOutgoingCall({ recipientUID }: { recipientUID: string }): Promise<void> {
-    return this.callRepo.clearInvite(recipientUID);
-  }
-
-  timeoutOutgoingCall({
+  cancelOutgoingCall({
     recipientUID,
+    roomId,
   }: {
     recipientUID: string;
+    roomId: string;
   }): Promise<void> {
-    return this.callRepo.clearInvite(recipientUID);
+    return this.post('/calls/cancel', {
+      conversationId: roomId,
+      calleeId: recipientUID,
+    });
   }
 
+  timeoutOutgoingCall(args: {
+    recipientUID: string;
+    roomId: string;
+  }): Promise<void> {
+    return this.cancelOutgoingCall(args);
+  }
+
+  /** Responses addressed to this user (the caller); filters expired/stale. */
   onCalleeResponse(
-    calleeId: string,
+    _calleeId: string,
     callback: (response: CallResponse | null) => void,
   ): () => void {
-    return this.callRepo.onResponseReceived(calleeId, callback);
+    return this.channel.onEnvelope((envelope) => {
+      if (envelope.t !== 'response') return;
+      if (!notExpired(envelope.response.expiresAt)) return;
+      callback(envelope.response as CallResponse);
+    });
   }
 
+  /** No stored invite to clear in the mailbox model; cancel is explicit. */
   clearIncomingCallInvite(): Promise<void> {
-    return this.callRepo.clearInvite(this.localUID);
+    return Promise.resolve();
   }
 
-  cleanup(): void {}
+  cleanup(): void {
+    this.channel.close();
+  }
 }

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -4,6 +4,10 @@ import {
 } from '../../realtime/mailbox-channel';
 import type { CallInvite, CallResponse } from './model/call-schema';
 
+export type IncomingCallEvent =
+  | { type: 'invite'; invite: CallInvite }
+  | { type: 'cancel'; roomId: string; by: string };
+
 interface CallServiceOptions {
   localUID: string;
   /** Data worker base URL (VITE_DATA_URL). */
@@ -83,14 +87,18 @@ export class CallService {
     }
   }
 
-  /** Incoming invites for this user; emits null when an invite is cancelled. */
-  onIncomingCall(callback: (call: CallInvite | null) => void): () => void {
+  /** Incoming invites and cancel events for this user. */
+  onIncomingCall(callback: (event: IncomingCallEvent) => void): () => void {
     return this.channel.onEnvelope((envelope) => {
       if (envelope.t === 'invite') {
         if (!notExpired(envelope.invite.expiresAt)) return;
-        callback(envelope.invite as CallInvite);
+        callback({ type: 'invite', invite: envelope.invite as CallInvite });
       } else if (envelope.t === 'cancel') {
-        callback(null);
+        callback({
+          type: 'cancel',
+          roomId: envelope.roomId,
+          by: envelope.by,
+        });
       }
     });
   }

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -62,9 +62,9 @@ export class CallService {
       );
     }
     this.localUID = localUID;
-    this.baseUrl = baseUrl;
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.getToken = getToken;
-    this.channel = createMailboxChannel({ baseUrl, getToken });
+    this.channel = createMailboxChannel({ baseUrl: this.baseUrl, getToken });
   }
 
   private async post(path: string, body: unknown): Promise<void> {

--- a/src/features/call/components/MemberStreams.tsx
+++ b/src/features/call/components/MemberStreams.tsx
@@ -1,20 +1,10 @@
-import { createMemo, For, Show } from 'solid-js';
+import { For, Show } from 'solid-js';
 import VideoStream from '../../../components/media/VideoStream';
 import { useP2PContext } from '../../../shared/p2p-context.js';
 import styles from './MemberStreams.module.css';
 
 export default function MemberStreams() {
   const p2p = useP2PContext();
-  const remoteStreams = createMemo(() => {
-    const byMemberId = new Map<
-      string,
-      ReturnType<typeof p2p.remoteMemberStreams>[number]
-    >();
-    for (const remote of p2p.remoteMemberStreams()) {
-      byMemberId.set(remote.memberId, remote);
-    }
-    return [...byMemberId.values()];
-  });
 
   return (
     <div
@@ -29,7 +19,7 @@ export default function MemberStreams() {
           <VideoStream stream={stream()} local={true} preview={true} />
         )}
       </Show>
-      <For each={remoteStreams()}>
+      <For each={p2p.remoteMemberStreams()}>
         {(remote) => (
           <VideoStream
             stream={remote.stream}

--- a/src/features/call/components/MemberStreams.tsx
+++ b/src/features/call/components/MemberStreams.tsx
@@ -1,10 +1,20 @@
-import { For, Show } from 'solid-js';
+import { createMemo, For, Show } from 'solid-js';
 import VideoStream from '../../../components/media/VideoStream';
 import { useP2PContext } from '../../../shared/p2p-context.js';
 import styles from './MemberStreams.module.css';
 
 export default function MemberStreams() {
   const p2p = useP2PContext();
+  const remoteStreams = createMemo(() => {
+    const byMemberId = new Map<
+      string,
+      ReturnType<typeof p2p.remoteMemberStreams>[number]
+    >();
+    for (const remote of p2p.remoteMemberStreams()) {
+      byMemberId.set(remote.memberId, remote);
+    }
+    return [...byMemberId.values()];
+  });
 
   return (
     <div
@@ -19,7 +29,7 @@ export default function MemberStreams() {
           <VideoStream stream={stream()} local={true} preview={true} />
         )}
       </Show>
-      <For each={p2p.remoteMemberStreams()}>
+      <For each={remoteStreams()}>
         {(remote) => (
           <VideoStream
             stream={remote.stream}

--- a/src/realtime/mailbox-channel.ts
+++ b/src/realtime/mailbox-channel.ts
@@ -1,0 +1,104 @@
+// Receive-only live channel for the logged-in user's own call-invite mailbox.
+// Connects to the data worker's `GET /users/me/mailbox/ws` Durable Object
+// endpoint and emits each delivered envelope. Reconnects with backoff (mirrors
+// conversation-channel); auth rides in the WebSocket subprotocol since browsers
+// can't set headers on the handshake. Transport only — it validates the envelope
+// shape but does not interpret it.
+
+import {
+  isMailboxEnvelope,
+  type MailboxEnvelope,
+} from '../../shared/call-mailbox/protocol';
+
+export interface MailboxChannelOptions {
+  /** Data worker base URL, e.g. https://localhost:8788 (http(s) → ws(s)). */
+  baseUrl: string;
+  /** Fresh bearer token per (re)connect, or null if logged out. */
+  getToken: () => Promise<string | null>;
+  maxBackoffMs?: number;
+}
+
+export interface MailboxChannel {
+  onEnvelope(handler: (envelope: MailboxEnvelope) => void): () => void;
+  close(): void;
+}
+
+function toWsUrl(baseUrl: string): string {
+  const base = baseUrl.replace(/\/$/, '').replace(/^http/, 'ws');
+  return `${base}/users/me/mailbox/ws`;
+}
+
+export function createMailboxChannel(
+  options: MailboxChannelOptions,
+): MailboxChannel {
+  const url = toWsUrl(options.baseUrl);
+  const maxBackoff = options.maxBackoffMs ?? 10_000;
+  const handlers = new Set<(e: MailboxEnvelope) => void>();
+
+  let ws: WebSocket | null = null;
+  let closed = false;
+  let backoff = 500;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  async function connect(): Promise<void> {
+    if (closed) return;
+    let token: string | null = null;
+    try {
+      token = await options.getToken();
+    } catch (error) {
+      console.warn('[mailbox-channel] token resolve failed:', error);
+    }
+    if (closed) return;
+    if (!token) {
+      scheduleReconnect();
+      return;
+    }
+
+    const socket = new WebSocket(url, ['bearer', token]);
+    ws = socket;
+
+    socket.addEventListener('open', () => {
+      backoff = 500;
+    });
+    socket.addEventListener('message', (event) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+      if (!isMailboxEnvelope(parsed)) return;
+      handlers.forEach((h) => h(parsed));
+    });
+    socket.addEventListener('close', () => {
+      if (ws === socket) ws = null;
+      scheduleReconnect();
+    });
+    socket.addEventListener('error', () => socket.close());
+  }
+
+  function scheduleReconnect(): void {
+    if (closed || reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = undefined;
+      void connect();
+    }, backoff);
+    backoff = Math.min(backoff * 2, maxBackoff);
+  }
+
+  void connect();
+
+  return {
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+    close() {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      handlers.clear();
+      ws?.close();
+      ws = null;
+    },
+  };
+}

--- a/workers/data/src/index.ts
+++ b/workers/data/src/index.ts
@@ -157,9 +157,14 @@ export default {
       ) {
         return json({ error: 'not_found' }, 404, cors);
       }
-      await env.USER_MAILBOX.getByName(callerId).clearPendingInvite(
-        conversationId,
-      );
+      // Retire this invite on the responder's OWN other sockets (other tabs/
+      // devices still ringing): `handled` both clears the retained invite and
+      // fans a dismiss to them. `by` is the responder who handled it.
+      await env.USER_MAILBOX.getByName(callerId).deliver({
+        t: 'handled',
+        roomId: conversationId,
+        by: callerId,
+      });
       await env.USER_MAILBOX.getByName(targetCallerId).deliver({
         t: 'response',
         response: {

--- a/workers/data/src/index.ts
+++ b/workers/data/src/index.ts
@@ -30,6 +30,7 @@ export interface Env {
 }
 
 const MAX_ATTACHMENT_FILE_NAME_LENGTH = 180;
+const CALL_SIGNAL_TTL_MS = 60_000;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -119,6 +120,8 @@ export default {
         return json({ error: 'not_found' }, 404, cors);
       }
       const startedAt = now;
+      const expiresAt =
+        numOrUndef(body?.expiresAt) ?? startedAt + CALL_SIGNAL_TTL_MS;
       await env.USER_MAILBOX.getByName(calleeId).deliver({
         t: 'invite',
         invite: {
@@ -128,7 +131,7 @@ export default {
           callerName: str(body?.callerName) ?? undefined,
           audioOnly: body?.audioOnly === true,
           startedAt,
-          expiresAt: numOrUndef(body?.expiresAt),
+          expiresAt,
         },
       });
       return json({ ok: true }, 200, cors);
@@ -154,6 +157,9 @@ export default {
       ) {
         return json({ error: 'not_found' }, 404, cors);
       }
+      await env.USER_MAILBOX.getByName(callerId).clearPendingInvite(
+        conversationId,
+      );
       await env.USER_MAILBOX.getByName(targetCallerId).deliver({
         t: 'response',
         response: {

--- a/workers/data/src/index.ts
+++ b/workers/data/src/index.ts
@@ -18,6 +18,7 @@ import type {
   ConversationServerEvent,
   WireMessage,
 } from '../../../shared/conversation-channel/protocol';
+import { CALLING_TTL_MS } from '../../../shared/constants';
 
 export { ConversationChannel, UserMailbox };
 
@@ -30,7 +31,6 @@ export interface Env {
 }
 
 const MAX_ATTACHMENT_FILE_NAME_LENGTH = 180;
-const CALL_SIGNAL_TTL_MS = 60_000;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -121,7 +121,7 @@ export default {
       }
       const startedAt = now;
       const expiresAt =
-        numOrUndef(body?.expiresAt) ?? startedAt + CALL_SIGNAL_TTL_MS;
+        numOrUndef(body?.expiresAt) ?? startedAt + CALLING_TTL_MS;
       await env.USER_MAILBOX.getByName(calleeId).deliver({
         t: 'invite',
         invite: {

--- a/workers/data/src/index.ts
+++ b/workers/data/src/index.ts
@@ -13,16 +13,18 @@ import {
   type NewAttachment,
 } from './repo';
 import { ConversationChannel } from './conversation-channel';
+import { UserMailbox } from './user-mailbox';
 import type {
   ConversationServerEvent,
   WireMessage,
 } from '../../../shared/conversation-channel/protocol';
 
-export { ConversationChannel };
+export { ConversationChannel, UserMailbox };
 
 export interface Env {
   DB: D1Database;
   CONVERSATION_CHANNEL: DurableObjectNamespace<ConversationChannel>;
+  USER_MAILBOX: DurableObjectNamespace<UserMailbox>;
   FIREBASE_PROJECT_ID: string;
   ALLOWED_ORIGINS: string;
 }
@@ -71,6 +73,20 @@ export default {
       return stub.fetch(request);
     }
 
+    // Per-user call-invite mailbox WS. You can only open your OWN mailbox, so no
+    // D1 check here — identity IS the key. Same subprotocol auth as above.
+    if (url.pathname === '/users/me/mailbox/ws') {
+      if (request.headers.get('Upgrade') !== 'websocket') {
+        return new Response('Expected WebSocket upgrade', { status: 426 });
+      }
+      if (!isAllowedOrigin(origin, env)) {
+        return new Response('Forbidden origin', { status: 403 });
+      }
+      const identity = await authenticateWebSocket(request, env);
+      if (!identity) return new Response('Unauthorized', { status: 401 });
+      return env.USER_MAILBOX.getByName(identity.userId).fetch(request);
+    }
+
     // Everything below requires authentication.
     const identity = await authenticate(request, env);
     if (!identity) return json({ error: 'unauthorized' }, 401, cors);
@@ -83,6 +99,93 @@ export default {
     // Identity echo — exercises the Bearer auth seam end-to-end.
     if (request.method === 'GET' && url.pathname === '/me') {
       return json({ userId: callerId }, 200, cors);
+    }
+
+    // Call-invite mailbox sends. Receiving is the WS above; these REST endpoints
+    // are the writes. Authz is authoritative here: the authenticated sender AND
+    // the target user must both be members of the conversation, then the envelope
+    // is delivered to the target's mailbox DO. roomId === conversationId.
+    if (request.method === 'POST' && url.pathname === '/calls/invite') {
+      const body = await readJson(request);
+      const conversationId = str(body?.conversationId);
+      const calleeId = str(body?.calleeId);
+      if (!conversationId || !calleeId) {
+        return json({ error: 'conversationId and calleeId required' }, 400, cors);
+      }
+      if (
+        !(await isMember(env.DB, conversationId, callerId)) ||
+        !(await isMember(env.DB, conversationId, calleeId))
+      ) {
+        return json({ error: 'not_found' }, 404, cors);
+      }
+      const startedAt = now;
+      await env.USER_MAILBOX.getByName(calleeId).deliver({
+        t: 'invite',
+        invite: {
+          roomId: conversationId,
+          callerId,
+          calleeId,
+          callerName: str(body?.callerName) ?? undefined,
+          audioOnly: body?.audioOnly === true,
+          startedAt,
+          expiresAt: numOrUndef(body?.expiresAt),
+        },
+      });
+      return json({ ok: true }, 200, cors);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/calls/response') {
+      const body = await readJson(request);
+      const conversationId = str(body?.conversationId);
+      const targetCallerId = str(body?.callerId);
+      const responseType = str(body?.responseType);
+      if (
+        !conversationId ||
+        !targetCallerId ||
+        (responseType !== 'accepted' &&
+          responseType !== 'rejected' &&
+          responseType !== 'busy')
+      ) {
+        return json({ error: 'invalid response' }, 400, cors);
+      }
+      if (
+        !(await isMember(env.DB, conversationId, callerId)) ||
+        !(await isMember(env.DB, conversationId, targetCallerId))
+      ) {
+        return json({ error: 'not_found' }, 404, cors);
+      }
+      await env.USER_MAILBOX.getByName(targetCallerId).deliver({
+        t: 'response',
+        response: {
+          roomId: conversationId,
+          responseType,
+          by: callerId,
+          respondedAt: now,
+          expiresAt: numOrUndef(body?.expiresAt),
+        },
+      });
+      return json({ ok: true }, 200, cors);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/calls/cancel') {
+      const body = await readJson(request);
+      const conversationId = str(body?.conversationId);
+      const calleeId = str(body?.calleeId);
+      if (!conversationId || !calleeId) {
+        return json({ error: 'conversationId and calleeId required' }, 400, cors);
+      }
+      if (
+        !(await isMember(env.DB, conversationId, callerId)) ||
+        !(await isMember(env.DB, conversationId, calleeId))
+      ) {
+        return json({ error: 'not_found' }, 404, cors);
+      }
+      await env.USER_MAILBOX.getByName(calleeId).deliver({
+        t: 'cancel',
+        roomId: conversationId,
+        by: callerId,
+      });
+      return json({ ok: true }, 200, cors);
     }
 
     // POST /conversations/resolve-direct  { otherUserId } -> { conversationId }
@@ -315,6 +418,16 @@ async function readJson(
   } catch {
     return null;
   }
+}
+
+/** Non-empty trimmed string, or null. */
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/** Finite number, or undefined (for optional payload fields). */
+function numOrUndef(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function json(

--- a/workers/data/src/user-mailbox.ts
+++ b/workers/data/src/user-mailbox.ts
@@ -1,17 +1,22 @@
 import { DurableObject } from 'cloudflare:workers';
-import type { MailboxEnvelope } from '../../../shared/call-mailbox/protocol';
+import type {
+  MailboxEnvelope,
+  MailboxInvite,
+} from '../../../shared/call-mailbox/protocol';
 import type { Env } from './index';
+
+const PENDING_INVITE_KEY = 'pendingInvite';
 
 /**
  * One instance per userId (keyed via getByName). Broadcast-only fan-out across
  * that user's connected sockets (multiple tabs/devices). The worker authenticates
  * the upgrade (you can only open your OWN mailbox) and authorizes each delivery
- * against D1 conversation membership before calling `deliver`, so the DO holds no
- * authoritative state — an idle mailbox hibernates and evicts.
+ * against D1 conversation membership before calling `deliver`.
  *
- * Minimal core: no pending-invite retention. A callee whose socket is connected
- * receives the invite immediately; reconnect-race retention is a deferred
- * refinement (see SLICE_B_CALL_INVITE_MAILBOX.md).
+ * Keeps one pending invite with its TTL so opening, refreshing, or reconnecting
+ * the app while the caller is still ringing resurfaces the incoming-call dialog.
+ * This deliberately is not a queue/history model; a new invite replaces the old
+ * one, and cancel/response clear the matching pending invite.
  *
  * ## RPC contract (worker → DO)
  * The worker calls `deliver(envelope)` after authorizing the sender. The DO fans
@@ -28,6 +33,15 @@ export class UserMailbox extends DurableObject<Env> {
     const client = pair[0];
     const server = pair[1];
     this.ctx.acceptWebSocket(server);
+    const pendingInvite = await this.getFreshPendingInvite();
+    if (pendingInvite) {
+      server.send(
+        JSON.stringify({
+          t: 'invite',
+          invite: pendingInvite,
+        } satisfies MailboxEnvelope),
+      );
+    }
 
     // Echo the auth subprotocol; browsers abort the handshake if the server
     // does not confirm one of the offered subprotocols.
@@ -48,7 +62,13 @@ export class UserMailbox extends DurableObject<Env> {
   async webSocketError(): Promise<void> {}
 
   /** Fan an envelope out to every connected socket of this user. */
-  deliver(envelope: MailboxEnvelope): void {
+  async deliver(envelope: MailboxEnvelope): Promise<void> {
+    if (envelope.t === 'invite') {
+      await this.storePendingInvite(envelope.invite);
+    } else if (envelope.t === 'cancel') {
+      await this.clearPendingInvite(envelope.roomId);
+    }
+
     const payload = JSON.stringify(envelope);
     for (const ws of this.ctx.getWebSockets()) {
       try {
@@ -57,5 +77,34 @@ export class UserMailbox extends DurableObject<Env> {
         // Socket closing; hibernation/eviction handles cleanup.
       }
     }
+  }
+
+  async clearPendingInvite(roomId: string): Promise<void> {
+    const pending = await this.ctx.storage.get<MailboxInvite>(
+      PENDING_INVITE_KEY,
+    );
+    if (pending?.roomId === roomId) {
+      await this.ctx.storage.delete(PENDING_INVITE_KEY);
+    }
+  }
+
+  private async storePendingInvite(invite: MailboxInvite): Promise<void> {
+    if (invite.expiresAt != null && invite.expiresAt <= Date.now()) {
+      await this.ctx.storage.delete(PENDING_INVITE_KEY);
+      return;
+    }
+    await this.ctx.storage.put(PENDING_INVITE_KEY, invite);
+  }
+
+  private async getFreshPendingInvite(): Promise<MailboxInvite | null> {
+    const pending = await this.ctx.storage.get<MailboxInvite>(
+      PENDING_INVITE_KEY,
+    );
+    if (!pending) return null;
+    if (pending.expiresAt != null && pending.expiresAt <= Date.now()) {
+      await this.ctx.storage.delete(PENDING_INVITE_KEY);
+      return null;
+    }
+    return pending;
   }
 }

--- a/workers/data/src/user-mailbox.ts
+++ b/workers/data/src/user-mailbox.ts
@@ -70,7 +70,7 @@ export class UserMailbox extends DurableObject<Env> {
   async deliver(envelope: MailboxEnvelope): Promise<void> {
     if (envelope.t === 'invite') {
       await this.storePendingInvite(envelope.invite);
-    } else if (envelope.t === 'cancel') {
+    } else if (envelope.t === 'cancel' || envelope.t === 'handled') {
       await this.clearPendingInvite(envelope.roomId);
     }
 

--- a/workers/data/src/user-mailbox.ts
+++ b/workers/data/src/user-mailbox.ts
@@ -1,0 +1,57 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { MailboxEnvelope } from '../../../shared/call-mailbox/protocol';
+import type { Env } from './index';
+
+/**
+ * One instance per userId (keyed via getByName). Broadcast-only fan-out across
+ * that user's connected sockets (multiple tabs/devices). The worker authenticates
+ * the upgrade (you can only open your OWN mailbox) and authorizes each delivery
+ * against D1 conversation membership before calling `deliver`, so the DO holds no
+ * authoritative state — an idle mailbox hibernates and evicts.
+ *
+ * Minimal core: no pending-invite retention. A callee whose socket is connected
+ * receives the invite immediately; reconnect-race retention is a deferred
+ * refinement (see SLICE_B_CALL_INVITE_MAILBOX.md).
+ *
+ * ## RPC contract (worker → DO)
+ * The worker calls `deliver(envelope)` after authorizing the sender. The DO fans
+ * the envelope to all of this user's connected sockets — no re-authentication or
+ * payload validation, as the worker is the trusted authority in the same process.
+ */
+export class UserMailbox extends DurableObject<Env> {
+  async fetch(request: Request): Promise<Response> {
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('Expected WebSocket upgrade', { status: 426 });
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    this.ctx.acceptWebSocket(server);
+
+    // Echo the auth subprotocol; browsers abort the handshake if the server
+    // does not confirm one of the offered subprotocols.
+    const headers: HeadersInit = {};
+    if (
+      (request.headers.get('Sec-WebSocket-Protocol') ?? '').includes('bearer')
+    ) {
+      headers['Sec-WebSocket-Protocol'] = 'bearer';
+    }
+    return new Response(null, { status: 101, webSocket: client, headers });
+  }
+
+  /** Clients are receive-only; ignore anything they send. */
+  async webSocketMessage(): Promise<void> {}
+
+  /** Fan an envelope out to every connected socket of this user. */
+  deliver(envelope: MailboxEnvelope): void {
+    const payload = JSON.stringify(envelope);
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(payload);
+      } catch {
+        // Socket closing; hibernation/eviction handles cleanup.
+      }
+    }
+  }
+}

--- a/workers/data/src/user-mailbox.ts
+++ b/workers/data/src/user-mailbox.ts
@@ -5,7 +5,12 @@ import type {
 } from '../../../shared/call-mailbox/protocol';
 import type { Env } from './index';
 
-const PENDING_INVITE_KEY = 'pendingInvite';
+// One stored key per pending invite, keyed by roomId (= conversationId). Using a
+// key per invite (rather than one blob) lets concurrent deliver() calls from
+// different callers each write their own key without a read-modify-write race,
+// and makes a re-invite to the same room a natural overwrite.
+const PENDING_INVITE_PREFIX = 'invite:';
+const inviteKey = (roomId: string): string => PENDING_INVITE_PREFIX + roomId;
 
 /**
  * One instance per userId (keyed via getByName). Broadcast-only fan-out across
@@ -13,10 +18,11 @@ const PENDING_INVITE_KEY = 'pendingInvite';
  * the upgrade (you can only open your OWN mailbox) and authorizes each delivery
  * against D1 conversation membership before calling `deliver`.
  *
- * Keeps one pending invite with its TTL so opening, refreshing, or reconnecting
- * the app while the caller is still ringing resurfaces the incoming-call dialog.
- * This deliberately is not a queue/history model; a new invite replaces the old
- * one, and cancel/response clear the matching pending invite.
+ * Keeps the set of currently-pending invites (one per room) with their TTLs, so
+ * opening, refreshing, or reconnecting the app while a caller is still ringing
+ * resurfaces every incoming-call dialog. This is not a queue/history model: a new
+ * invite for a room replaces that room's pending invite, and cancel/response
+ * clear the matching one. Responses are not retained (transient live delivery).
  *
  * ## RPC contract (worker → DO)
  * The worker calls `deliver(envelope)` after authorizing the sender. The DO fans
@@ -33,12 +39,11 @@ export class UserMailbox extends DurableObject<Env> {
     const client = pair[0];
     const server = pair[1];
     this.ctx.acceptWebSocket(server);
-    const pendingInvite = await this.getFreshPendingInvite();
-    if (pendingInvite) {
+    for (const invite of await this.getFreshPendingInvites()) {
       server.send(
         JSON.stringify({
           t: 'invite',
-          invite: pendingInvite,
+          invite,
         } satisfies MailboxEnvelope),
       );
     }
@@ -80,31 +85,34 @@ export class UserMailbox extends DurableObject<Env> {
   }
 
   async clearPendingInvite(roomId: string): Promise<void> {
-    const pending = await this.ctx.storage.get<MailboxInvite>(
-      PENDING_INVITE_KEY,
-    );
-    if (pending?.roomId === roomId) {
-      await this.ctx.storage.delete(PENDING_INVITE_KEY);
-    }
+    await this.ctx.storage.delete(inviteKey(roomId));
   }
 
   private async storePendingInvite(invite: MailboxInvite): Promise<void> {
+    const key = inviteKey(invite.roomId);
     if (invite.expiresAt != null && invite.expiresAt <= Date.now()) {
-      await this.ctx.storage.delete(PENDING_INVITE_KEY);
+      await this.ctx.storage.delete(key);
       return;
     }
-    await this.ctx.storage.put(PENDING_INVITE_KEY, invite);
+    await this.ctx.storage.put(key, invite);
   }
 
-  private async getFreshPendingInvite(): Promise<MailboxInvite | null> {
-    const pending = await this.ctx.storage.get<MailboxInvite>(
-      PENDING_INVITE_KEY,
-    );
-    if (!pending) return null;
-    if (pending.expiresAt != null && pending.expiresAt <= Date.now()) {
-      await this.ctx.storage.delete(PENDING_INVITE_KEY);
-      return null;
+  /** All non-expired pending invites; sweeps any expired keys it encounters. */
+  private async getFreshPendingInvites(): Promise<MailboxInvite[]> {
+    const stored = await this.ctx.storage.list<MailboxInvite>({
+      prefix: PENDING_INVITE_PREFIX,
+    });
+    const now = Date.now();
+    const fresh: MailboxInvite[] = [];
+    const expiredKeys: string[] = [];
+    for (const [key, invite] of stored) {
+      if (invite.expiresAt != null && invite.expiresAt <= now) {
+        expiredKeys.push(key);
+      } else {
+        fresh.push(invite);
+      }
     }
-    return pending;
+    if (expiredKeys.length) await this.ctx.storage.delete(expiredKeys);
+    return fresh;
   }
 }

--- a/workers/data/src/user-mailbox.ts
+++ b/workers/data/src/user-mailbox.ts
@@ -43,6 +43,10 @@ export class UserMailbox extends DurableObject<Env> {
   /** Clients are receive-only; ignore anything they send. */
   async webSocketMessage(): Promise<void> {}
 
+  async webSocketClose(): Promise<void> {}
+
+  async webSocketError(): Promise<void> {}
+
   /** Fan an envelope out to every connected socket of this user. */
   deliver(envelope: MailboxEnvelope): void {
     const payload = JSON.stringify(envelope);

--- a/workers/data/test/worker.test.ts
+++ b/workers/data/test/worker.test.ts
@@ -337,6 +337,49 @@ describe('call invite retention', () => {
     }
   });
 
+  it("fans 'handled' to the responder's other sockets on response", async () => {
+    // A second tab/device of the callee is still ringing; answering on one
+    // device must dismiss the incoming dialog everywhere, not just clear storage.
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(env.DB, callerId, calleeId, 1000);
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    const otherTab = await connectMailbox(calleeToken);
+    try {
+      expect(
+        (
+          await jsonPost('/calls/invite', callerToken, {
+            conversationId: convoId,
+            calleeId,
+            expiresAt: Date.now() + 30_000,
+          })
+        ).status,
+      ).toBe(200);
+      // The live invite reaches the other tab.
+      expect((await otherTab.next() as { t: string }).t).toBe('invite');
+
+      expect(
+        (
+          await jsonPost('/calls/response', calleeToken, {
+            conversationId: convoId,
+            callerId,
+            responseType: 'accepted',
+          })
+        ).status,
+      ).toBe(200);
+
+      expect(await otherTab.next()).toEqual({
+        t: 'handled',
+        roomId: convoId,
+        by: calleeId,
+      });
+    } finally {
+      otherTab.close();
+    }
+  });
+
   it('replays pending invites from multiple callers', async () => {
     const calleeId = `callee-${crypto.randomUUID()}`;
     const callerAId = `caller-${crypto.randomUUID()}`;

--- a/workers/data/test/worker.test.ts
+++ b/workers/data/test/worker.test.ts
@@ -57,6 +57,50 @@ function messagesRequest(conversationId: string, token?: string) {
   );
 }
 
+function jsonPost(path: string, token: string, body: unknown) {
+  return SELF.fetch(`https://data${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function connectMailbox(token: string) {
+  const res = await SELF.fetch('https://data/users/me/mailbox/ws', {
+    headers: {
+      Upgrade: 'websocket',
+      Origin: ORIGIN,
+      'Sec-WebSocket-Protocol': `bearer, ${token}`,
+    },
+  });
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  ws.accept();
+
+  const queue: unknown[] = [];
+  const waiters: ((message: unknown) => void)[] = [];
+  ws.addEventListener('message', (event: MessageEvent) => {
+    const parsed = JSON.parse(event.data as string) as unknown;
+    const waiter = waiters.shift();
+    if (waiter) waiter(parsed);
+    else queue.push(parsed);
+  });
+
+  return {
+    close: () => ws.close(),
+    next: () =>
+      new Promise<unknown>((resolve) => {
+        const queued = queue.shift();
+        if (queued) resolve(queued);
+        else waiters.push(resolve);
+      }),
+  };
+}
+
 beforeAll(async () => {
   const pair = await crypto.subtle.generateKey(
     {
@@ -135,5 +179,44 @@ describe('auth + membership guard on GET /conversations/:id/messages', () => {
     const res = await messagesRequest(convoId, token);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ messages: [] });
+  });
+});
+
+describe('call cancel mailbox route', () => {
+  it('404s when the caller is not a conversation member', async () => {
+    const convoId = await resolveOrCreateDirect(env.DB, 'user-a', 'user-b', 1000);
+    const token = await signToken(validClaims('user-c'));
+
+    const res = await jsonPost('/calls/cancel', token, {
+      conversationId: convoId,
+      calleeId: 'user-b',
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('delivers the cancel envelope with room and caller identity', async () => {
+    const convoId = await resolveOrCreateDirect(env.DB, 'user-a', 'user-b', 1000);
+    const callerToken = await signToken(validClaims('user-a'));
+    const calleeToken = await signToken(validClaims('user-b'));
+    const mailbox = await connectMailbox(calleeToken);
+
+    try {
+      const res = await jsonPost('/calls/cancel', callerToken, {
+        conversationId: convoId,
+        calleeId: 'user-b',
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      expect(await mailbox.next()).toEqual({
+        t: 'cancel',
+        roomId: convoId,
+        by: 'user-a',
+      });
+    } finally {
+      mailbox.close();
+    }
   });
 });

--- a/workers/data/test/worker.test.ts
+++ b/workers/data/test/worker.test.ts
@@ -17,6 +17,7 @@ const JWKS_URL =
 
 let privateKey: CryptoKey;
 const originalFetch = globalThis.fetch;
+const NO_MESSAGE = Symbol('no message');
 
 function b64urlFromString(s: string): string {
   return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
@@ -99,6 +100,18 @@ async function connectMailbox(token: string) {
         else waiters.push(resolve);
       }),
   };
+}
+
+async function nextOrNoMessage(
+  mailbox: Awaited<ReturnType<typeof connectMailbox>>,
+  timeoutMs = 100,
+): Promise<unknown | typeof NO_MESSAGE> {
+  return Promise.race([
+    mailbox.next(),
+    new Promise<typeof NO_MESSAGE>((resolve) => {
+      setTimeout(() => resolve(NO_MESSAGE), timeoutMs);
+    }),
+  ]);
 }
 
 beforeAll(async () => {
@@ -215,6 +228,110 @@ describe('call cancel mailbox route', () => {
         roomId: convoId,
         by: 'user-a',
       });
+    } finally {
+      mailbox.close();
+    }
+  });
+});
+
+describe('call invite retention', () => {
+  it('replays a fresh pending invite when the callee connects late', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(env.DB, callerId, calleeId, 1000);
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    const res = await jsonPost('/calls/invite', callerToken, {
+      conversationId: convoId,
+      calleeId,
+      callerName: 'Caller',
+      audioOnly: true,
+      expiresAt: Date.now() + 30_000,
+    });
+    expect(res.status).toBe(200);
+
+    const mailbox = await connectMailbox(calleeToken);
+    try {
+      expect(await mailbox.next()).toEqual({
+        t: 'invite',
+        invite: {
+          roomId: convoId,
+          callerId,
+          calleeId,
+          callerName: 'Caller',
+          audioOnly: true,
+          startedAt: expect.any(Number),
+          expiresAt: expect.any(Number),
+        },
+      });
+    } finally {
+      mailbox.close();
+    }
+  });
+
+  it('does not replay a pending invite after caller cancel', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(env.DB, callerId, calleeId, 1000);
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    expect(
+      (
+        await jsonPost('/calls/invite', callerToken, {
+          conversationId: convoId,
+          calleeId,
+          expiresAt: Date.now() + 30_000,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await jsonPost('/calls/cancel', callerToken, {
+          conversationId: convoId,
+          calleeId,
+        })
+      ).status,
+    ).toBe(200);
+
+    const mailbox = await connectMailbox(calleeToken);
+    try {
+      expect(await nextOrNoMessage(mailbox)).toBe(NO_MESSAGE);
+    } finally {
+      mailbox.close();
+    }
+  });
+
+  it('does not replay a pending invite after callee response', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(env.DB, callerId, calleeId, 1000);
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    expect(
+      (
+        await jsonPost('/calls/invite', callerToken, {
+          conversationId: convoId,
+          calleeId,
+          expiresAt: Date.now() + 30_000,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await jsonPost('/calls/response', calleeToken, {
+          conversationId: convoId,
+          callerId,
+          responseType: 'accepted',
+        })
+      ).status,
+    ).toBe(200);
+
+    const mailbox = await connectMailbox(calleeToken);
+    try {
+      expect(await nextOrNoMessage(mailbox)).toBe(NO_MESSAGE);
     } finally {
       mailbox.close();
     }

--- a/workers/data/test/worker.test.ts
+++ b/workers/data/test/worker.test.ts
@@ -336,4 +336,42 @@ describe('call invite retention', () => {
       mailbox.close();
     }
   });
+
+  it('replays pending invites from multiple callers', async () => {
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const callerAId = `caller-${crypto.randomUUID()}`;
+    const callerBId = `caller-${crypto.randomUUID()}`;
+    const convoA = await resolveOrCreateDirect(env.DB, callerAId, calleeId, 1000);
+    const convoB = await resolveOrCreateDirect(env.DB, callerBId, calleeId, 1000);
+    const calleeToken = await signToken(validClaims(calleeId));
+    const callerAToken = await signToken(validClaims(callerAId));
+    const callerBToken = await signToken(validClaims(callerBId));
+
+    for (const [token, convoId] of [
+      [callerAToken, convoA],
+      [callerBToken, convoB],
+    ] as const) {
+      expect(
+        (
+          await jsonPost('/calls/invite', token, {
+            conversationId: convoId,
+            calleeId,
+            expiresAt: Date.now() + 30_000,
+          })
+        ).status,
+      ).toBe(200);
+    }
+
+    const mailbox = await connectMailbox(calleeToken);
+    try {
+      const a = (await mailbox.next()) as { t: string; invite: { roomId: string } };
+      const b = (await mailbox.next()) as { t: string; invite: { roomId: string } };
+      expect([a.t, b.t]).toEqual(['invite', 'invite']);
+      expect(new Set([a.invite.roomId, b.invite.roomId])).toEqual(
+        new Set([convoA, convoB]),
+      );
+    } finally {
+      mailbox.close();
+    }
+  });
 });

--- a/workers/data/wrangler.jsonc
+++ b/workers/data/wrangler.jsonc
@@ -20,10 +20,14 @@
   "durable_objects": {
     "bindings": [
       { "name": "CONVERSATION_CHANNEL", "class_name": "ConversationChannel" },
+      // Per-user call-invite mailbox. One DO per userId; broadcast-only across
+      // that user's connected sockets. Authz lives in the worker (D1 membership).
+      { "name": "USER_MAILBOX", "class_name": "UserMailbox" },
     ],
   },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["ConversationChannel"] },
+    { "tag": "v2", "new_sqlite_classes": ["UserMailbox"] },
   ],
   "vars": {
     // Firebase project id used to validate ID-token claims (aud/iss).

--- a/workers/signaling/src/signaling-room.ts
+++ b/workers/signaling/src/signaling-room.ts
@@ -13,6 +13,7 @@ import type { Env } from './index';
 interface SocketState {
   peerId: PeerId | null;
   data?: PresenceData;
+  joinedAt?: number;
 }
 
 /**
@@ -24,6 +25,8 @@ interface SocketState {
  * room simply hibernates and evicts.
  */
 export class SignalingRoom extends DurableObject<Env> {
+  private joinSequence = 0;
+
   async fetch(request: Request): Promise<Response> {
     if (request.headers.get('Upgrade') !== 'websocket') {
       return new Response('Expected WebSocket upgrade', { status: 426 });
@@ -69,7 +72,12 @@ export class SignalingRoom extends DurableObject<Env> {
     const message = parsed as ClientMessage;
     switch (message.t) {
       case 'join':
-        this.setSocketState(ws, { peerId: message.peerId, data: message.data });
+        this.replaceExistingPeerSocket(ws, message.peerId);
+        this.setSocketState(ws, {
+          peerId: message.peerId,
+          data: message.data,
+          joinedAt: this.nextJoinOrder(),
+        });
         this.broadcastPeers();
         return;
       case 'leave':
@@ -82,7 +90,11 @@ export class SignalingRoom extends DurableObject<Env> {
         // toggle) reaches every member, including the sender.
         const { peerId } = this.getSocketState(ws);
         if (!peerId) return this.sendError(ws, 'join before setting presence');
-        this.setSocketState(ws, { peerId, data: message.data });
+        this.setSocketState(ws, {
+          peerId,
+          data: message.data,
+          joinedAt: this.getSocketState(ws).joinedAt,
+        });
         this.broadcastPeers();
         return;
       }
@@ -133,19 +145,49 @@ export class SignalingRoom extends DurableObject<Env> {
   /** Joined peers with their presence data; the local peer is included (its own
    * socket is in getWebSockets()), so self mute toggles round-trip back. */
   private presenceMembers(): PresenceMember[] {
-    const members: PresenceMember[] = [];
+    const byPeerId = new Map<
+      PeerId,
+      { member: PresenceMember; joinedAt: number }
+    >();
     for (const ws of this.ctx.getWebSockets()) {
-      const { peerId, data } = this.getSocketState(ws);
-      if (peerId) members.push(data ? { peerId, data } : { peerId });
+      const { peerId, data, joinedAt = 0 } = this.getSocketState(ws);
+      if (!peerId) continue;
+      const existing = byPeerId.get(peerId);
+      if (existing && existing.joinedAt > joinedAt) continue;
+      byPeerId.set(peerId, {
+        member: data ? { peerId, data } : { peerId },
+        joinedAt,
+      });
     }
-    return members;
+    return [...byPeerId.values()].map(({ member }) => member);
   }
 
   private findSocket(peerId: PeerId): WebSocket | null {
+    let target: WebSocket | null = null;
+    let targetJoinedAt = -1;
     for (const ws of this.ctx.getWebSockets()) {
-      if (this.getSocketState(ws).peerId === peerId) return ws;
+      const state = this.getSocketState(ws);
+      if (state.peerId !== peerId) continue;
+      const joinedAt = state.joinedAt ?? 0;
+      if (target && targetJoinedAt > joinedAt) continue;
+      target = ws;
+      targetJoinedAt = joinedAt;
     }
-    return null;
+    return target;
+  }
+
+  private replaceExistingPeerSocket(current: WebSocket, peerId: PeerId): void {
+    for (const ws of this.ctx.getWebSockets()) {
+      if (ws === current) continue;
+      if (this.getSocketState(ws).peerId !== peerId) continue;
+      this.setSocketState(ws, { peerId: null });
+      try {
+        ws.close(4000, 'replaced by newer connection');
+      } catch {
+        // Socket is already closing; clearing attachment above is enough to
+        // keep subsequent relay routing away from the stale connection.
+      }
+    }
   }
 
   private send(ws: WebSocket, message: ServerMessage): void {
@@ -166,5 +208,10 @@ export class SignalingRoom extends DurableObject<Env> {
 
   private setSocketState(ws: WebSocket, state: SocketState): void {
     ws.serializeAttachment(state);
+  }
+
+  private nextJoinOrder(): number {
+    this.joinSequence = (this.joinSequence + 1) % 1000;
+    return Date.now() * 1000 + this.joinSequence;
   }
 }

--- a/workers/signaling/src/signaling-room.ts
+++ b/workers/signaling/src/signaling-room.ts
@@ -81,7 +81,7 @@ export class SignalingRoom extends DurableObject<Env> {
         this.broadcastPeers();
         return;
       case 'leave':
-        this.setSocketState(ws, { peerId: null });
+        this.clearPeerPresence(this.getSocketState(ws).peerId);
         this.broadcastPeers();
         return;
       case 'presence': {
@@ -104,11 +104,12 @@ export class SignalingRoom extends DurableObject<Env> {
   }
 
   async webSocketClose(ws: WebSocket): Promise<void> {
-    // The socket is gone from getWebSockets() by the time presence recomputes.
+    this.clearPeerPresence(this.getSocketState(ws).peerId);
     this.broadcastPeers();
   }
 
   async webSocketError(ws: WebSocket): Promise<void> {
+    this.clearPeerPresence(this.getSocketState(ws).peerId);
     this.broadcastPeers();
   }
 
@@ -186,6 +187,15 @@ export class SignalingRoom extends DurableObject<Env> {
       } catch {
         // Socket is already closing; clearing attachment above is enough to
         // keep subsequent relay routing away from the stale connection.
+      }
+    }
+  }
+
+  private clearPeerPresence(peerId: PeerId | null): void {
+    if (!peerId) return;
+    for (const ws of this.ctx.getWebSockets()) {
+      if (this.getSocketState(ws).peerId === peerId) {
+        this.setSocketState(ws, { peerId: null });
       }
     }
   }

--- a/workers/signaling/test/signaling-room.test.ts
+++ b/workers/signaling/test/signaling-room.test.ts
@@ -104,4 +104,48 @@ describe('SignalingRoom', () => {
       message: 'join before setting presence',
     });
   });
+
+  it('routes relays to the newest socket when a peer rejoins after reload', async () => {
+    const oldB = await connect('room-4');
+    expect(await oldB.next()).toEqual({ t: 'peers', peers: [] });
+    oldB.send({ t: 'join', peerId: 'peer-b' });
+    expect(await oldB.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-b' }],
+    });
+
+    const newB = await connect('room-4');
+    expect(await newB.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-b' }],
+    });
+    newB.send({ t: 'join', peerId: 'peer-b' });
+    expect(await newB.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-b' }],
+    });
+
+    const a = await connect('room-4');
+    expect(await a.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-b' }],
+    });
+    a.send({ t: 'join', peerId: 'peer-a' });
+    expect(memberIds(await a.next())).toEqual(['peer-a', 'peer-b']);
+    expect(memberIds(await newB.next())).toEqual(['peer-a', 'peer-b']);
+
+    a.send({
+      t: 'relay',
+      to: 'peer-b',
+      channel: 'sdp',
+      data: { sdp: 'offer-for-new-page' },
+    });
+
+    expect(await newB.next()).toEqual({
+      t: 'relay',
+      from: 'peer-a',
+      channel: 'sdp',
+      data: { sdp: 'offer-for-new-page' },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Moves the call-invite mailbox off Firebase RTDB and onto the existing data worker using a per-user Durable Object mailbox.

## Changes

- Adds a shared call-mailbox envelope protocol and client receive-only mailbox WebSocket channel.
- Rewrites `CallService` to send invites, responses, and cancels through authenticated data-worker REST endpoints.
- Adds `UserMailbox` Durable Object fan-out plus `/users/me/mailbox/ws` and `/calls/{invite,response,cancel}` routes with D1 membership authorization.
- Retains one pending invite per user mailbox with TTL replay so opening, refreshing, or reconnecting while the caller is still ringing resurfaces the incoming-call dialog.
- Clears retained invites on matching cancel, callee response, or expiry.
- Adds the `USER_MAILBOX` Durable Object binding/migration and documents the slice plus deferred RTDB cleanup.
- Fails fast when direct conversation resolution fails instead of falling back to a random room id that cannot pass D1 membership authorization.
- Normalizes the data worker base URL before constructing mailbox REST and WebSocket URLs.
- Preserves cancel envelope metadata and only dismisses matching incoming-call dialogs.
- Shows a simple alert when starting a call fails.
- Adds worker coverage for cancel authorization, cancel envelope shape, and pending-invite replay/clearing.

## Notes

Manual browser e2e call functionality was verified before the initial commit. The legacy RTDB call files are intentionally left in place for prod comparison/switchback while this DO mailbox is tested live.

## Validation

- `pnpm vitest --run src/features/call/call-service.test.js`
- `pnpm -C workers/data run typecheck`
- `pnpm ts`
- `pnpm test:data` (23 tests passed)
- `pnpm lint:boundaries`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a per-user call-invite mailbox with real-time WebSocket delivery.
  - Introduced structured invite/response/cancel signaling envelopes.
  - Added a “Continue call” playback prompt to VideoStream when playback is blocked.
- **Refactor**
  - Migrated call handshake and call signaling from Firebase RTDB to an authenticated worker-based mailbox flow.
- **Bug Fixes**
  - Improved invite/response expiration, cancel handling, and replay behavior across reconnects.
  - Fixed relay routing after peer reconnects.
- **Documentation**
  - Added call mailbox architecture and response retention documentation.
- **Tests**
  - Expanded worker and handshake controller coverage (including cancel and invite-retention cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->