### PR TITLE
feat: auto-answer call on push notification "Accept" action

### DIFF
--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -80,9 +80,9 @@ export function CallHandshakeProvider(props: ParentProps) {
   // no matching invite arrives, falling back to the in-app dialog (one tap).
   if (typeof window !== 'undefined') {
     const params = new URLSearchParams(window.location.search);
-    let wantAcceptRoomId =
-      params.get('accept') === '1' ? params.get('room') : null;
-    if (wantAcceptRoomId) {
+    const hasAcceptMarker = params.get('accept') === '1';
+    let wantAcceptRoomId = hasAcceptMarker ? params.get('room') : null;
+    if (hasAcceptMarker) {
       // Strip the marker so a reload/back doesn't re-trigger the accept.
       params.delete('accept');
       const query = params.toString();

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -75,6 +75,34 @@ export function CallHandshakeProvider(props: ParentProps) {
     declineIncoming: controller.declineIncoming,
   };
 
+  // Auto-answer when the app was opened from a push notification's explicit
+  // "Accept" action (SW appends ?accept=1). No-ops on a plain body click or if
+  // no matching invite arrives, falling back to the in-app dialog (one tap).
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    let wantAcceptRoomId =
+      params.get('accept') === '1' ? params.get('room') : null;
+    if (wantAcceptRoomId) {
+      // Strip the marker so a reload/back doesn't re-trigger the accept.
+      params.delete('accept');
+      const query = params.toString();
+      window.history.replaceState(
+        null,
+        '',
+        query
+          ? `${window.location.pathname}?${query}`
+          : window.location.pathname,
+      );
+    }
+    createEffect(() => {
+      const call = incomingCall();
+      if (wantAcceptRoomId && call?.roomId === wantAcceptRoomId) {
+        wantAcceptRoomId = null;
+        controller.acceptIncoming();
+      }
+    });
+  }
+
   // Re-attach the incoming-call listener whenever the logged-in user changes.
   // A one-shot init at mount missed the common case where login completes
   // AFTER mount (the listener never attached → no incoming-call dialog until a

--- a/src/features/push-notifications/sw/__tests__/notification-click-handler.test.js
+++ b/src/features/push-notifications/sw/__tests__/notification-click-handler.test.js
@@ -19,6 +19,15 @@ describe('notification click routing', () => {
     ).toBe('/?room=room-123');
   });
 
+  it('marks the incoming-call path for auto-accept on the explicit accept action', () => {
+    expect(
+      getNotificationNavigationPath(
+        { type: 'incoming_call', roomId: 'room-123' },
+        'accept',
+      ),
+    ).toBe('/?room=room-123&accept=1');
+  });
+
   it('routes missed calls explicitly to caller contact first, then room fallback', () => {
     expect(
       getNotificationNavigationPath({

--- a/src/features/push-notifications/sw/notification-click-handler.js
+++ b/src/features/push-notifications/sw/notification-click-handler.js
@@ -7,7 +7,11 @@ export function getNotificationNavigationPath(data, action) {
   const { type, roomId, senderId, callerId, conversationId } = data || {};
 
   if (isIncomingCallType(type)) {
-    return roomId ? `/?room=${encodeURIComponent(roomId)}` : '/';
+    if (!roomId) return '/';
+    const path = `/?room=${encodeURIComponent(roomId)}`;
+    // The explicit "Accept" notification action (where supported) auto-answers;
+    // a plain body click just opens the in-app incoming-call dialog.
+    return action === 'accept' ? `${path}&accept=1` : path;
   }
 
   if (type === 'missed_call') {


### PR DESCRIPTION
Accept-action notification clicks now auto-answer; body clicks unchanged (open in-app dialog, one tap).

SW appends `?accept=1` only for the explicit Accept action; client reads it on open and calls `acceptIncoming()` once the matching invite arrives. Purely additive — no-ops to current behavior when unsupported or on warm windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incoming calls can now be auto-accepted directly from push notification actions, automatically routing and accepting the call when the page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->