### PR TITLE
Live MRU reorder + unread badge on D1 backend

### DIFF
--- a/src/features/messaging-next/adapters/d1-activity.test.js
+++ b/src/features/messaging-next/adapters/d1-activity.test.js
@@ -68,10 +68,9 @@ describe('d1 adapter watchConversationActivity', () => {
     repo.markConversationRead('c1', 'me');
 
     const last = seen.at(-1);
-    // lastReadAt clamps past the newest message so the unread test fails.
+    // lastReadAt is never earlier than the newest message, so the unread
+    // test (latestSentAt > lastReadAt) is false: badge cleared.
     expect(last.lastReadAt).toBeGreaterThanOrEqual(500);
-    expect(last.lastReadAt > last.latestSentAt || last.latestSentAt === 0).toBe(
-      true,
-    );
+    expect(last.lastReadAt).toBeGreaterThanOrEqual(last.latestSentAt);
   });
 });

--- a/src/features/messaging-next/adapters/d1-activity.test.js
+++ b/src/features/messaging-next/adapters/d1-activity.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createD1MessageRepository } from './d1.ts';
+
+// Fake D1MessageClient: in-memory message log + a settable live-broadcast hook.
+function createFakeClient() {
+  let broadcast = null;
+  const loaded = [];
+  return {
+    loaded,
+    emit: (msg) => broadcast?.(msg),
+    loadMessages: vi.fn(async () => loaded.slice()),
+    sendMessage: vi.fn(),
+    subscribe: vi.fn((_id, onMessage) => {
+      broadcast = onMessage;
+      return () => {
+        broadcast = null;
+      };
+    }),
+  };
+}
+
+const wire = (over) => ({
+  id: 'm',
+  conversationId: 'c1',
+  senderId: 'other',
+  kind: 'text',
+  body: 'hi',
+  attachments: [],
+  sentAt: 100,
+  ...over,
+});
+
+describe('d1 adapter watchConversationActivity', () => {
+  beforeEach(() => {
+    try {
+      localStorage.clear();
+    } catch {
+      // jsdom-less env: ignore
+    }
+  });
+
+  it('advances latest* on each live broadcast (newest wins)', async () => {
+    const client = createFakeClient();
+    const repo = createD1MessageRepository(client);
+    const seen = [];
+
+    const off = repo.watchConversationActivity('c1', 'me', (a) => seen.push(a));
+    await Promise.resolve();
+
+    client.emit(wire({ sentAt: 200, senderId: 'other' }));
+    client.emit(wire({ sentAt: 150, senderId: 'other' })); // older: ignored
+
+    const last = seen.at(-1);
+    expect(last.latestSentAt).toBe(200);
+    expect(last.latestSenderId).toBe('other');
+    off();
+  });
+
+  it('markConversationRead clears past the newest message and re-emits live', async () => {
+    const client = createFakeClient();
+    const repo = createD1MessageRepository(client);
+    const seen = [];
+
+    repo.watchConversationActivity('c1', 'me', (a) => seen.push(a));
+    await Promise.resolve();
+    client.emit(wire({ sentAt: 500, senderId: 'other' }));
+
+    repo.markConversationRead('c1', 'me');
+
+    const last = seen.at(-1);
+    // lastReadAt clamps past the newest message so the unread test fails.
+    expect(last.lastReadAt).toBeGreaterThanOrEqual(500);
+    expect(last.lastReadAt > last.latestSentAt || last.latestSentAt === 0).toBe(
+      true,
+    );
+  });
+});

--- a/src/features/messaging-next/adapters/d1.ts
+++ b/src/features/messaging-next/adapters/d1.ts
@@ -13,7 +13,12 @@
 // Scope (decision 2026-06-15 #5): text + file messages with live push. The
 // reaction/read methods are inert (deferred to the fast-follow).
 
-import type { IncomingMessage, MessageRepository, ReactionMap } from '../interfaces.js';
+import type {
+  ConversationActivity,
+  IncomingMessage,
+  MessageRepository,
+  ReactionMap,
+} from '../interfaces.js';
 import type { ConversationId, MessageEnvelope, UserId } from '../types.js';
 import type { WireMessage } from '../../../realtime/conversation-protocol';
 
@@ -50,6 +55,38 @@ export interface D1MessageClient {
 
 const noop = () => {};
 const EMPTY_REACTIONS: ReactionMap = {};
+
+// ── Per-device read state ──────────────────────────────────────────────────
+// lastReadAt lives in localStorage keyed by conversation. ponytail: per-device,
+// not synced across devices — the contract (markConversationRead / lastReadAt)
+// is identical to a server-backed version, so swapping to D1 later is internal
+// to this adapter, no UI or interface change.
+const readKey = (conversationId: string) => `hangvidu:lastRead:${conversationId}`;
+
+function getLastReadAt(conversationId: string): number {
+  try {
+    return Number(localStorage.getItem(readKey(conversationId))) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function setLastReadAt(conversationId: string, at: number): void {
+  try {
+    localStorage.setItem(readKey(conversationId), String(at));
+  } catch {
+    // localStorage unavailable (SSR/private mode): read state is best-effort.
+  }
+}
+
+// In-process activity subscribers, so markConversationRead re-emits the cleared
+// lastReadAt to the contacts list live on the same device without a reload.
+interface ActivitySub {
+  userId: UserId;
+  state: ConversationActivity;
+  emit: () => void;
+}
+const activitySubs = new Map<string, Set<ActivitySub>>();
 
 // Cap the in-memory live window so long-lived sessions don't grow unbounded.
 // Matches the rtdb adapter's RECENT_MESSAGES_WINDOW.
@@ -177,15 +214,62 @@ export function createD1MessageRepository(
       return { id: stored.id, sentAt: stored.sentAt };
     },
 
-    // Read receipts are deferred (decision #5); marking is a no-op for now.
-    markConversationRead() {},
+    markConversationRead(conversationId, _userId) {
+      const subs = activitySubs.get(conversationId);
+      // Clamp past the newest known message so clock skew can't leave a stale
+      // badge: a read always wins over a message we've already seen.
+      let readAt = Date.now();
+      if (subs) for (const s of subs) readAt = Math.max(readAt, s.state.latestSentAt);
+      setLastReadAt(conversationId, readAt);
+      if (subs)
+        for (const s of subs) {
+          s.state.lastReadAt = readAt;
+          s.emit();
+        }
+    },
 
-    // Activity / unread badges are deferred (decision #5). The contacts list
-    // watches this for every contact; doing real work here would resolve+load
-    // per contact. Emit one zero snapshot to satisfy the contract, no network.
-    watchConversationActivity(_conversationId, _userId, onChange) {
-      onChange({ latestSentAt: 0, latestSenderId: null, lastReadAt: 0 });
-      return noop;
+    // Derive activity from the live conversation channel: initial snapshot seeds
+    // latest*, each broadcast advances it. lastReadAt comes from localStorage and
+    // is updated in-process by markConversationRead. ponytail: one WS + one
+    // loadMessages per watched conversation — fine for a small contact list;
+    // upgrade path is a single per-user activity stream if lists grow large.
+    watchConversationActivity(conversationId, userId, onChange, onError) {
+      const state: ConversationActivity = {
+        latestSentAt: 0,
+        latestSenderId: null,
+        lastReadAt: getLastReadAt(conversationId),
+      };
+      const sub: ActivitySub = {
+        userId,
+        state,
+        emit: () => onChange({ ...state }),
+      };
+      let subs = activitySubs.get(conversationId);
+      if (!subs) activitySubs.set(conversationId, (subs = new Set()));
+      subs.add(sub);
+
+      const advance = (m: WireMessage) => {
+        if (m.sentAt <= state.latestSentAt) return;
+        state.latestSentAt = m.sentAt;
+        state.latestSenderId = m.senderId as UserId;
+        sub.emit();
+      };
+
+      const off = client.subscribe(conversationId, advance);
+
+      sub.emit(); // satisfy the contract: emit current state immediately.
+      void client
+        .loadMessages(conversationId)
+        .then((rows) => {
+          for (const m of rows) advance(m); // advance() keeps only the newest.
+        })
+        .catch((error) => onError?.(error));
+
+      return () => {
+        off();
+        subs?.delete(sub);
+        if (subs && subs.size === 0) activitySubs.delete(conversationId);
+      };
     },
 
     // Reactions are deferred (decision #5).

--- a/src/features/messaging-next/adapters/d1.ts
+++ b/src/features/messaging-next/adapters/d1.ts
@@ -214,6 +214,8 @@ export function createD1MessageRepository(
       return { id: stored.id, sentAt: stored.sentAt };
     },
 
+    // _userId is unused: per-device read state is keyed by conversation only,
+    // not scoped per user. A server-backed version would use it (see #563).
     markConversationRead(conversationId, _userId) {
       const subs = activitySubs.get(conversationId);
       // Clamp past the newest known message so clock skew can't leave a stale

--- a/src/features/messaging-next/adapters/d1.ts
+++ b/src/features/messaging-next/adapters/d1.ts
@@ -82,6 +82,8 @@ function setLastReadAt(conversationId: string, at: number): void {
 // In-process activity subscribers, so markConversationRead re-emits the cleared
 // lastReadAt to the contacts list live on the same device without a reload.
 interface ActivitySub {
+  // Unused by the per-device impl; the #563 server-backed version keys read
+  // state by (conversation, user). Kept for parity with the in-memory adapter.
   userId: UserId;
   state: ConversationActivity;
   emit: () => void;


### PR DESCRIPTION
## What
Implements the deferred \`watchConversationActivity\` / \`markConversationRead\` in the D1 message adapter ([d1.ts](../blob/feat/contacts-live-activity/src/features/messaging-next/adapters/d1.ts)). The contacts-list UI (MRU sort + unread dot) was already wired to the \`watchConversationActivity\` contract via \`useContacts\`; the live adapter just returned zeros, so nothing reordered or badged on the deployed Cloudflare backend.

## How
- \`watchConversationActivity\`: seeds \`latestSentAt\`/\`latestSenderId\` from the initial \`loadMessages\` snapshot, then advances on each broadcast from the existing per-conversation Durable Object channel. Live reorder + badge, no reload.
- \`markConversationRead\`: persists \`lastReadAt\` in localStorage and re-emits to a module-level subscriber registry, so opening a conversation clears its badge on the contacts list instantly (works across runtime instances).

## Notes
- Backend-agnostic seam untouched — the contacts list depends only on the \`watchConversationActivity\` contract. No new server code, no migration.
- Read state is **per-device** (localStorage). The contract is identical to a server-backed version, so cross-device sync is a later, adapter-internal upgrade.
- Cost: one WS + one \`loadMessages\` per watched conversation. Fine for the current small contact list; upgrade path is a single per-user activity stream if lists grow large.

## Test
\`src/features/messaging-next/adapters/d1-activity.test.js\` — broadcast advances latest* (newest wins); markRead clamps past the newest message and re-emits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation read status now properly syncs and persists on your device.
  * Unread message badge indicators now update correctly in real-time as new messages arrive.
  * Read timestamp computation now accurately reflects the newest message in conversation.

* **Tests**
  * Added test suite for conversation activity watching and read state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->