### PR TITLE
Fix call teardown on auth-user change

### DIFF
--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -53,6 +53,7 @@ export class CallHandshakeController {
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
+  private lastBoundUID: string | undefined;
 
   constructor({
     p2p,
@@ -96,13 +97,21 @@ export class CallHandshakeController {
     // (incl. p2p.close) stays in cleanup(), used on logout/unmount.
     // initCallService() below swaps the service when the uid changes, so the
     // dropped cleanupCallService() is covered.
-    // ponytail: account switch (uid→uid' without a null in between) won't end
-    // the old call here, but Firebase routes account changes through logout
-    // (uid→null→uid'), so that transition doesn't occur in practice.
+    const localUID = getLoggedInUserId();
+
+    // Direct account switch (uid → different uid without a logout in between):
+    // tear down the previous user's call. Firebase normally routes account
+    // changes through logout (uid→null→uid'), but guard by construction here
+    // rather than relying on that. A plain login (undefined→uid) or re-init for
+    // the same uid is NOT a switch and must not tear down an active call.
+    if (this.lastBoundUID && localUID && this.lastBoundUID !== localUID) {
+      this.cleanup();
+    }
+    this.lastBoundUID = localUID ?? undefined;
+
     this.unsubscribeIncomingCall?.();
     this.unsubscribeIncomingCall = undefined;
 
-    const localUID = getLoggedInUserId();
     if (!localUID) return;
 
     const callService = initCallService({

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -89,7 +89,18 @@ export class CallHandshakeController {
    * on a logged-in user, but we re-read the uid defensively.
    */
   init(): void {
-    this.cleanup();
+    // Re-bind ONLY the incoming-call listener for the current user. This runs on
+    // every auth-user change (including login), so it must NOT tear down an
+    // active call — p2p.close() here black-screens a live call when it races an
+    // in-flight join ("answered just after logging in"). Full teardown
+    // (incl. p2p.close) stays in cleanup(), used on logout/unmount.
+    // initCallService() below swaps the service when the uid changes, so the
+    // dropped cleanupCallService() is covered.
+    // ponytail: account switch (uid→uid' without a null in between) won't end
+    // the old call here, but Firebase routes account changes through logout
+    // (uid→null→uid'), so that transition doesn't occur in practice.
+    this.unsubscribeIncomingCall?.();
+    this.unsubscribeIncomingCall = undefined;
 
     const localUID = getLoggedInUserId();
     if (!localUID) return;

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -90,20 +90,11 @@ export class CallHandshakeController {
    * on a logged-in user, but we re-read the uid defensively.
    */
   init(): void {
-    // Re-bind ONLY the incoming-call listener for the current user. This runs on
-    // every auth-user change (including login), so it must NOT tear down an
-    // active call — p2p.close() here black-screens a live call when it races an
-    // in-flight join ("answered just after logging in"). Full teardown
-    // (incl. p2p.close) stays in cleanup(), used on logout/unmount.
-    // initCallService() below swaps the service when the uid changes, so the
-    // dropped cleanupCallService() is covered.
+    // Runs on every auth change incl. login, so it must not tear down an active
+    // call (p2p.close here black-screens a call that's mid-join). Only a switch
+    // to a *different* user does full teardown; full cleanup() is otherwise
+    // reserved for logout/unmount.
     const localUID = getLoggedInUserId();
-
-    // Direct account switch (uid → different uid without a logout in between):
-    // tear down the previous user's call. Firebase normally routes account
-    // changes through logout (uid→null→uid'), but guard by construction here
-    // rather than relying on that. A plain login (undefined→uid) or re-init for
-    // the same uid is NOT a switch and must not tear down an active call.
     if (this.lastBoundUID && localUID && this.lastBoundUID !== localUID) {
       this.cleanup();
     }

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -225,9 +225,14 @@ export class CallHandshakeController {
           console.error('Error entering room on callee accept:', err);
           this.exitActiveRoom();
         } finally {
-          svc.ackCallResponse(response.roomId).catch((err) =>
-            console.warn('[CallHandshake] Failed to acknowledge call response:', err),
-          );
+          svc
+            .ackCallResponse(response.roomId)
+            .catch((err) =>
+              console.warn(
+                '[CallHandshake] Failed to acknowledge call response:',
+                err,
+              ),
+            );
           this.setHandshakeState(null);
         }
       },
@@ -301,7 +306,8 @@ export class CallHandshakeController {
         if (autoExitOnEmpty) this.exitActiveRoom();
       },
     });
-    if (!room) throw this.p2p.error() ?? new Error('Room join returned no room');
+    if (!room)
+      throw this.p2p.error() ?? new Error('Room join returned no room');
 
     import.meta.env.DEV &&
       room &&
@@ -430,5 +436,6 @@ export class CallHandshakeController {
     this.setCalleeBusy(false);
     this.p2p.close();
     cleanupCallService();
+    this.lastBoundUID = undefined;
   }
 }


### PR DESCRIPTION
## What

`CallHandshakeController.init()` runs on every auth-user change (including login). It used to call full `cleanup()` (incl. `p2p.close()`), which black-screened a live call when login raced an in-flight join ("answered just after logging in").

Two commits:
1. **Login no longer tears down an active call** — `init()` re-binds only the incoming-call listener; full teardown stays in `cleanup()` (logout/unmount).
2. **Direct account switch now tears down the old call** — `init()` tracks the last bound uid; on `A → B` (both non-null, no logout in between) it runs `cleanup()` first. Makes safety hold by construction instead of relying on Firebase always routing account changes through logout.

## Scope

One file (`call-handshake-controller.ts`). No API or behavior change for the common login/logout paths.

## Test

Not exercised automatically — needs two accounts + active call + a logout-less switch (a path that doesn't occur through Firebase today). Verified via typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call-handshake stability across session transitions by avoiding unnecessary teardown when the active user hasn’t truly changed.
  * Enhanced handling of repeated initialization so existing active P2P calls are preserved, while incoming-call listening is refreshed correctly to prevent interruptions.
  * Refined related call invite/room-join logic formatting without altering behavior, keeping call flows consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->