### PR TITLE
bugfix: already incoming call on login

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "dependencies": {
     "@kidlib/create-component": "^0.1.5",
-    "@kidlib/p2p": "^0.2.2",
+    "@kidlib/p2p": "^0.2.3",
     "@mediabunny/ac3": "^1.40.1",
     "@sentry/browser": "^10.49.0",
     "firebase": "^12.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       '@kidlib/p2p':
-        specifier: ^0.2.2
-        version: 0.2.2(solid-js@1.9.12)
+        specifier: ^0.2.3
+        version: 0.2.3(solid-js@1.9.12)
       '@mediabunny/ac3':
         specifier: ^1.40.1
         version: 1.40.1(mediabunny@1.41.0)
@@ -1971,8 +1971,8 @@ packages:
   '@kidlib/create-component@0.1.5':
     resolution: {integrity: sha512-viom5Q6hIMz13plwb6665OT+2N3OBLs+8T7dNT5G9+0UQFcCtOI0iFE0tq0PNf5nnkNsrhS/NkhkyFvclTbMKA==}
 
-  '@kidlib/p2p@0.2.2':
-    resolution: {integrity: sha512-MHyRKBWtnvXHVEeBXsjAINJcaZkdutEbTP9SAO1rmk7+rR0FVLERHL+vO+SVuGP7cswtMhGrDY5sUIH047sZKA==}
+  '@kidlib/p2p@0.2.3':
+    resolution: {integrity: sha512-dFQzLOLp8PldmdxhOwARwWjtgbQQUFWkt0zP/H1hVSBZSX93KcDgR0UmcsfOkjHYpu5LmnlGlQ+8RgFC07i53g==}
     peerDependencies:
       solid-js: '>=1.8.0'
     peerDependenciesMeta:
@@ -6897,7 +6897,7 @@ snapshots:
 
   '@kidlib/create-component@0.1.5': {}
 
-  '@kidlib/p2p@0.2.2(solid-js@1.9.12)':
+  '@kidlib/p2p@0.2.3(solid-js@1.9.12)':
     optionalDependencies:
       solid-js: 1.9.12
 

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -168,10 +168,12 @@ describe('CallHandshakeController', () => {
   });
 
   it('does not notify accepted when joining the room fails', async () => {
+    const joinError = new Error('camera blocked');
     const p2p = {
-      join: vi.fn(() => Promise.reject(new Error('camera blocked'))),
+      join: vi.fn(() => Promise.resolve(undefined)),
       close: vi.fn(),
       state: vi.fn(() => 'idle'),
+      error: vi.fn(() => joinError),
       room: vi.fn(),
     };
     const controller = new CallHandshakeController({

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -281,6 +281,7 @@ export class CallHandshakeController {
         if (autoExitOnEmpty) this.exitActiveRoom();
       },
     });
+    if (!room) throw this.p2p.error() ?? new Error('Room join returned no room');
 
     import.meta.env.DEV &&
       room &&


### PR DESCRIPTION
answering a call that was already incoming resulted in p2p.join() returning undefined on failure, while enterRoom() treated it as success. Both the p2p package update applied fixes this, as well as enterRoom assumption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error detection and handling when call room join operations fail, ensuring proper error notification and recovery instead of proceeding with invalid state.

* **Chores**
  * Updated peer-to-peer communication library dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->