### PR TITLE
Plan backend consolidation and add file storage boundary

### DIFF
--- a/BACKEND_CONSOLIDATION_CHECKLIST.md
+++ b/BACKEND_CONSOLIDATION_CHECKLIST.md
@@ -1,0 +1,90 @@
+# Backend Consolidation — Checklist
+
+Tracker for [`BACKEND_CONSOLIDATION_PLAN.md`](./BACKEND_CONSOLIDATION_PLAN.md).
+Deferred work is tracked separately in
+[`BACKEND_CONSOLIDATION_POST.md`](./BACKEND_CONSOLIDATION_POST.md).
+
+## 1. Consolidated Worker config
+
+- [ ] Create `backend/cloudflare/src/{index,auth,cors}.ts` and `data/ files/ realtime/`
+- [ ] Keep deployed script name `hangvidu-data`
+- [ ] Preserve D1 binding/migrations and DO migration history v1/v2
+- [ ] Add R2 binding and all three DO bindings
+- [ ] Set and test compatibility date `2026-06-02`
+
+## 2. Data and in-place Durable Objects
+
+- [ ] Move D1 repo and data/call handlers into `data/`
+- [ ] Move `ConversationChannel` and `UserMailbox` into `realtime/`
+- [ ] Port data/repo/DO tests
+- [ ] Verify pending mailbox invites survive a normal `hangvidu-data` deploy
+
+## 3. Signaling transfer
+
+- [ ] Move signaling routes and `SignalingRoom` into `realtime/`
+- [ ] Append v3 `transferred_classes` from `hangvidu-signaling`
+- [ ] Do not list `SignalingRoom` under `new_sqlite_classes`
+- [ ] Rehearse transfer with disposable Workers
+- [ ] Verify source-binding forwarding and WebSocket reconnect
+
+## 4. Files
+
+- [ ] Define narrow server-side `FileObjectStore` port
+- [ ] Implement only `R2FileObjectStore`; handlers must not use `FILES_BUCKET` directly
+- [ ] Add the provider resolver seam with R2 as the only current selection
+- [ ] Keep existing `r2_key`/`bucket` persistence and browser contract unchanged
+- [ ] Preserve GET auth cache, bound, App Check cache key, and D1-failure 502
+- [ ] Replace only the wrapper's inner membership query with shared `isMember`
+- [ ] Test handlers against a fake store and add R2 adapter contract tests
+- [ ] Port upload/download/delete and authorization tests
+
+## 5. Router, auth, and CORS
+
+- [ ] Dispatch route family before route-specific auth/CORS/method behavior
+- [ ] Match anchored, most-specific routes before generic `/conversations/:id`
+- [ ] Merge auth as tested superset: JWKS timeout/logging + WS token extraction
+- [ ] Bundle `config/origins.json` and select origins by environment
+- [ ] Exclude development/localhost origins in production
+- [ ] Add auth/CORS parity tests for REST, files, and WebSockets
+
+## 6. Stable HangVidU API URL
+
+- [ ] Add `VITE_HANGVIDU_API_URL` to typings and environment files
+- [ ] Document it as the stable HangVidU API entry point, not a provider selector
+- [ ] Add tested URL normalization, HTTP↔WS conversion, and path construction
+- [ ] Repoint existing `src/storage` and `src/realtime` clients
+- [ ] Enforce that feature code does not read `VITE_HANGVIDU_API_URL` directly
+- [ ] Keep provider choice and credentials server-side/runtime; never in `VITE_*`
+- [ ] Remove per-worker URL variables after cutover
+
+## 7. Boundaries, tooling, and observability
+
+- [ ] Extend boundary linting to `backend/cloudflare`
+- [ ] Allow only the documented files→membership cross-capability import
+- [ ] Add route-family fields to logs
+- [ ] Collapse scripts to `dev:cf`, `deploy:cf`, and `test:cf`
+- [ ] Update CI and old Worker path references
+
+## 8. Verification gates
+
+- [ ] `pnpm ts`, boundary lint, and `test:cf`
+- [ ] Wrangler config validation/dry run
+- [ ] Auth/CORS parity, files cache/502, and store contract tests
+- [ ] Disposable `SignalingRoom` transfer rehearsal
+- [ ] Local REST, R2, mailbox/live-push/signaling WS smoke checks
+- [ ] Browser smoke: text, image, and call flows
+
+## 9. Production cutover
+
+- [ ] Verify bindings, resource IDs, v1/v2 history, routes, and source script name
+- [ ] Deploy consolidated `hangvidu-data` and accept forward-fix-only boundary
+- [ ] Verify all route families and `hangvidu-signaling` binding forwarding
+- [ ] Deploy `VITE_HANGVIDU_API_URL` client and force immediate SW update
+- [ ] Keep `hangvidu-files` and `hangvidu-signaling` live through short verification window
+- [ ] Confirm smoke checks and no material legacy endpoint traffic
+- [ ] Retire old services and source directories
+- [ ] Update architecture and operations documentation
+
+## Deferred explicitly
+
+See `BACKEND_CONSOLIDATION_POST.md`; deferred work is not part of this checklist.

--- a/BACKEND_CONSOLIDATION_CHECKLIST.md
+++ b/BACKEND_CONSOLIDATION_CHECKLIST.md
@@ -49,7 +49,11 @@ Deferred/optional work belongs in
 ## 5. Public API URL
 
 - [ ] Set production to `https://hangvidu-data.kristinnroach.workers.dev`
-- [ ] Set local development to `https://localhost:8788`
+- [ ] Make default frontend development use the deployed production endpoint
+- [ ] Make the local-persistence workflow override the endpoint with
+  `https://localhost:8788`
+- [ ] Remove `.env.development.local` URL overrides so default environment
+  selection cannot silently target localhost
 - [ ] Add/test normalization, HTTP↔WS conversion, and path construction
 - [ ] Repoint every `src/storage` and `src/realtime` client
 - [ ] Ensure feature code does not read `VITE_HANGVIDU_API_URL` directly
@@ -67,7 +71,12 @@ Deferred/optional work belongs in
 
 ## 6. Tooling and tests
 
-- [ ] Collapse scripts to `dev:cf`, `deploy:cf`, and `test:cf`
+- [ ] Collapse Worker scripts to `dev:cf`, `deploy:cf`, and `test:cf`
+- [ ] Set `dev` to Vite-only against the deployed Worker
+- [ ] Set `dev:local` to run Vite and `dev:cf` together with persistent local
+  D1, R2, and Durable Object state
+- [ ] Rename the current tunnel-backed `dev` script unchanged to `dev:mobile`
+- [ ] Preserve the existing Wrangler HTTPS certificate flags in `dev:cf`
 - [ ] Update required CI and moved-file path references
 - [ ] Port all existing Worker tests
 - [ ] Run `pnpm ts`, `test:cf`, and Wrangler config validation/dry run

--- a/BACKEND_CONSOLIDATION_CHECKLIST.md
+++ b/BACKEND_CONSOLIDATION_CHECKLIST.md
@@ -1,90 +1,72 @@
 # Backend Consolidation — Checklist
 
-Tracker for [`BACKEND_CONSOLIDATION_PLAN.md`](./BACKEND_CONSOLIDATION_PLAN.md).
-Deferred work is tracked separately in
+Implementation tracker for
+[`BACKEND_CONSOLIDATION_PLAN.md`](./BACKEND_CONSOLIDATION_PLAN.md).
+Deferred/optional work belongs in
 [`BACKEND_CONSOLIDATION_POST.md`](./BACKEND_CONSOLIDATION_POST.md).
 
-## 1. Consolidated Worker config
+## 0. Preparatory PR
 
-- [ ] Create `backend/cloudflare/src/{index,auth,cors}.ts` and `data/ files/ realtime/`
+- [x] Document the consolidation and post-migration work
+- [x] Add `FileObjectStore` and `R2FileObjectStore` to the files Worker
+- [x] Keep current R2 persistence and browser contract unchanged
+
+## 1. Consolidated Worker
+
+- [ ] Create `backend/cloudflare/src/{index,auth,cors}.ts` and capability folders
 - [ ] Keep deployed script name `hangvidu-data`
-- [ ] Preserve D1 binding/migrations and DO migration history v1/v2
-- [ ] Add R2 binding and all three DO bindings
-- [ ] Set and test compatibility date `2026-06-02`
+- [ ] Add production D1/R2 and all three DO bindings
+- [ ] Preserve DO migration history v1/v2
+- [ ] Append v3 `new_sqlite_classes: ["SignalingRoom"]`; do not transfer it
+- [ ] Set compatibility date `2026-06-02`
+- [ ] Use top-level config for production and local `wrangler dev`; no named envs
 
-## 2. Data and in-place Durable Objects
+## 2. Data and realtime
 
 - [ ] Move D1 repo and data/call handlers into `data/`
-- [ ] Move `ConversationChannel` and `UserMailbox` into `realtime/`
-- [ ] Port data/repo/DO tests
-- [ ] Verify pending mailbox invites survive a normal `hangvidu-data` deploy
+- [ ] Move `ConversationChannel` and `UserMailbox` without namespace changes
+- [ ] Move `SignalingRoom` into the fresh v3 namespace
+- [ ] Keep pending-invite persistence unchanged
 
-## 3. Signaling transfer
+## 3. Files
 
-- [ ] Move signaling routes and `SignalingRoom` into `realtime/`
-- [ ] Append v3 `transferred_classes` from `hangvidu-signaling`
-- [ ] Do not list `SignalingRoom` under `new_sqlite_classes`
-- [ ] Rehearse transfer with disposable Workers
-- [ ] Verify source-binding forwarding and WebSocket reconnect
+- [ ] Move existing files handlers, `FileObjectStore`, and `R2FileObjectStore`
+- [ ] Preserve `r2_key`/`bucket` persistence and browser contract
+- [ ] Preserve auth cache/bound, App Check key, and D1-failure 502
+- [ ] Replace only the inner membership query with shared `isMember`
 
-## 4. Files
-
-- [ ] Define narrow server-side `FileObjectStore` port
-- [ ] Implement only `R2FileObjectStore`; handlers must not use `FILES_BUCKET` directly
-- [ ] Add the provider resolver seam with R2 as the only current selection
-- [ ] Keep existing `r2_key`/`bucket` persistence and browser contract unchanged
-- [ ] Preserve GET auth cache, bound, App Check cache key, and D1-failure 502
-- [ ] Replace only the wrapper's inner membership query with shared `isMember`
-- [ ] Test handlers against a fake store and add R2 adapter contract tests
-- [ ] Port upload/download/delete and authorization tests
-
-## 5. Router, auth, and CORS
+## 4. Router, auth, and CORS
 
 - [ ] Dispatch route family before route-specific auth/CORS/method behavior
-- [ ] Match anchored, most-specific routes before generic `/conversations/:id`
-- [ ] Merge auth as tested superset: JWKS timeout/logging + WS token extraction
-- [ ] Bundle `config/origins.json` and select origins by environment
-- [ ] Exclude development/localhost origins in production
-- [ ] Add auth/CORS parity tests for REST, files, and WebSockets
+- [ ] Match anchored, specific routes before generic `/conversations/:id`
+- [ ] Merge auth superset: JWKS timeout/logging + WS token extraction
+- [ ] Use `config/origins.json`; exclude dev/localhost origins in production
+- [ ] Preserve core auth, membership, origin, and WebSocket tests
 
-## 6. Stable HangVidU API URL
+## 5. Public API URL
 
-- [ ] Add `VITE_HANGVIDU_API_URL` to typings and environment files
-- [ ] Document it as the stable HangVidU API entry point, not a provider selector
-- [ ] Add tested URL normalization, HTTP↔WS conversion, and path construction
-- [ ] Repoint existing `src/storage` and `src/realtime` clients
-- [ ] Enforce that feature code does not read `VITE_HANGVIDU_API_URL` directly
-- [ ] Keep provider choice and credentials server-side/runtime; never in `VITE_*`
-- [ ] Remove per-worker URL variables after cutover
+- [ ] Set production to `https://hangvidu-data.kristinnroach.workers.dev`
+- [ ] Set local development to `https://localhost:8788`
+- [ ] Add/test normalization, HTTP↔WS conversion, and path construction
+- [ ] Repoint every `src/storage` and `src/realtime` client
+- [ ] Ensure feature code does not read `VITE_HANGVIDU_API_URL` directly
+- [ ] Remove old URL variables and verify `rg 'VITE_(DATA|FILES|SIGNALING)_URL' src` is empty
 
-## 7. Boundaries, tooling, and observability
+## 6. Tooling and tests
 
-- [ ] Extend boundary linting to `backend/cloudflare`
-- [ ] Allow only the documented files→membership cross-capability import
-- [ ] Add route-family fields to logs
 - [ ] Collapse scripts to `dev:cf`, `deploy:cf`, and `test:cf`
-- [ ] Update CI and old Worker path references
+- [ ] Update required CI and moved-file path references
+- [ ] Port all existing Worker tests
+- [ ] Run `pnpm ts`, `test:cf`, and Wrangler config validation/dry run
+- [ ] Complete local REST/R2/WebSocket smoke checks
+- [ ] Complete production text/image/call smoke checks
 
-## 8. Verification gates
+## 7. Production cutover
 
-- [ ] `pnpm ts`, boundary lint, and `test:cf`
-- [ ] Wrangler config validation/dry run
-- [ ] Auth/CORS parity, files cache/502, and store contract tests
-- [ ] Disposable `SignalingRoom` transfer rehearsal
-- [ ] Local REST, R2, mailbox/live-push/signaling WS smoke checks
-- [ ] Browser smoke: text, image, and call flows
-
-## 9. Production cutover
-
-- [ ] Verify bindings, resource IDs, v1/v2 history, routes, and source script name
-- [ ] Deploy consolidated `hangvidu-data` and accept forward-fix-only boundary
-- [ ] Verify all route families and `hangvidu-signaling` binding forwarding
-- [ ] Deploy `VITE_HANGVIDU_API_URL` client and force immediate SW update
-- [ ] Keep `hangvidu-files` and `hangvidu-signaling` live through short verification window
-- [ ] Confirm smoke checks and no material legacy endpoint traffic
-- [ ] Retire old services and source directories
-- [ ] Update architecture and operations documentation
-
-## Deferred explicitly
-
-See `BACKEND_CONSOLIDATION_POST.md`; deferred work is not part of this checklist.
+- [ ] Owner verifies resource IDs, bindings, migrations, CORS, URL, tests, and dry run
+- [ ] Confirm old files/signaling Workers remain deployed
+- [ ] Deploy consolidated `hangvidu-data`; treat post-v3 recovery as forward-fix
+- [ ] Smoke-test backend before deploying the client
+- [ ] Deploy client and force immediate SW update
+- [ ] Keep both old Workers for exactly seven days
+- [ ] Repeat smoke test, retire old Workers, and update operations docs

--- a/BACKEND_CONSOLIDATION_CHECKLIST.md
+++ b/BACKEND_CONSOLIDATION_CHECKLIST.md
@@ -33,7 +33,10 @@ Deferred/optional work belongs in
 - [ ] Move existing files handlers, `FileObjectStore`, and `R2FileObjectStore`
 - [ ] Preserve `r2_key`/`bucket` persistence and browser contract
 - [ ] Preserve auth cache/bound, App Check key, and D1-failure 502
-- [ ] Replace only the inner membership query with shared `isMember`
+- [ ] Move the `isMember` export from `workers/data/src/repo.ts` to the
+  consolidated `data/repo.ts`, import it from the files handler originating at
+  `workers/files/src/index.ts`, and replace only that handler's inline
+  `conversation_members` SQL query; keep its cache and 502 error handling
 
 ## 4. Router, auth, and CORS
 
@@ -50,7 +53,17 @@ Deferred/optional work belongs in
 - [ ] Add/test normalization, HTTP↔WS conversion, and path construction
 - [ ] Repoint every `src/storage` and `src/realtime` client
 - [ ] Ensure feature code does not read `VITE_HANGVIDU_API_URL` directly
-- [ ] Remove old URL variables and verify `rg 'VITE_(DATA|FILES|SIGNALING)_URL' src` is empty
+- [ ] Replace and remove `VITE_DATA_URL`, `VITE_FILES_URL`, and
+  `VITE_SIGNALING_URL` in all current locations:
+  - `src/stores/message-repository.ts`
+  - `src/stores/conversations-client.ts`
+  - `src/stores/filesStore.ts`
+  - `src/realtime/signaling/do-room-signaling.ts`
+  - `src/features/call/call-handshake-controller.ts`
+  - declarations in `src/env.d.ts`
+- [ ] Update documentation/comment references, including the `VITE_DATA_URL`
+  reference in `src/features/call/call-service.ts`
+- [ ] Verify `rg 'VITE_(DATA|FILES|SIGNALING)_URL' src` returns no matches
 
 ## 6. Tooling and tests
 

--- a/BACKEND_CONSOLIDATION_PLAN.md
+++ b/BACKEND_CONSOLIDATION_PLAN.md
@@ -6,237 +6,227 @@ Collapse the three Cloudflare Workers into the existing `hangvidu-data` Worker.
 The source moves to `backend/cloudflare/`; the deployed script name remains
 `hangvidu-data`.
 
-**Progress tracker:** [`BACKEND_CONSOLIDATION_CHECKLIST.md`](./BACKEND_CONSOLIDATION_CHECKLIST.md)
+**Implementation tracker:** [`BACKEND_CONSOLIDATION_CHECKLIST.md`](./BACKEND_CONSOLIDATION_CHECKLIST.md)
 
 **Post-migration tracker:** [`BACKEND_CONSOLIDATION_POST.md`](./BACKEND_CONSOLIDATION_POST.md)
-— source of truth for work deliberately deferred from this cutover.
+— source of truth for deferred and optional work.
 
----
+## 1. Current PR scope
 
-## 1. Goal
+This first PR contains the consolidation documents and small preparatory changes
+that reduce later implementation work. It does not perform the Worker cutover.
 
-- Replace the separately deployed `data`, `files`, and `signaling` Workers with
-  one `hangvidu-data` Worker organized as `data/`, `files/`, and `realtime/`.
+Completed preparatory change:
+
+- The files Worker now uses a narrow `FileObjectStore` with an
+  `R2FileObjectStore` adapter. Consolidation moves these unchanged.
+
+## 2. Goal
+
+- Replace separately deployed `data`, `files`, and `signaling` Workers with one
+  `hangvidu-data` Worker organized as `data/`, `files/`, and `realtime/`.
 - Keep one membership predicate, auth implementation, CORS policy, Wrangler
-  config, deployment, and local Worker process.
-- Preserve the existing client ports in `src/storage` and `src/realtime`; feature
-  code must use those ports and must not read the global API URL directly.
-- Use one stable `VITE_HANGVIDU_API_URL` for the public HangVidU API entry point.
-  It identifies HangVidU's API, not a selected backend provider.
-- Put file bytes behind a server-side `FileObjectStore` port with the existing R2
-  implementation as its first adapter, so storage is selected behind the API.
+  config, deployment command, and local Worker process.
+- Preserve existing client ports in `src/storage` and `src/realtime`.
+- Use one stable `VITE_HANGVIDU_API_URL` for the HangVidU-owned API entry point.
+- Preserve current D1, R2, file, message, call, and RTDB behavior.
 
-Consolidation is justified by the combined auth/CORS/config/deploy duplication
-and the tight data/realtime coupling. The duplicated membership predicate alone
-could instead be removed through a shared package.
+The consolidation is justified by the combined auth/CORS/config/deploy
+duplication and tight data/realtime coupling. Membership duplication alone would
+not justify the migration.
 
-## 2. Non-goals
+## 3. Non-goals
 
-- No Firebase Functions move. `functions/` remains at the repository root; moving
-  it is a separate future change.
-- No file-storage provider beyond R2, provider-selection UI, connected-storage
-  credential flow, general capability registry, or feature rewrite.
-- No D1 schema or attachment metadata migration. Provider-neutral persistence is
-  a separate post-consolidation PR tracked in `BACKEND_CONSOLIDATION_POST.md`.
-- No RTDB cleanup or changes to deferred contacts/user-profile paths.
-- No indefinite compatibility shim for old clients. The project uses
-  force-immediate service-worker updates and has a small user base.
+- No Firebase Functions move.
+- No D1 schema or attachment metadata migration.
+- No storage provider beyond R2 or provider-selection UI.
+- No RTDB cleanup or deferred contacts/user-profile work.
+- No custom API domain, named staging environment, or transfer of the existing
+  signaling namespace.
+- No expanded architecture lint rules, structured route logging, or exhaustive
+  header-level auth/CORS parity matrix.
 
-## 3. Current system
+Deferred and optional work belongs in `BACKEND_CONSOLIDATION_POST.md`.
 
-| Path                                       | Responsibility                                          | Consolidated destination     |
-| ------------------------------------------ | ------------------------------------------------------- | ---------------------------- |
-| `workers/data/src/index.ts`                | D1 HTTP routes, call routes, live-push/mailbox WS       | `src/index.ts` + `src/data/` |
-| `workers/data/src/repo.ts`                 | D1 access and authoritative `isMember` predicate        | `src/data/repo.ts`           |
-| `workers/data/src/conversation-channel.ts` | Live message push DO                                    | `src/realtime/`              |
-| `workers/data/src/user-mailbox.ts`         | Call mailbox DO with persisted pending invites          | `src/realtime/`              |
-| `workers/files/src/index.ts`               | R2 upload/download and membership authorization wrapper | `src/files/`                 |
-| `workers/signaling/src/signaling-room.ts`  | WebRTC signaling DO                                     | `src/realtime/`              |
-| `workers/*/src/auth.ts`                    | Three related Firebase RS256 implementations            | `src/auth.ts`                |
+## 4. Current system
 
-Membership is delete-based: a row in `conversation_members` means the user is a
-member. Migrations `0003_drop_member_status.sql` and
-`0004_drop_member_role.sql` removed the unused status and role columns. The data
-and files guards are behaviorally consistent today, but duplicate the predicate.
+| Path | Responsibility | Destination |
+|---|---|---|
+| `workers/data/src/index.ts` | D1 HTTP, call routes, live-push/mailbox WS | `src/index.ts` + `src/data/` |
+| `workers/data/src/repo.ts` | D1 access and `isMember` | `src/data/repo.ts` |
+| `workers/data/src/conversation-channel.ts` | Live message push DO | `src/realtime/` |
+| `workers/data/src/user-mailbox.ts` | Mailbox DO with persisted pending invites | `src/realtime/` |
+| `workers/files/src/index.ts` | R2 HTTP and membership authorization | `src/files/` |
+| `workers/files/src/file-object-store.ts` | Object-storage port | `src/files/` |
+| `workers/files/src/r2-file-object-store.ts` | R2 adapter | `src/files/` |
+| `workers/signaling/src/signaling-room.ts` | WebRTC signaling DO | `src/realtime/` |
+| `workers/*/src/auth.ts` | Three related Firebase RS256 implementations | `src/auth.ts` |
 
-The files authorization wrapper must remain intact: preserve its 30-second GET
-cache, bounded cache size, App Check token cache key, and explicit 502 response on
-D1 failure. Replace only its inner membership query with the shared predicate.
+Membership is delete-based: a `conversation_members` row means the user is a
+member. Data and files implement the same correct rule but duplicate it.
 
-## 4. Target structure and boundaries
+The files authorization wrapper remains intact: preserve its 30-second GET cache,
+bounded cache, App Check token cache key, and explicit 502 on D1 failure. Replace
+only its inner membership query with the shared predicate.
+
+## 5. Target structure and routing
 
 ```text
 backend/cloudflare/
   src/
-    index.ts                 # path-family dispatch only
-    auth.ts                  # canonical Firebase RS256 implementation
-    cors.ts                  # environment-selected shared origin policy
-    data/                    # D1 repo and data/call handlers
+    index.ts                  # route-family dispatch
+    auth.ts                   # canonical Firebase RS256 implementation
+    cors.ts                   # shared environment-aware origin policy
+    data/                     # D1 repo and data/call handlers
     files/
-      handlers.ts            # provider-neutral HTTP/auth behavior
-      file-object-store.ts   # narrow blob-storage port + provider resolver seam
-      adapters/r2.ts         # only provider implemented in this pass
-    realtime/                # all three Durable Object classes and WS handlers
-  migrations/               # existing D1 migration history, unchanged
-  wrangler.jsonc             # deployed name remains hangvidu-data
+      handlers.ts
+      file-object-store.ts
+      r2-file-object-store.ts
+    realtime/                 # three DO classes and WS handlers
+  migrations/                # existing D1 history, unchanged
+  wrangler.jsonc              # deployed name: hangvidu-data
 ```
 
-The client owns one shared HangVidU API URL helper under `src/infra/`; storage and
-realtime adapters use it for REST/WS URL construction.
+The router dispatches by route family before route-specific auth, CORS, method,
+or error behavior. Matching is anchored and most-specific-first: files/messages
+subpaths are checked before generic `^/conversations/([^/]+)$`. Unknown paths
+return 404.
 
-`src/index.ts` dispatches by route family before route-specific auth, CORS, method,
-or error handling runs. Route matching is anchored and most-specific-first:
-files/messages subpaths are checked before generic `^/conversations/([^/]+)$`, so
-the generic conversation route cannot shadow them. Unknown paths return 404.
+Allowed cross-capability dependency: files may call the narrow membership
+predicate in `data/repo.ts`. Feature code uses `src/storage` or `src/realtime` and
+does not read the API environment variable directly.
 
-Backend boundary linting enforces:
+## 6. Public API endpoint and environments
 
-- `data`, `files`, and `realtime` handlers may use shared root modules.
-- `files` may use the narrow membership predicate from `data/repo.ts`; no other
-  cross-capability imports are allowed without updating this plan.
-- Feature code uses `src/storage` or `src/realtime`, never
-  `VITE_HANGVIDU_API_URL` directly.
+Production uses the existing automatically provisioned Workers endpoint:
 
-## 5. Stable public API and composable file storage
-
-`VITE_HANGVIDU_API_URL` is the stable browser entry point for the consolidated
-HangVidU-owned API, for example `https://api.hangvidu.com`. It is expected to
-change only when selecting an environment or moving the public API domain:
-
-```text
-local       https://localhost:8788
-staging     https://api-staging.hangvidu.com
-production  https://api.hangvidu.com
+```env
+VITE_HANGVIDU_API_URL=https://hangvidu-data.kristinnroach.workers.dev
 ```
 
-It is used by the adapters for:
+Local development uses:
 
-- conversations, messages, calls, and file authorization/coordination over HTTP;
-- live conversation push, mailbox, and signaling over WebSockets;
-- initiating file upload/download, even when the API later returns a short-lived
-  direct provider URL.
+```env
+VITE_HANGVIDU_API_URL=https://localhost:8788
+```
 
-Firebase Auth, RTDB contacts/user profiles, and storage-provider credentials do
-not use or live in this variable. Changing R2 to S3 or user-connected storage does
-not change it. `VITE_*` values are public build-time configuration and cannot hold
-provider credentials or express a per-user provider choice.
+There are only two modes in this plan:
 
-The files HTTP handlers depend on a narrow server-side `FileObjectStore`, never
-directly on `env.FILES_BUCKET`. The initial provider resolver always returns
-`R2FileObjectStore`; future policy may resolve by user, conversation, or file
-without changing the client API. Provider credentials remain server-side. This
-pass keeps the existing `r2_key`/`bucket` persistence unchanged behind the adapter.
-Generalizing those fields is intentionally deferred until the consolidated Worker
-is stable; see `BACKEND_CONSOLIDATION_POST.md`.
+- top-level Wrangler configuration = production;
+- local `wrangler dev` bindings/state = development.
 
-## 6. Shared auth, CORS, and compatibility
+Do not add named Wrangler environments or staging resources. The consolidated
+Wrangler config explicitly contains the production D1, R2, DO, vars, and migration
+history. Local development uses the same binding names with local resources.
 
-- The canonical `auth.ts` is the tested superset: files' JWKS timeout/error
-  logging plus data's WebSocket token extraction. Port auth parity tests before
-  deleting the old implementations.
-- `config/origins.json` remains the source of truth and is bundled into `cors.ts`.
-  Wrangler sets an environment selector: production uses only `production`;
-  local/dev uses `production + development`. Production does not accept localhost.
-- REST, files, and WebSocket tests cover allowed, missing, and rejected origins,
-  including their existing response/header behavior.
-- Use compatibility date `2026-06-02`. Advancing data/signaling from `2025-05-01`
-  is treated as behavior-affecting and all three route families are tested against it.
+The shared client URL helper trims trailing slashes, converts `http → ws` and
+`https → wss`, and constructs data/files/realtime paths. All existing consumers
+of `VITE_DATA_URL`, `VITE_FILES_URL`, and `VITE_SIGNALING_URL` move to that helper.
+Completion requires this command to return no client matches:
 
-## 7. Durable Object migration
+```sh
+rg 'VITE_(DATA|FILES|SIGNALING)_URL' src
+```
 
-The destination is the existing `hangvidu-data` script:
+Changing the public endpoint later is straightforward: configure a Worker custom
+domain/route, update CORS, change `VITE_HANGVIDU_API_URL`, and deploy the client.
+That optional task is tracked in `BACKEND_CONSOLIDATION_POST.md`.
+
+## 7. Shared auth, CORS, and compatibility date
+
+- Canonical auth is the tested superset: files' JWKS timeout/error logging plus
+  data's WebSocket token extraction.
+- `config/origins.json` remains the source of truth. Production permits only its
+  production origins; local development additionally permits development origins.
+- Preserve core tests: valid/invalid authentication, member/non-member access,
+  allowed/rejected origin, and WebSocket authentication.
+- Use compatibility date `2026-06-02`. Run all existing Worker tests plus the core
+  smoke tests; do not add a separate exhaustive compatibility matrix.
+
+## 8. Durable Object strategy
+
+The destination remains the existing `hangvidu-data` script:
 
 - `ConversationChannel` stays in its existing namespace.
-- `UserMailbox` stays in its existing namespace and retains pending-invite storage.
-- Only `SignalingRoom` transfers from `hangvidu-signaling`.
+- `UserMailbox` stays in its existing namespace and retains pending invites.
+- `SignalingRoom` is created as a fresh namespace in `hangvidu-data`; the old
+  namespace is not transferred.
 
-Keep the existing `hangvidu-data` migration history and append:
+Keep v1/v2 and append:
 
 ```jsonc
 "migrations": [
   { "tag": "v1", "new_sqlite_classes": ["ConversationChannel"] },
   { "tag": "v2", "new_sqlite_classes": ["UserMailbox"] },
-  {
-    "tag": "v3",
-    "transferred_classes": [
-      {
-        "from": "SignalingRoom",
-        "from_script": "hangvidu-signaling",
-        "to": "SignalingRoom"
-      }
-    ]
-  }
+  { "tag": "v3", "new_sqlite_classes": ["SignalingRoom"] }
 ]
 ```
 
-Do not add `SignalingRoom` to `new_sqlite_classes`; the transfer creates the
-destination namespace. Rehearse the cross-script transfer with disposable Worker
-names before production. See Cloudflare's
-[Durable Object migration reference](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/).
+This avoids transfer rehearsal and namespace-forwarding complexity. It still is
+an atomic DO migration and creates a rollback boundary: after v3 deploys, backend
+recovery is forward-fix rather than rollback to pre-v3.
 
-The migration is the rollback boundary: after production transfer, the backend
-cannot roll back to a pre-v3 Worker version. Recovery is forward-fix only.
+During the seven-day transition, old clients signal through
+`hangvidu-signaling`; updated clients use the fresh namespace in `hangvidu-data`.
+Old/new client versions cannot signal each other, and forced updates may drop an
+active call. This is accepted for the current small friends-and-family user base.
 
-## 8. Implementation sequence
+## 9. Implementation sequence
 
-1. Scaffold `backend/cloudflare/` with deployed name `hangvidu-data`, existing D1
-   migrations/bindings, the R2 binding, all three DO bindings, compatibility date
-   `2026-06-02`, and the unchanged v1/v2 migration history.
-2. Move data handlers/repo and the two in-place data DO classes. Port tests and
-   verify pending mailbox invites survive a normal `hangvidu-data` deployment.
-3. Move signaling code and add the v3 `SignalingRoom` transfer. Rehearse the
-   transfer, source-binding forwarding, and WebSocket reconnect behavior.
-4. Move files code behind `FileObjectStore`; implement only `R2FileObjectStore`.
-   Preserve the authorization wrapper and replace only its inner D1 membership
-   query with the shared predicate. Keep attachment persistence unchanged.
-5. Unify auth and environment-split CORS behind parity tests. Route-family
-   dispatch remains outside global auth/CORS behavior.
-6. Add a tested HangVidU API URL helper: trim trailing slashes, convert
-   `http → ws` / `https → wss`, and construct data/files/realtime paths.
-   Repoint existing storage/realtime clients to `VITE_HANGVIDU_API_URL`; remove
-   per-worker URL variables after the cutover.
-7. Extend backend boundary linting, add route-family log fields, and collapse
-   root dev/deploy/test scripts to `dev:cf`, `deploy:cf`, and `test:cf`.
-8. Execute the cutover runbook in §10; retire old source directories only after
-   production verification.
+1. Create `backend/cloudflare/` with production D1/R2 bindings, existing DO
+   bindings/migrations v1/v2, fresh `SignalingRoom` v3, and compatibility date
+   `2026-06-02`.
+2. Move data handlers/repo and the two existing data DO classes; keep their
+   behavior and migration history.
+3. Move signaling routes/class and use the fresh namespace—no transfer config or
+   disposable rehearsal infrastructure.
+4. Move files handlers, `FileObjectStore`, and `R2FileObjectStore`; preserve the
+   authorization wrapper and attachment persistence.
+5. Unify auth/CORS and preserve the core tests in §7.
+6. Add the shared URL helper, repoint every old client URL consumer, and remove
+   the old URL variables.
+7. Collapse root scripts to `dev:cf`, `deploy:cf`, and `test:cf`; update CI/path
+   references required by moved files.
+8. Run verification and execute the production cutover in §11.
 
-## 9. Verification gates
+## 10. Verification gates
 
-- `pnpm ts`, boundary lint, and `test:cf` with all existing Worker suites ported.
-- Auth and CORS parity across all route families.
-- Files authorization cache behavior and D1-failure 502 behavior.
-- File handlers tested against a fake `FileObjectStore` and R2 adapter contract tests.
+- `pnpm ts` and `test:cf`; port all existing Worker tests into the consolidated suite.
 - Wrangler config validation/dry run.
-- Disposable cross-script `SignalingRoom` transfer rehearsal: destination works,
-  source binding forwards, and clients reconnect after active sockets reset.
-- Normal `hangvidu-data` deployment preserves pending `UserMailbox` invites.
-- Local smoke: health, resolve-direct dedup, member/non-member reads, image
-  upload/download/delete, live message WS, mailbox WS, and signaling WS.
-- Browser smoke: send/receive text and image, place/receive/cancel a call.
+- Core auth, membership, CORS, and WebSocket tests.
+- Existing file upload/download/delete and cache/502 tests through
+  `R2FileObjectStore`.
+- Local smoke: health, resolve-direct, member/non-member reads, image operations,
+  live push, mailbox, and signaling.
+- Production smoke: send/receive text and image, place/receive/cancel a call.
+- No old Worker URL variable reads remain under `src/`.
 
-## 10. Production cutover and retirement
+## 11. Production cutover
 
-1. Confirm production bindings, routes, bucket/database IDs, compatibility date,
-   v1/v2 history, and the exact source script name `hangvidu-signaling`.
-2. Deploy consolidated `hangvidu-data`. This performs the v3 transfer. From this
-   point backend recovery is forward-fix only.
-3. Verify every route family, structured logs, pending-invite persistence, and
-   that the still-deployed `hangvidu-signaling` binding forwards correctly.
-4. Deploy the client with `VITE_HANGVIDU_API_URL` pointing to `hangvidu-data` and
-   force the immediate service-worker update.
-5. Keep `hangvidu-files` live for old clients and keep `hangvidu-signaling` live
-   for source-binding forwarding during a short verification window. This is not
-   a long-term compatibility commitment.
-6. Retire the old services only after the forced-update cycle succeeds, smoke
-   checks pass, and route-family logs show no material legacy endpoint traffic.
-   `hangvidu-files` requires explicit retention because ordinary Worker requests
-   do not auto-forward after consolidation.
-7. Update architecture/operations documentation to the as-built layout.
+The project owner performs the deployment.
 
-## 11. Accepted tradeoff
+Before deploy, abort if any check fails:
 
-One Worker has a larger blast radius and merges deploy cadence and observability.
-At the current scale, simpler configuration and removal of version skew outweigh
-that cost. Route-family logs, boundary linting, and per-capability smoke checks
-are required controls. Files remains the first candidate to split out later if
-upload load or its security profile warrants a separate deploy boundary.
+- Wrangler config/dry run and all tests are green.
+- Production D1/R2 IDs, DO bindings, v1/v2 history, and v3 fresh-class migration
+  match this plan.
+- `hangvidu-files` and `hangvidu-signaling` remain deployed.
+- Production CORS origins and `VITE_HANGVIDU_API_URL` are correct.
+
+Then:
+
+1. Deploy consolidated `hangvidu-data`; after v3, recovery is forward-fix only.
+2. Smoke-test all REST, file, mailbox/live-push, and signaling paths. Forward-fix
+   the Worker before deploying the client if any check fails.
+3. Deploy the client and force the immediate service-worker update.
+4. Keep `hangvidu-files` and `hangvidu-signaling` deployed for exactly seven days.
+5. After seven days, repeat the production smoke test, retire both old Workers,
+   and update architecture/operations documentation. Dormant clients may require
+   a refresh; indefinite compatibility is explicitly out of scope.
+
+## 12. Accepted tradeoff
+
+One Worker increases deployment and security blast radius and removes independent
+release cadence. Fresh signaling temporarily splits old/new clients. At this
+project's scale, simpler configuration, one public endpoint, and removal of
+auth/CORS/membership drift outweigh those costs.

--- a/BACKEND_CONSOLIDATION_PLAN.md
+++ b/BACKEND_CONSOLIDATION_PLAN.md
@@ -98,19 +98,39 @@ does not read the API environment variable directly.
 
 ## 6. Public API endpoint and environments
 
-Production uses the existing automatically provisioned Workers endpoint:
+Production and the default frontend development workflow use the existing
+automatically provisioned Workers endpoint:
 
 ```env
 VITE_HANGVIDU_API_URL=https://hangvidu-data.kristinnroach.workers.dev
 ```
 
-Local development uses:
+This lets `pnpm dev` run only Vite while exercising the deployed D1, R2, and
+Durable Object backend. It is the normal production-like UX workflow and writes
+to production backend state.
+
+The opt-in local-persistence workflow overrides the URL with:
 
 ```env
 VITE_HANGVIDU_API_URL=https://localhost:8788
 ```
 
-There are only two modes in this plan:
+`pnpm dev:local` starts Vite and the consolidated local Worker together with
+`concurrently`. The Worker uses HTTPS with the existing localhost certificate
+flags and persists local D1, R2, and Durable Object state. `pnpm dev:cf` remains
+available for running only that local Worker when backend-focused debugging
+needs separate process control.
+
+Rename the current tunnel-backed `dev` script unchanged to `dev:mobile`. Mobile
+tunnel performance is outside this migration; the workflow remains available
+without being part of normal desktop development.
+
+Environment selection must be explicit and deterministic: normal `pnpm dev`
+targets the deployed endpoint, while only `pnpm dev:local` overrides it with the
+localhost endpoint. Remove the current `.env.development.local` URL overrides
+so they cannot silently redirect the default workflow.
+
+Wrangler itself still has only two resource modes in this plan:
 
 - top-level Wrangler configuration = production;
 - local `wrangler dev` bindings/state = development.
@@ -185,8 +205,10 @@ active call. This is accepted for the current small friends-and-family user base
 5. Unify auth/CORS and preserve the core tests in §7.
 6. Add the shared URL helper, repoint every old client URL consumer, and remove
    the old URL variables.
-7. Collapse root scripts to `dev:cf`, `deploy:cf`, and `test:cf`; update CI/path
-   references required by moved files.
+7. Collapse Worker scripts to `dev:cf`, `deploy:cf`, and `test:cf`; make `dev`
+   Vite-only against the deployed Worker, make `dev:local` run Vite plus
+   `dev:cf`, and rename the existing tunnel-backed `dev` script unchanged to
+   `dev:mobile`. Update CI/path references required by moved files.
 8. Run verification and execute the production cutover in §11.
 
 ## 10. Verification gates

--- a/BACKEND_CONSOLIDATION_PLAN.md
+++ b/BACKEND_CONSOLIDATION_PLAN.md
@@ -1,0 +1,242 @@
+# Backend Consolidation Plan — three Workers → one
+
+**Status:** approved · **Branch:** `refactor/storage-boundaries`
+
+Collapse the three Cloudflare Workers into the existing `hangvidu-data` Worker.
+The source moves to `backend/cloudflare/`; the deployed script name remains
+`hangvidu-data`.
+
+**Progress tracker:** [`BACKEND_CONSOLIDATION_CHECKLIST.md`](./BACKEND_CONSOLIDATION_CHECKLIST.md)
+
+**Post-migration tracker:** [`BACKEND_CONSOLIDATION_POST.md`](./BACKEND_CONSOLIDATION_POST.md)
+— source of truth for work deliberately deferred from this cutover.
+
+---
+
+## 1. Goal
+
+- Replace the separately deployed `data`, `files`, and `signaling` Workers with
+  one `hangvidu-data` Worker organized as `data/`, `files/`, and `realtime/`.
+- Keep one membership predicate, auth implementation, CORS policy, Wrangler
+  config, deployment, and local Worker process.
+- Preserve the existing client ports in `src/storage` and `src/realtime`; feature
+  code must use those ports and must not read the global API URL directly.
+- Use one stable `VITE_HANGVIDU_API_URL` for the public HangVidU API entry point.
+  It identifies HangVidU's API, not a selected backend provider.
+- Put file bytes behind a server-side `FileObjectStore` port with the existing R2
+  implementation as its first adapter, so storage is selected behind the API.
+
+Consolidation is justified by the combined auth/CORS/config/deploy duplication
+and the tight data/realtime coupling. The duplicated membership predicate alone
+could instead be removed through a shared package.
+
+## 2. Non-goals
+
+- No Firebase Functions move. `functions/` remains at the repository root; moving
+  it is a separate future change.
+- No file-storage provider beyond R2, provider-selection UI, connected-storage
+  credential flow, general capability registry, or feature rewrite.
+- No D1 schema or attachment metadata migration. Provider-neutral persistence is
+  a separate post-consolidation PR tracked in `BACKEND_CONSOLIDATION_POST.md`.
+- No RTDB cleanup or changes to deferred contacts/user-profile paths.
+- No indefinite compatibility shim for old clients. The project uses
+  force-immediate service-worker updates and has a small user base.
+
+## 3. Current system
+
+| Path                                       | Responsibility                                          | Consolidated destination     |
+| ------------------------------------------ | ------------------------------------------------------- | ---------------------------- |
+| `workers/data/src/index.ts`                | D1 HTTP routes, call routes, live-push/mailbox WS       | `src/index.ts` + `src/data/` |
+| `workers/data/src/repo.ts`                 | D1 access and authoritative `isMember` predicate        | `src/data/repo.ts`           |
+| `workers/data/src/conversation-channel.ts` | Live message push DO                                    | `src/realtime/`              |
+| `workers/data/src/user-mailbox.ts`         | Call mailbox DO with persisted pending invites          | `src/realtime/`              |
+| `workers/files/src/index.ts`               | R2 upload/download and membership authorization wrapper | `src/files/`                 |
+| `workers/signaling/src/signaling-room.ts`  | WebRTC signaling DO                                     | `src/realtime/`              |
+| `workers/*/src/auth.ts`                    | Three related Firebase RS256 implementations            | `src/auth.ts`                |
+
+Membership is delete-based: a row in `conversation_members` means the user is a
+member. Migrations `0003_drop_member_status.sql` and
+`0004_drop_member_role.sql` removed the unused status and role columns. The data
+and files guards are behaviorally consistent today, but duplicate the predicate.
+
+The files authorization wrapper must remain intact: preserve its 30-second GET
+cache, bounded cache size, App Check token cache key, and explicit 502 response on
+D1 failure. Replace only its inner membership query with the shared predicate.
+
+## 4. Target structure and boundaries
+
+```text
+backend/cloudflare/
+  src/
+    index.ts                 # path-family dispatch only
+    auth.ts                  # canonical Firebase RS256 implementation
+    cors.ts                  # environment-selected shared origin policy
+    data/                    # D1 repo and data/call handlers
+    files/
+      handlers.ts            # provider-neutral HTTP/auth behavior
+      file-object-store.ts   # narrow blob-storage port + provider resolver seam
+      adapters/r2.ts         # only provider implemented in this pass
+    realtime/                # all three Durable Object classes and WS handlers
+  migrations/               # existing D1 migration history, unchanged
+  wrangler.jsonc             # deployed name remains hangvidu-data
+```
+
+The client owns one shared HangVidU API URL helper under `src/infra/`; storage and
+realtime adapters use it for REST/WS URL construction.
+
+`src/index.ts` dispatches by route family before route-specific auth, CORS, method,
+or error handling runs. Route matching is anchored and most-specific-first:
+files/messages subpaths are checked before generic `^/conversations/([^/]+)$`, so
+the generic conversation route cannot shadow them. Unknown paths return 404.
+
+Backend boundary linting enforces:
+
+- `data`, `files`, and `realtime` handlers may use shared root modules.
+- `files` may use the narrow membership predicate from `data/repo.ts`; no other
+  cross-capability imports are allowed without updating this plan.
+- Feature code uses `src/storage` or `src/realtime`, never
+  `VITE_HANGVIDU_API_URL` directly.
+
+## 5. Stable public API and composable file storage
+
+`VITE_HANGVIDU_API_URL` is the stable browser entry point for the consolidated
+HangVidU-owned API, for example `https://api.hangvidu.com`. It is expected to
+change only when selecting an environment or moving the public API domain:
+
+```text
+local       https://localhost:8788
+staging     https://api-staging.hangvidu.com
+production  https://api.hangvidu.com
+```
+
+It is used by the adapters for:
+
+- conversations, messages, calls, and file authorization/coordination over HTTP;
+- live conversation push, mailbox, and signaling over WebSockets;
+- initiating file upload/download, even when the API later returns a short-lived
+  direct provider URL.
+
+Firebase Auth, RTDB contacts/user profiles, and storage-provider credentials do
+not use or live in this variable. Changing R2 to S3 or user-connected storage does
+not change it. `VITE_*` values are public build-time configuration and cannot hold
+provider credentials or express a per-user provider choice.
+
+The files HTTP handlers depend on a narrow server-side `FileObjectStore`, never
+directly on `env.FILES_BUCKET`. The initial provider resolver always returns
+`R2FileObjectStore`; future policy may resolve by user, conversation, or file
+without changing the client API. Provider credentials remain server-side. This
+pass keeps the existing `r2_key`/`bucket` persistence unchanged behind the adapter.
+Generalizing those fields is intentionally deferred until the consolidated Worker
+is stable; see `BACKEND_CONSOLIDATION_POST.md`.
+
+## 6. Shared auth, CORS, and compatibility
+
+- The canonical `auth.ts` is the tested superset: files' JWKS timeout/error
+  logging plus data's WebSocket token extraction. Port auth parity tests before
+  deleting the old implementations.
+- `config/origins.json` remains the source of truth and is bundled into `cors.ts`.
+  Wrangler sets an environment selector: production uses only `production`;
+  local/dev uses `production + development`. Production does not accept localhost.
+- REST, files, and WebSocket tests cover allowed, missing, and rejected origins,
+  including their existing response/header behavior.
+- Use compatibility date `2026-06-02`. Advancing data/signaling from `2025-05-01`
+  is treated as behavior-affecting and all three route families are tested against it.
+
+## 7. Durable Object migration
+
+The destination is the existing `hangvidu-data` script:
+
+- `ConversationChannel` stays in its existing namespace.
+- `UserMailbox` stays in its existing namespace and retains pending-invite storage.
+- Only `SignalingRoom` transfers from `hangvidu-signaling`.
+
+Keep the existing `hangvidu-data` migration history and append:
+
+```jsonc
+"migrations": [
+  { "tag": "v1", "new_sqlite_classes": ["ConversationChannel"] },
+  { "tag": "v2", "new_sqlite_classes": ["UserMailbox"] },
+  {
+    "tag": "v3",
+    "transferred_classes": [
+      {
+        "from": "SignalingRoom",
+        "from_script": "hangvidu-signaling",
+        "to": "SignalingRoom"
+      }
+    ]
+  }
+]
+```
+
+Do not add `SignalingRoom` to `new_sqlite_classes`; the transfer creates the
+destination namespace. Rehearse the cross-script transfer with disposable Worker
+names before production. See Cloudflare's
+[Durable Object migration reference](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/).
+
+The migration is the rollback boundary: after production transfer, the backend
+cannot roll back to a pre-v3 Worker version. Recovery is forward-fix only.
+
+## 8. Implementation sequence
+
+1. Scaffold `backend/cloudflare/` with deployed name `hangvidu-data`, existing D1
+   migrations/bindings, the R2 binding, all three DO bindings, compatibility date
+   `2026-06-02`, and the unchanged v1/v2 migration history.
+2. Move data handlers/repo and the two in-place data DO classes. Port tests and
+   verify pending mailbox invites survive a normal `hangvidu-data` deployment.
+3. Move signaling code and add the v3 `SignalingRoom` transfer. Rehearse the
+   transfer, source-binding forwarding, and WebSocket reconnect behavior.
+4. Move files code behind `FileObjectStore`; implement only `R2FileObjectStore`.
+   Preserve the authorization wrapper and replace only its inner D1 membership
+   query with the shared predicate. Keep attachment persistence unchanged.
+5. Unify auth and environment-split CORS behind parity tests. Route-family
+   dispatch remains outside global auth/CORS behavior.
+6. Add a tested HangVidU API URL helper: trim trailing slashes, convert
+   `http → ws` / `https → wss`, and construct data/files/realtime paths.
+   Repoint existing storage/realtime clients to `VITE_HANGVIDU_API_URL`; remove
+   per-worker URL variables after the cutover.
+7. Extend backend boundary linting, add route-family log fields, and collapse
+   root dev/deploy/test scripts to `dev:cf`, `deploy:cf`, and `test:cf`.
+8. Execute the cutover runbook in §10; retire old source directories only after
+   production verification.
+
+## 9. Verification gates
+
+- `pnpm ts`, boundary lint, and `test:cf` with all existing Worker suites ported.
+- Auth and CORS parity across all route families.
+- Files authorization cache behavior and D1-failure 502 behavior.
+- File handlers tested against a fake `FileObjectStore` and R2 adapter contract tests.
+- Wrangler config validation/dry run.
+- Disposable cross-script `SignalingRoom` transfer rehearsal: destination works,
+  source binding forwards, and clients reconnect after active sockets reset.
+- Normal `hangvidu-data` deployment preserves pending `UserMailbox` invites.
+- Local smoke: health, resolve-direct dedup, member/non-member reads, image
+  upload/download/delete, live message WS, mailbox WS, and signaling WS.
+- Browser smoke: send/receive text and image, place/receive/cancel a call.
+
+## 10. Production cutover and retirement
+
+1. Confirm production bindings, routes, bucket/database IDs, compatibility date,
+   v1/v2 history, and the exact source script name `hangvidu-signaling`.
+2. Deploy consolidated `hangvidu-data`. This performs the v3 transfer. From this
+   point backend recovery is forward-fix only.
+3. Verify every route family, structured logs, pending-invite persistence, and
+   that the still-deployed `hangvidu-signaling` binding forwards correctly.
+4. Deploy the client with `VITE_HANGVIDU_API_URL` pointing to `hangvidu-data` and
+   force the immediate service-worker update.
+5. Keep `hangvidu-files` live for old clients and keep `hangvidu-signaling` live
+   for source-binding forwarding during a short verification window. This is not
+   a long-term compatibility commitment.
+6. Retire the old services only after the forced-update cycle succeeds, smoke
+   checks pass, and route-family logs show no material legacy endpoint traffic.
+   `hangvidu-files` requires explicit retention because ordinary Worker requests
+   do not auto-forward after consolidation.
+7. Update architecture/operations documentation to the as-built layout.
+
+## 11. Accepted tradeoff
+
+One Worker has a larger blast radius and merges deploy cadence and observability.
+At the current scale, simpler configuration and removal of version skew outweigh
+that cost. Route-family logs, boundary linting, and per-capability smoke checks
+are required controls. Files remains the first candidate to split out later if
+upload load or its security profile warrants a separate deploy boundary.

--- a/BACKEND_CONSOLIDATION_POST.md
+++ b/BACKEND_CONSOLIDATION_POST.md
@@ -1,0 +1,44 @@
+# Backend Consolidation — Post-migration Work
+
+**Status:** deferred · **Start after:** consolidated `hangvidu-data` is deployed,
+verified, and stable.
+
+This is the source of truth for work deliberately excluded from
+[`BACKEND_CONSOLIDATION_PLAN.md`](./BACKEND_CONSOLIDATION_PLAN.md). Add future
+post-cutover tasks here instead of widening the consolidation PR.
+
+## 1. Provider-neutral attachment metadata
+
+Implement as its own PR after consolidation. It is not required for the
+`FileObjectStore`/`R2FileObjectStore` seam: that seam lands during consolidation
+and initially encapsulates the existing `r2_key` and `bucket` fields.
+
+Target persistence:
+
+- `storage_provider` — adapter identifier, initially `r2`;
+- `storage_locator` — opaque provider-specific locator interpreted by the adapter.
+
+Do not add `storage_connection_id` until connected user storage is designed and
+there is a concrete ownership/lifecycle model for connections.
+
+Checklist:
+
+- [ ] Design the forward D1 migration from `r2_key`/`bucket`
+- [ ] Preserve every existing row as provider `r2` with its current key as locator
+- [ ] Keep the browser-facing file/message contract stable
+- [ ] Keep the R2 bucket in deployment configuration, not attachment domain data
+- [ ] Update repository types/queries and `R2FileObjectStore` mapping
+- [ ] Test migration on a production-shaped D1 copy
+- [ ] Verify upload, download, delete, and existing attachment rendering
+- [ ] Deploy and verify independently from any Durable Object migration
+
+This migration must complete before adding a second storage provider.
+
+## 2. Firebase source relocation
+
+Move `functions/` under `backend/firebase/` only as a separate repository-layout
+change. Update Firebase config, npm scripts, maintenance scripts, secret-file
+paths, ignore rules, CI, and documentation together.
+
+- [ ] Write a focused move plan and inventory all `functions/` path references
+- [ ] Move and verify Firebase Functions in its own PR

--- a/BACKEND_CONSOLIDATION_POST.md
+++ b/BACKEND_CONSOLIDATION_POST.md
@@ -5,40 +5,60 @@ verified, and stable.
 
 This is the source of truth for work deliberately excluded from
 [`BACKEND_CONSOLIDATION_PLAN.md`](./BACKEND_CONSOLIDATION_PLAN.md). Add future
-post-cutover tasks here instead of widening the consolidation PR.
+post-cutover tasks here instead of widening the consolidation implementation.
 
-## 1. Provider-neutral attachment metadata
+## Required before adding a second file-storage provider
 
-Implement as its own PR after consolidation. It is not required for the
-`FileObjectStore`/`R2FileObjectStore` seam: that seam lands during consolidation
-and initially encapsulates the existing `r2_key` and `bucket` fields.
+### Provider-neutral attachment metadata
+
+The existing `FileObjectStore`/`R2FileObjectStore` seam encapsulates object
+operations while persistence retains `r2_key` and `bucket`. Implement the metadata
+migration as its own PR after consolidation.
 
 Target persistence:
 
 - `storage_provider` — adapter identifier, initially `r2`;
 - `storage_locator` — opaque provider-specific locator interpreted by the adapter.
 
-Do not add `storage_connection_id` until connected user storage is designed and
-there is a concrete ownership/lifecycle model for connections.
-
-Checklist:
+Do not add `storage_connection_id` until connected user storage has a concrete
+ownership and lifecycle design.
 
 - [ ] Design the forward D1 migration from `r2_key`/`bucket`
-- [ ] Preserve every existing row as provider `r2` with its current key as locator
+- [ ] Preserve existing rows as provider `r2` with their current key as locator
 - [ ] Keep the browser-facing file/message contract stable
-- [ ] Keep the R2 bucket in deployment configuration, not attachment domain data
-- [ ] Update repository types/queries and `R2FileObjectStore` mapping
-- [ ] Test migration on a production-shaped D1 copy
-- [ ] Verify upload, download, delete, and existing attachment rendering
-- [ ] Deploy and verify independently from any Durable Object migration
+- [ ] Keep the R2 bucket in deployment configuration
+- [ ] Update repository types/queries and R2 adapter mapping
+- [ ] Test on a production-shaped D1 copy
+- [ ] Verify existing attachment rendering and all file operations
+- [ ] Deploy independently from any Durable Object migration
 
-This migration must complete before adding a second storage provider.
+## OPTIONAL — undecided or nonessential
 
-## 2. Firebase source relocation
+These are not commitments. Promote an item into a dedicated plan only when its
+value justifies the added operational or maintenance cost.
 
-Move `functions/` under `backend/firebase/` only as a separate repository-layout
-change. Update Firebase config, npm scripts, maintenance scripts, secret-file
-paths, ignore rules, CI, and documentation together.
+### Custom API domain
+
+Move from the current Workers endpoint to a stable first-party domain such as
+`https://api.hangvidu.com`. This is a straightforward later change:
+
+- [ ] Configure the Worker custom domain/route and DNS
+- [ ] Add the domain to production CORS origins
+- [ ] Change `VITE_HANGVIDU_API_URL` and deploy the client
+- [ ] Keep the workers.dev endpoint temporarily if a transition window is useful
+
+### Named staging environment
+
+- [ ] Define separate Worker name, D1/R2/DO resources, bindings, migrations, vars,
+  secrets, and deploy commands before introducing a Wrangler named environment
+
+### Expanded observability and architecture enforcement
+
+- [ ] Add structured route-family logging if production diagnosis needs it
+- [ ] Extend boundary linting to `backend/cloudflare` if folder conventions drift
+- [ ] Add an exhaustive auth/CORS header parity matrix if core tests prove insufficient
+
+### Firebase source relocation
 
 - [ ] Write a focused move plan and inventory all `functions/` path references
-- [ ] Move and verify Firebase Functions in its own PR
+- [ ] Move `functions/` under `backend/firebase/` in its own PR

--- a/workers/files/src/file-object-store.ts
+++ b/workers/files/src/file-object-store.ts
@@ -1,0 +1,24 @@
+export interface FileObjectWrite {
+  body: ArrayBuffer;
+  contentType: string;
+  conversationId: string;
+  uploadedBy: string;
+}
+
+export interface FileObjectInfo {
+  uploadedBy?: string;
+}
+
+export interface FileObject extends FileObjectInfo {
+  body: ReadableStream;
+  contentType?: string;
+  etag: string;
+  size: number;
+}
+
+export interface FileObjectStore {
+  put(key: string, file: FileObjectWrite): Promise<void>;
+  get(key: string): Promise<FileObject | null>;
+  head(key: string): Promise<FileObjectInfo | null>;
+  delete(key: string): Promise<void>;
+}

--- a/workers/files/src/index.ts
+++ b/workers/files/src/index.ts
@@ -1,4 +1,6 @@
 import { authenticate, type Identity } from './auth';
+import type { FileObjectStore } from './file-object-store';
+import { R2FileObjectStore } from './r2-file-object-store';
 
 export interface Env {
   FILES_BUCKET: R2Bucket;
@@ -234,6 +236,7 @@ async function readCappedBody(request: Request): Promise<ArrayBuffer | null> {
 async function handleUpload(
   request: Request,
   env: Env,
+  store: FileObjectStore,
   conversationId: string,
   identity: Identity,
 ) {
@@ -261,12 +264,11 @@ async function handleUpload(
   }
 
   const key = objectKey(conversationId, crypto.randomUUID());
-  await env.FILES_BUCKET.put(key, body, {
-    httpMetadata: { contentType: mimeType },
-    customMetadata: {
-      conversationId,
-      uploadedBy: identity.userId,
-    },
+  await store.put(key, {
+    body,
+    contentType: mimeType,
+    conversationId,
+    uploadedBy: identity.userId,
   });
 
   return json(
@@ -281,14 +283,19 @@ async function handleUpload(
   );
 }
 
-async function handleDownload(request: Request, env: Env, key: string) {
-  const object = await env.FILES_BUCKET.get(key);
+async function handleDownload(
+  request: Request,
+  env: Env,
+  store: FileObjectStore,
+  key: string,
+) {
+  const object = await store.get(key);
   if (!object) return response(request, env, 'Not found', { status: 404 });
 
   const headers = new Headers();
   headers.set(
     'Content-Type',
-    object.httpMetadata?.contentType ?? 'application/octet-stream',
+    object.contentType ?? 'application/octet-stream',
   );
   headers.set('Content-Length', String(object.size));
   headers.set('ETag', object.etag);
@@ -304,15 +311,16 @@ async function handleDownload(request: Request, env: Env, key: string) {
 async function handleDelete(
   request: Request,
   env: Env,
+  store: FileObjectStore,
   key: string,
   identity: Identity,
 ) {
-  const object = await env.FILES_BUCKET.head(key);
+  const object = await store.head(key);
   if (!object) {
     return response(request, env, 'Not found', { status: 404 });
   }
 
-  const uploadedBy = object.customMetadata?.uploadedBy;
+  const uploadedBy = object.uploadedBy;
   if (!uploadedBy) {
     console.warn('[delete] missing uploadedBy metadata', { key });
     return response(request, env, 'Forbidden', { status: 403 });
@@ -321,12 +329,13 @@ async function handleDelete(
     return response(request, env, 'Forbidden', { status: 403 });
   }
 
-  await env.FILES_BUCKET.delete(key);
+  await store.delete(key);
   return response(request, env, null, { status: 204 });
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    const store = new R2FileObjectStore(env.FILES_BUCKET);
     const origin = allowedOrigin(request, env);
     if (request.method === 'OPTIONS') {
       if (!origin) return new Response('Forbidden origin', { status: 403 });
@@ -372,7 +381,7 @@ export default {
       if (request.method !== 'POST') {
         return response(request, env, 'Method not allowed', { status: 405 });
       }
-      return handleUpload(request, env, conversationId, identity);
+      return handleUpload(request, env, store, conversationId, identity);
     }
 
     const key = storageKeyFromUrl(url, conversationId);
@@ -381,10 +390,10 @@ export default {
     }
 
     if (request.method === 'GET') {
-      return handleDownload(request, env, key);
+      return handleDownload(request, env, store, key);
     }
     if (request.method === 'DELETE') {
-      return handleDelete(request, env, key, identity);
+      return handleDelete(request, env, store, key, identity);
     }
     return response(request, env, 'Method not allowed', { status: 405 });
   },

--- a/workers/files/src/r2-file-object-store.ts
+++ b/workers/files/src/r2-file-object-store.ts
@@ -1,0 +1,43 @@
+import type {
+  FileObject,
+  FileObjectInfo,
+  FileObjectStore,
+  FileObjectWrite,
+} from './file-object-store';
+
+export class R2FileObjectStore implements FileObjectStore {
+  constructor(private readonly bucket: R2Bucket) {}
+
+  async put(key: string, file: FileObjectWrite): Promise<void> {
+    await this.bucket.put(key, file.body, {
+      httpMetadata: { contentType: file.contentType },
+      customMetadata: {
+        conversationId: file.conversationId,
+        uploadedBy: file.uploadedBy,
+      },
+    });
+  }
+
+  async get(key: string): Promise<FileObject | null> {
+    const object = await this.bucket.get(key);
+    if (!object) return null;
+
+    return {
+      body: object.body,
+      contentType: object.httpMetadata?.contentType,
+      etag: object.etag,
+      size: object.size,
+      uploadedBy: object.customMetadata?.uploadedBy,
+    };
+  }
+
+  async head(key: string): Promise<FileObjectInfo | null> {
+    const object = await this.bucket.head(key);
+    if (!object) return null;
+    return { uploadedBy: object.customMetadata?.uploadedBy };
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.bucket.delete(key);
+  }
+}


### PR DESCRIPTION
## Summary

- document the minimal three-Worker consolidation plan, checklist, cutover tradeoffs, and deferred work
- add a narrow FileObjectStore port with the existing R2 implementation behind R2FileObjectStore
- preserve the current files API, R2 metadata, authorization behavior, and deployment topology
- choose a fresh signaling namespace and a seven-day old-client transition for the later consolidation implementation

This PR does not perform the Worker consolidation or production migration.

## Verification

- pnpm -C workers/files run typecheck
- pnpm -C workers/files run test: 13 tests passed
- CodeRabbit review: 0 issues
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a backend consolidation checklist to track implementation phases and verification gates.
  * Added a consolidation plan describing consolidated worker responsibilities, routing, and production cutover/rollback timing.
  * Added a post-migration guide for deferred work, including attachment/file migration considerations.
* **Refactor**
  * Updated file image upload/download/delete to use a typed file storage abstraction backed by R2, preserving existing download headers and upload/download/delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->