### PR TITLE
Fix dropped call accepts after deployment

### DIFF
--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -176,6 +176,16 @@ export async function handleDataRequest(
       return json({ ok: true }, 200, cors);
     }
 
+    if (request.method === 'POST' && url.pathname === '/calls/response/ack') {
+      const conversationId = str((await readJson(request))?.conversationId);
+      if (!conversationId) return json({ error: 'conversationId required' }, 400, cors);
+      if (!(await isMember(env.DB, conversationId, callerId))) {
+        return json({ error: 'not_found' }, 404, cors);
+      }
+      await env.USER_MAILBOX.getByName(callerId).clearPendingResponse(conversationId);
+      return json({ ok: true }, 200, cors);
+    }
+
     if (request.method === 'POST' && url.pathname === '/calls/cancel') {
       const body = await readJson(request);
       const conversationId = str(body?.conversationId);

--- a/backend/cloudflare/src/index.ts
+++ b/backend/cloudflare/src/index.ts
@@ -12,7 +12,7 @@ const SIGNALING_PATH = /^\/rooms\/[^/]+\/signal$/;
 const DATA_PATHS = [
   /^\/health$/,
   /^\/me$/,
-  /^\/calls\/(?:invite|response|cancel)$/,
+  /^\/calls\/(?:invite|response(?:\/ack)?|cancel)$/,
   /^\/users\/me\/mailbox\/ws$/,
   /^\/conversations$/,
   /^\/conversations\/resolve-direct$/,

--- a/backend/cloudflare/src/realtime/user-mailbox.ts
+++ b/backend/cloudflare/src/realtime/user-mailbox.ts
@@ -2,6 +2,7 @@ import { DurableObject } from 'cloudflare:workers';
 import type {
   MailboxEnvelope,
   MailboxInvite,
+  MailboxResponse,
 } from '../../../../shared/call-mailbox/protocol';
 
 // One stored key per pending invite, keyed by roomId (= conversationId). Using a
@@ -10,6 +11,8 @@ import type {
 // and makes a re-invite to the same room a natural overwrite.
 const PENDING_INVITE_PREFIX = 'invite:';
 const inviteKey = (roomId: string): string => PENDING_INVITE_PREFIX + roomId;
+const PENDING_RESPONSE_PREFIX = 'response:';
+const responseKey = (roomId: string): string => PENDING_RESPONSE_PREFIX + roomId;
 
 /**
  * One instance per userId (keyed via getByName). Broadcast-only fan-out across
@@ -21,7 +24,7 @@ const inviteKey = (roomId: string): string => PENDING_INVITE_PREFIX + roomId;
  * opening, refreshing, or reconnecting the app while a caller is still ringing
  * resurfaces every incoming-call dialog. This is not a queue/history model: a new
  * invite for a room replaces that room's pending invite, and cancel/response
- * clear the matching one. Responses are not retained (transient live delivery).
+ * clear the matching one. Accepted responses are retained until acknowledged.
  *
  * ## RPC contract (worker → DO)
  * The worker calls `deliver(envelope)` after authorizing the sender. The DO fans
@@ -46,6 +49,9 @@ export class UserMailbox extends DurableObject<Env> {
         } satisfies MailboxEnvelope),
       );
     }
+    for (const response of await this.getFreshPendingResponses()) {
+      server.send(JSON.stringify({ t: 'response', response } satisfies MailboxEnvelope));
+    }
 
     // Echo the auth subprotocol; browsers abort the handshake if the server
     // does not confirm one of the offered subprotocols.
@@ -69,6 +75,8 @@ export class UserMailbox extends DurableObject<Env> {
   async deliver(envelope: MailboxEnvelope): Promise<void> {
     if (envelope.t === 'invite') {
       await this.storePendingInvite(envelope.invite);
+    } else if (envelope.t === 'response' && envelope.response.responseType === 'accepted') {
+      await this.ctx.storage.put(responseKey(envelope.response.roomId), envelope.response);
     } else if (envelope.t === 'cancel' || envelope.t === 'handled') {
       await this.clearPendingInvite(envelope.roomId);
     }
@@ -85,6 +93,10 @@ export class UserMailbox extends DurableObject<Env> {
 
   async clearPendingInvite(roomId: string): Promise<void> {
     await this.ctx.storage.delete(inviteKey(roomId));
+  }
+
+  async clearPendingResponse(roomId: string): Promise<void> {
+    await this.ctx.storage.delete(responseKey(roomId));
   }
 
   private async storePendingInvite(invite: MailboxInvite): Promise<void> {
@@ -110,6 +122,21 @@ export class UserMailbox extends DurableObject<Env> {
       } else {
         fresh.push(invite);
       }
+    }
+    if (expiredKeys.length) await this.ctx.storage.delete(expiredKeys);
+    return fresh;
+  }
+
+  private async getFreshPendingResponses(): Promise<MailboxResponse[]> {
+    const stored = await this.ctx.storage.list<MailboxResponse>({
+      prefix: PENDING_RESPONSE_PREFIX,
+    });
+    const now = Date.now();
+    const fresh: MailboxResponse[] = [];
+    const expiredKeys: string[] = [];
+    for (const [key, response] of stored) {
+      if (response.expiresAt != null && response.expiresAt <= now) expiredKeys.push(key);
+      else fresh.push(response);
     }
     if (expiredKeys.length) await this.ctx.storage.delete(expiredKeys);
     return fresh;

--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -434,3 +434,47 @@ describe('call invite retention', () => {
     }
   });
 });
+
+describe('call response retention', () => {
+  it('replays an accepted response until the caller acknowledges it', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(env.DB, callerId, calleeId, 1000);
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    expect((await jsonPost('/calls/response', calleeToken, {
+      conversationId: convoId,
+      callerId,
+      responseType: 'accepted',
+      expiresAt: Date.now() + 30_000,
+    })).status).toBe(200);
+
+    const mailbox = await connectMailbox(callerToken);
+    try {
+      expect(await mailbox.next()).toEqual({
+        t: 'response',
+        response: {
+          roomId: convoId,
+          responseType: 'accepted',
+          by: calleeId,
+          respondedAt: expect.any(Number),
+          expiresAt: expect.any(Number),
+        },
+      });
+    } finally {
+      mailbox.close();
+    }
+
+    expect((await jsonPost('/calls/response/ack', callerToken, {
+      conversationId: convoId,
+    })).status).toBe(200);
+
+    const reconnected = await connectMailbox(callerToken);
+    try {
+      expect(await nextOrNoMessage(reconnected)).toBe(NO_MESSAGE);
+    } finally {
+      reconnected.close();
+    }
+  });
+});

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   incomingCallback: undefined,
+  responseCallback: undefined,
   initCallService: vi.fn(),
   getCallService: vi.fn(),
   cleanupCallService: vi.fn(),
@@ -10,6 +11,12 @@ const mocks = vi.hoisted(() => ({
     return vi.fn();
   }),
   respondToIncomingCallInvite: vi.fn(),
+  sendOutgoingCallInvite: vi.fn(),
+  onCalleeResponse: vi.fn((_calleeId, callback) => {
+    mocks.responseCallback = callback;
+    return vi.fn();
+  }),
+  ackCallResponse: vi.fn(),
   getLoggedInUserId: vi.fn(() => 'callee-id'),
   getLoggedInUserToken: vi.fn(async () => 'token'),
   getUser: vi.fn(() => ({ userName: 'Callee' })),
@@ -62,13 +69,20 @@ describe('CallHandshakeController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.incomingCallback = undefined;
+    mocks.responseCallback = undefined;
     const service = {
       onIncomingCall: mocks.onIncomingCall,
       respondToIncomingCallInvite: mocks.respondToIncomingCallInvite,
+      sendOutgoingCallInvite: mocks.sendOutgoingCallInvite,
+      onCalleeResponse: mocks.onCalleeResponse,
+      ackCallResponse: mocks.ackCallResponse,
     };
     mocks.initCallService.mockReturnValue(service);
     mocks.getCallService.mockReturnValue(service);
     mocks.respondToIncomingCallInvite.mockResolvedValue(undefined);
+    mocks.sendOutgoingCallInvite.mockResolvedValue(undefined);
+    mocks.ackCallResponse.mockResolvedValue(undefined);
+    mocks.resolveDirectConversationId.mockResolvedValue('room-1');
   });
 
   it("dismisses a matching incoming call when another device handles it", () => {
@@ -184,5 +198,42 @@ describe('CallHandshakeController', () => {
 
     expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
     expect(p2p.close).toHaveBeenCalled();
+  });
+
+  it('listens for a response before sending the invite', async () => {
+    const send = deferred();
+    mocks.sendOutgoingCallInvite.mockReturnValue(send.promise);
+    const p2p = {
+      join: vi.fn(async () => ({ roomId: 'room-1', members: ['caller-id'] })),
+      close: vi.fn(),
+      state: vi.fn(() => 'idle'),
+      room: vi.fn(),
+    };
+    const controller = new CallHandshakeController({
+      p2p,
+      createSignaling: vi.fn(),
+      onStateChange: vi.fn(),
+      onCalleeBusy: vi.fn(),
+    });
+
+    const start = controller.sendOutgoingCallInvite({
+      calleeId: 'callee-id',
+      calleeName: 'Callee',
+      audioOnly: false,
+    });
+    await flushPromises();
+    expect(mocks.responseCallback).toBeTypeOf('function');
+
+    await mocks.responseCallback?.({
+      roomId: 'room-1',
+      responseType: 'accepted',
+      by: 'callee-id',
+      respondedAt: Date.now(),
+    });
+    expect(p2p.join).toHaveBeenCalled();
+    expect(mocks.ackCallResponse).toHaveBeenCalledWith('room-1');
+
+    send.resolve();
+    await start;
   });
 });

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -202,9 +202,10 @@ describe('CallHandshakeController', () => {
 
   it('listens for a response before sending the invite', async () => {
     const send = deferred();
+    const join = deferred();
     mocks.sendOutgoingCallInvite.mockReturnValue(send.promise);
     const p2p = {
-      join: vi.fn(async () => ({ roomId: 'room-1', members: ['caller-id'] })),
+      join: vi.fn(() => join.promise),
       close: vi.fn(),
       state: vi.fn(() => 'idle'),
       room: vi.fn(),
@@ -224,16 +225,21 @@ describe('CallHandshakeController', () => {
     await flushPromises();
     expect(mocks.responseCallback).toBeTypeOf('function');
 
-    await mocks.responseCallback?.({
+    const response = mocks.responseCallback?.({
       roomId: 'room-1',
       responseType: 'accepted',
       by: 'callee-id',
       respondedAt: Date.now(),
     });
+    await flushPromises();
     expect(p2p.join).toHaveBeenCalled();
-    expect(mocks.ackCallResponse).toHaveBeenCalledWith('room-1');
 
     send.resolve();
     await start;
+    expect(mocks.sendIncomingCallPushNotification).not.toHaveBeenCalled();
+
+    join.resolve({ roomId: 'room-1', members: ['caller-id'] });
+    await response;
+    expect(mocks.ackCallResponse).toHaveBeenCalledWith('room-1');
   });
 });

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -226,8 +226,14 @@ export class CallHandshakeController {
       return;
     }
 
-    sendIncomingCallPushNotification(nextOutgoingCall);
-
+    const state = this._handshakeState;
+    if (
+      state &&
+      state.direction === 'outgoing' &&
+      state.call.roomId === roomId
+    ) {
+      sendIncomingCallPushNotification(nextOutgoingCall);
+    }
     if (import.meta.env.DEV) {
       console.debug('Initiated outgoing call invite, command details:', {
         details,

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -178,11 +178,13 @@ export class CallHandshakeController {
     this.setCalleeBusy(false);
     this.scheduleOutgoingCallTimeout(svc, nextOutgoingCall);
 
+    let responseReceived = false;
     this.unsubCalleeResponse?.();
     this.unsubCalleeResponse = svc.onCalleeResponse(
       calleeId,
       async (response) => {
         if (!response || response.roomId !== roomId) return;
+        responseReceived = true;
         this.clearOutgoingCallTracking();
         try {
           if (response.responseType === 'accepted') {
@@ -229,6 +231,7 @@ export class CallHandshakeController {
     const state = this._handshakeState;
     if (
       state &&
+      !responseReceived &&
       state.direction === 'outgoing' &&
       state.call.roomId === roomId
     ) {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -174,23 +174,9 @@ export class CallHandshakeController {
       audioOnly,
     };
 
-    try {
-      await svc.sendOutgoingCallInvite({
-        roomId,
-        calleeId,
-        callerName,
-        audioOnly,
-      });
-    } catch (err) {
-      console.error('Error sending outgoing call invite:', err);
-      this.alertCallStartFailed();
-      return;
-    }
-
     this.setHandshakeState({ direction: 'outgoing', call: nextOutgoingCall });
     this.setCalleeBusy(false);
     this.scheduleOutgoingCallTimeout(svc, nextOutgoingCall);
-    sendIncomingCallPushNotification(nextOutgoingCall);
 
     this.unsubCalleeResponse?.();
     this.unsubCalleeResponse = svc.onCalleeResponse(
@@ -217,10 +203,30 @@ export class CallHandshakeController {
           console.error('Error entering room on callee accept:', err);
           this.exitActiveRoom();
         } finally {
+          svc.ackCallResponse(response.roomId).catch((err) =>
+            console.warn('[CallHandshake] Failed to acknowledge call response:', err),
+          );
           this.setHandshakeState(null);
         }
       },
     );
+
+    try {
+      await svc.sendOutgoingCallInvite({
+        roomId,
+        calleeId,
+        callerName,
+        audioOnly,
+      });
+    } catch (err) {
+      this.clearOutgoingCallTracking();
+      this.setHandshakeState(null);
+      console.error('Error sending outgoing call invite:', err);
+      this.alertCallStartFailed();
+      return;
+    }
+
+    sendIncomingCallPushNotification(nextOutgoingCall);
 
     if (import.meta.env.DEV) {
       console.debug('Initiated outgoing call invite, command details:', {

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -178,6 +178,10 @@ export class CallService {
     });
   }
 
+  ackCallResponse(roomId: string): Promise<void> {
+    return this.post('/calls/response/ack', { conversationId: roomId });
+  }
+
   /** No stored invite to clear in the mailbox model; cancel is explicit. */
   clearIncomingCallInvite(): Promise<void> {
     return Promise.resolve();

--- a/src/stores/conversations-client.ts
+++ b/src/stores/conversations-client.ts
@@ -39,8 +39,14 @@ export async function resolveDirectConversationId(
   const cacheKey = `${myUserId}:${otherUserId}`;
   const cached = directConversationIds.get(cacheKey);
   if (cached) return cached;
-  const conversationId =
-    await getConversationsClient().resolveDirect(otherUserId);
+  let conversationId: string;
+  try {
+    conversationId = await getConversationsClient().resolveDirect(otherUserId);
+  } catch (error) {
+    if (!(error instanceof DOMException) || error.name !== 'TimeoutError') throw error;
+    // ponytail: resolve-direct is idempotent; one retry covers a cold Worker.
+    conversationId = await getConversationsClient().resolveDirect(otherUserId);
+  }
   directConversationIds.set(cacheKey, conversationId);
   return conversationId;
 }


### PR DESCRIPTION
## What changed

- Retry the idempotent direct-conversation lookup once after a timeout.
- Subscribe for call responses before sending the invite.
- Retain accepted responses until the caller acknowledges them.

## Root cause

Conversation resolution could fail on one transient 8-second timeout. Separately, accepted responses were live-only, so a response arriving during listener setup or a mailbox reconnect was dropped; the callee joined while the caller kept ringing.

## Checks

- `pnpm vitest --run src/features/call/call-handshake-controller.test.js`
- `pnpm -C backend/cloudflare test`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call “accepted” responses are now persisted and delivered reliably until the caller explicitly acknowledges them.
  * Added support for acknowledging accepted call responses so the system can stop replaying them.

* **Improvements**
  * Conversation ID resolution now retries once on timeouts for better reliability.
  * Outgoing call flow now registers callee response handling earlier; incoming notifications are only sent after a successful invite.

* **Tests**
  * Added end-to-end coverage for call response retention and acknowledgement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->