### PR TITLE
feat: live conversation-list reorder + unread (single mailbox socket)

### DIFF
--- a/HANDOFF_conversation-activity.md
+++ b/HANDOFF_conversation-activity.md
@@ -10,9 +10,10 @@ unread badge, in real time, without reload. Backend-agnostic at the seam.
 
 ## Status
 
-- Branch `feat/conversation-activity-feed`, commit `a685b954` — working spike,
-  verified "mostly works" in-browser via `pnpm dev:local` (two users, one DM).
-- There are a few core issues to address before refining (below).
+- Branch `feat/conversation-activity-feed` — spike verified in-browser via
+  `pnpm dev:local` (two users, one DM). Both deploy-blockers now cleared
+  (single socket + sender's own send); additive wire changes, safe to merge.
+- Remaining items are deferred refinements (below), not blockers.
 
 ## Approach (decided — do not relitigate)
 
@@ -41,17 +42,27 @@ Per-user **push** by reusing the existing `UserMailbox` Durable Object.
 prod-worker 403 trap). Two users sharing a DM; send from one, watch the other's list
 reorder + badge live with no conversation open.
 
+## Resolved (deploy-blockers cleared)
+
+- **Single mailbox socket** — `src/realtime/user-mailbox.ts` is a uid-keyed
+  singleton over `createMailboxChannel`; both `CallService` and
+  `conversation-activity` subscribe through it. No second per-user WS.
+- **Sender's own send** — `recordConversationActivity` bumps the open
+  conversation's row from the `watchRecentMessages` callback (DM-only, keyed on
+  the peer uid), so the sender's list reorders without a refetch.
+
 ## Deliberate spike shortcuts to refine (all flagged in code comments)
 
-- **Second mailbox socket** — `conversation-activity` opens its own mailbox WS,
-  separate from `CallService`'s. Consolidate to one shared mailbox subscription.
 - **Naming** — `call-mailbox` protocol now also carries message activity; rename to a
-  general per-user event channel.
+  general per-user event channel (the client `user-mailbox` keeps the `mailbox`
+  term until that pass).
 - **Boundaries** — `useContacts` and `ConversationPanel` (feature) import
   `stores/conversation-activity`. Re-decide boundaries in refine.
 - **DM-only** — live path keys on `senderId == the participant` (true for DMs, all the
   list shows); groups unhandled.
-- **Sender's own list** updates on seed refetch, not on their own send.
+- **Activity after logout/user-switch** — `closeUserMailbox` drops handlers and
+  `startConversationActivity` is latched, so activity stops until reload. Dominant
+  flow reloads on auth change; fix when in-place user-switch matters.
 - **Server N+1** — two correlated subqueries per conversation in the seed; fold into a
   grouped join if the list grows.
 - **Read-state** — per-device localStorage for now; cross-device is issue #563.

--- a/HANDOFF_conversation-activity.md
+++ b/HANDOFF_conversation-activity.md
@@ -1,0 +1,64 @@
+# Handoff: live conversation-list activity (reorder + unread)
+
+Transient working doc for picking this up in a fresh session. Delete when the
+feature lands.
+
+## Goal
+
+The contacts/conversation list reorders by most-recent message (MRU) and shows an
+unread badge, in real time, without reload. Backend-agnostic at the seam.
+
+## Status
+
+- Branch `feat/conversation-activity-feed`, commit `a685b954` — working spike,
+  verified "mostly works" in-browser via `pnpm dev:local` (two users, one DM).
+- There are a few core issues to address before refining (below).
+
+## Approach (decided — do not relitigate)
+
+Per-user **push** by reusing the existing `UserMailbox` Durable Object.
+
+- NOT a new per-user DO, NOT one socket per conversation, NOT fetch-on-focus-only.
+- Contact-driven list, conversations stay **lazy**, joined by **participant uid**.
+  (NOT conversation-driven/eager; NOT doing the contacts→D1 migration first.)
+
+## How it works (the seam)
+
+- **Push:** on message store, `backend/cloudflare/src/data/handlers.ts` fans out an
+  `activity` mailbox envelope to every _other_ member. The DO's `deliver()` already
+  broadcasts non-persisted envelopes, so no DO change. Envelope defined in
+  `shared/call-mailbox/protocol.ts` (`{ t:'activity', conversationId, senderId, sentAt }`).
+- **Seed (first paint):** `GET /conversations` (`repo.ts listConversations`) now
+  returns `latest_sent_at` / `latest_sender_id` for correct initial order + unread.
+- **Client seam:** `src/stores/conversation-activity.ts` — seeds via `GET /conversations`
+  - subscribes to the mailbox → reactive `Map<participantUid, activity>`;
+    localStorage read-state. `useContacts` consumes it; `ConversationPanel` calls
+    `markConversationRead` on open.
+
+## Verify
+
+`pnpm dev:local` (local worker, `APP_ENV=development` allows localhost — avoids the
+prod-worker 403 trap). Two users sharing a DM; send from one, watch the other's list
+reorder + badge live with no conversation open.
+
+## Deliberate spike shortcuts to refine (all flagged in code comments)
+
+- **Second mailbox socket** — `conversation-activity` opens its own mailbox WS,
+  separate from `CallService`'s. Consolidate to one shared mailbox subscription.
+- **Naming** — `call-mailbox` protocol now also carries message activity; rename to a
+  general per-user event channel.
+- **Boundaries** — `useContacts` and `ConversationPanel` (feature) import
+  `stores/conversation-activity`. Re-decide boundaries in refine.
+- **DM-only** — live path keys on `senderId == the participant` (true for DMs, all the
+  list shows); groups unhandled.
+- **Sender's own list** updates on seed refetch, not on their own send.
+- **Server N+1** — two correlated subqueries per conversation in the seed; fold into a
+  grouped join if the list grows.
+- **Read-state** — per-device localStorage for now; cross-device is issue #563.
+
+## Related (context, not to redo)
+
+- PR #562 — draft; abandoned first cut (per-contact client fan-out, watched the wrong
+  legacy composite id). Kept for reference only.
+- PR #564 — merged; retired the vestigial `contact.conversationId` field.
+- Issue #563 — cross-device read state (server `last_read_at`), folds in later.

--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -302,6 +302,26 @@ export async function handleDataRequest(
         } catch (err) {
           console.warn('[data] live broadcast failed', { conversationId, err });
         }
+        // Per-user activity push: ping every other member's mailbox so their
+        // conversation list reorders + badges without the conversation open.
+        // Best-effort, fire-and-forget (not persisted in the mailbox).
+        try {
+          const members = await getMembers(env.DB, conversationId);
+          await Promise.all(
+            members
+              .filter((m) => m.user_id !== callerId)
+              .map((m) =>
+                env.USER_MAILBOX.getByName(m.user_id).deliver({
+                  t: 'activity',
+                  conversationId,
+                  senderId: callerId,
+                  sentAt: now,
+                }),
+              ),
+          );
+        } catch (err) {
+          console.warn('[data] activity fan-out failed', { conversationId, err });
+        }
         return json({ message: wire }, 200, cors);
       }
     }

--- a/backend/cloudflare/src/data/repo.ts
+++ b/backend/cloudflare/src/data/repo.ts
@@ -349,10 +349,10 @@ export async function listConversations(
       `SELECT c.*,
               (SELECT msg.created_at FROM messages msg
                 WHERE msg.conversation_id = c.id
-                ORDER BY msg.created_at DESC LIMIT 1) AS latest_sent_at,
+                ORDER BY msg.created_at DESC, msg.id DESC LIMIT 1) AS latest_sent_at,
               (SELECT msg.sender_id FROM messages msg
                 WHERE msg.conversation_id = c.id
-                ORDER BY msg.created_at DESC LIMIT 1) AS latest_sender_id
+                ORDER BY msg.created_at DESC, msg.id DESC LIMIT 1) AS latest_sender_id
        FROM conversations c
        JOIN conversation_members m
          ON m.conversation_id = c.id AND m.user_id = ?

--- a/backend/cloudflare/src/data/repo.ts
+++ b/backend/cloudflare/src/data/repo.ts
@@ -334,17 +334,37 @@ export async function getMembers(
 export async function listConversations(
   db: D1Database,
   userId: string,
-): Promise<(ConversationRow & { members: MemberRow[] })[]> {
+): Promise<
+  (ConversationRow & {
+    members: MemberRow[];
+    latest_sent_at: number | null;
+    latest_sender_id: string | null;
+  })[]
+> {
+  // latest_* feed the conversation list's MRU sort + unread badge (last message
+  // time + who sent it). ponytail: per-conversation correlated subqueries —
+  // fine at current scale; fold into a grouped join if the list grows large.
   const { results } = await db
     .prepare(
-      `SELECT c.*
+      `SELECT c.*,
+              (SELECT msg.created_at FROM messages msg
+                WHERE msg.conversation_id = c.id
+                ORDER BY msg.created_at DESC LIMIT 1) AS latest_sent_at,
+              (SELECT msg.sender_id FROM messages msg
+                WHERE msg.conversation_id = c.id
+                ORDER BY msg.created_at DESC LIMIT 1) AS latest_sender_id
        FROM conversations c
        JOIN conversation_members m
          ON m.conversation_id = c.id AND m.user_id = ?
        ORDER BY c.updated_at DESC`,
     )
     .bind(userId)
-    .all<ConversationRow>();
+    .all<
+      ConversationRow & {
+        latest_sent_at: number | null;
+        latest_sender_id: string | null;
+      }
+    >();
 
   const conversations = results ?? [];
   return Promise.all(
@@ -355,6 +375,8 @@ export async function listConversations(
       title: c.title,
       created_at: c.created_at,
       updated_at: c.updated_at,
+      latest_sent_at: c.latest_sent_at,
+      latest_sender_id: c.latest_sender_id,
       members: await getMembers(db, c.id),
     })),
   );

--- a/backend/cloudflare/src/files/handlers.ts
+++ b/backend/cloudflare/src/files/handlers.ts
@@ -5,12 +5,14 @@ import type { WorkerEnv } from '../types';
 import type { FileObjectStore } from './file-object-store';
 import { R2FileObjectStore } from './r2-file-object-store';
 
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
 const AUTHORIZATION_CACHE_TTL_MS = 30 * 1000;
 const AUTHORIZATION_CACHE_MAX_ENTRIES = 500;
 const CONVERSATION_FILE_PREFIX = 'conversation-files';
-const IMAGE_UPLOAD_PATH = /^\/conversations\/([^/]+)\/files\/images$/;
 const FILE_OBJECT_PATH = /^\/conversations\/([^/]+)\/files\/object$/;
+const IMAGE_UPLOAD_PATH = /^\/conversations\/([^/]+)\/files\/images$/;
+// TODO: Wire client uploads to this path, then remove IMAGE_UPLOAD_PATH.
+const FILE_UPLOAD_PATH = /^\/conversations\/([^/]+)\/files$/;
 
 const authorizationCache = new Map<string, number>();
 
@@ -180,7 +182,7 @@ async function authorizeConversation(
 
 async function readCappedBody(request: Request): Promise<ArrayBuffer | null> {
   const contentLength = Number(request.headers.get('Content-Length') ?? '0');
-  if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
+  if (Number.isFinite(contentLength) && contentLength > MAX_FILE_BYTES) {
     return null;
   }
 
@@ -195,7 +197,7 @@ async function readCappedBody(request: Request): Promise<ArrayBuffer | null> {
     if (done) break;
 
     totalBytes += value.byteLength;
-    if (totalBytes > MAX_IMAGE_BYTES) {
+    if (totalBytes > MAX_FILE_BYTES) {
       await reader.cancel();
       return null;
     }
@@ -271,10 +273,7 @@ async function handleDownload(
   if (!object) return response(request, env, 'Not found', { status: 404 });
 
   const headers = new Headers();
-  headers.set(
-    'Content-Type',
-    object.contentType ?? 'application/octet-stream',
-  );
+  headers.set('Content-Type', object.contentType ?? 'application/octet-stream');
   headers.set('Content-Length', String(object.size));
   headers.set('ETag', object.etag);
   // Defense-in-depth for user-supplied files (e.g. SVG): neutralize any
@@ -315,65 +314,67 @@ export async function handleFilesRequest(
   request: Request,
   env: WorkerEnv,
 ): Promise<Response> {
-    const store = new R2FileObjectStore(env.FILES_BUCKET);
-    const origin = allowedOrigin(request, env);
-    if (request.method === 'OPTIONS') {
-      if (!origin) return new Response('Forbidden origin', { status: 403 });
-      const headers = new Headers(corsHeaders(origin));
-      appendVaryOrigin(headers);
-      return new Response(null, { status: 204, headers });
-    }
+  const store = new R2FileObjectStore(env.FILES_BUCKET);
+  const origin = allowedOrigin(request, env);
+  if (request.method === 'OPTIONS') {
     if (!origin) return new Response('Forbidden origin', { status: 403 });
+    const headers = new Headers(corsHeaders(origin));
+    appendVaryOrigin(headers);
+    return new Response(null, { status: 204, headers });
+  }
+  if (!origin) return new Response('Forbidden origin', { status: 403 });
 
-    const url = new URL(request.url);
-    const uploadMatch = url.pathname.match(IMAGE_UPLOAD_PATH);
-    const objectMatch = url.pathname.match(FILE_OBJECT_PATH);
-    if (!uploadMatch && !objectMatch) {
-      return response(request, env, 'Not found', { status: 404 });
-    }
+  const url = new URL(request.url);
+  const uploadMatch =
+    url.pathname.match(FILE_UPLOAD_PATH) ??
+    url.pathname.match(IMAGE_UPLOAD_PATH);
+  const objectMatch = url.pathname.match(FILE_OBJECT_PATH);
+  if (!uploadMatch && !objectMatch) {
+    return response(request, env, 'Not found', { status: 404 });
+  }
 
-    const identity = await authenticate(request, env);
-    if (!identity) {
-      return response(request, env, 'Unauthorized', { status: 401 });
-    }
+  const identity = await authenticate(request, env);
+  if (!identity) {
+    return response(request, env, 'Unauthorized', { status: 401 });
+  }
 
-    let conversationId: string;
-    try {
-      conversationId = decodeURIComponent((uploadMatch ?? objectMatch)![1]);
-    } catch {
-      return response(request, env, 'Invalid path', { status: 400 });
-    }
+  let conversationId: string;
+  try {
+    conversationId = decodeURIComponent((uploadMatch ?? objectMatch)![1]);
+  } catch {
+    return response(request, env, 'Invalid path', { status: 400 });
+  }
 
-    const authResult = await authorizeConversation(
-      request,
-      conversationId,
-      identity,
-      env,
-    );
-    if (authResult instanceof Response) {
-      return authResult;
-    }
-    if (!authResult) {
-      return response(request, env, 'Forbidden', { status: 403 });
-    }
+  const authResult = await authorizeConversation(
+    request,
+    conversationId,
+    identity,
+    env,
+  );
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+  if (!authResult) {
+    return response(request, env, 'Forbidden', { status: 403 });
+  }
 
-    if (uploadMatch) {
-      if (request.method !== 'POST') {
-        return response(request, env, 'Method not allowed', { status: 405 });
-      }
-      return handleUpload(request, env, store, conversationId, identity);
+  if (uploadMatch) {
+    if (request.method !== 'POST') {
+      return response(request, env, 'Method not allowed', { status: 405 });
     }
+    return handleUpload(request, env, store, conversationId, identity);
+  }
 
-    const key = storageKeyFromUrl(url, conversationId);
-    if (!key) {
-      return response(request, env, 'Invalid file key', { status: 400 });
-    }
+  const key = storageKeyFromUrl(url, conversationId);
+  if (!key) {
+    return response(request, env, 'Invalid file key', { status: 400 });
+  }
 
-    if (request.method === 'GET') {
-      return handleDownload(request, env, store, key);
-    }
-    if (request.method === 'DELETE') {
-      return handleDelete(request, env, store, key, identity);
-    }
-    return response(request, env, 'Method not allowed', { status: 405 });
+  if (request.method === 'GET') {
+    return handleDownload(request, env, store, key);
+  }
+  if (request.method === 'DELETE') {
+    return handleDelete(request, env, store, key, identity);
+  }
+  return response(request, env, 'Method not allowed', { status: 405 });
 }

--- a/backend/cloudflare/src/index.ts
+++ b/backend/cloudflare/src/index.ts
@@ -7,7 +7,9 @@ export { ConversationChannel } from './realtime/conversation-channel';
 export { SignalingRoom } from './realtime/signaling-room';
 export { UserMailbox } from './realtime/user-mailbox';
 
-const FILES_PATH = /^\/conversations\/[^/]+\/files\/(?:images|object)$/;
+const FILES_PATH = /^\/conversations\/[^/]+\/files$/;
+const FILES_SUBRESOURCE_PATH =
+  /^\/conversations\/[^/]+\/files\/(?:images|object)$/;
 const SIGNALING_PATH = /^\/rooms\/[^/]+\/signal$/;
 const DATA_PATHS = [
   /^\/health$/,
@@ -23,7 +25,7 @@ const DATA_PATHS = [
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const { pathname } = new URL(request.url);
-    if (FILES_PATH.test(pathname)) {
+    if (FILES_PATH.test(pathname) || FILES_SUBRESOURCE_PATH.test(pathname)) {
       return handleFilesRequest(request, env);
     }
     if (SIGNALING_PATH.test(pathname)) {

--- a/backend/cloudflare/test/data-repo.test.ts
+++ b/backend/cloudflare/test/data-repo.test.ts
@@ -193,4 +193,14 @@ describe('listConversations', () => {
       'user-b',
     ]);
   });
+
+  it('uses message id to break latest-message timestamp ties', async () => {
+    const convoId = await resolveOrCreateDirect(db, 'user-a', 'user-b', 1000);
+    await insertMessage(db, convoId, 'm1', 'user-a', 'text', 'first', null, 2000);
+    await insertMessage(db, convoId, 'm2', 'user-b', 'text', 'second', null, 2000);
+
+    const [conversation] = await listConversations(db, 'user-a');
+    expect(conversation.latest_sent_at).toBe(2000);
+    expect(conversation.latest_sender_id).toBe('user-b');
+  });
 });

--- a/backend/cloudflare/test/files-worker.test.ts
+++ b/backend/cloudflare/test/files-worker.test.ts
@@ -342,7 +342,7 @@ describe('files worker routing + auth', () => {
   it('accepts small non-image file uploads', async () => {
     const token = await signToken(validClaims());
     await allowMember('conversation-1', 'user-a');
-    const res = await request('/conversations/conversation-1/files/images', {
+    const res = await request('/conversations/conversation-1/files', {
       method: 'POST',
       token,
       contentType: 'application/pdf',

--- a/backend/cloudflare/test/files-worker.test.ts
+++ b/backend/cloudflare/test/files-worker.test.ts
@@ -139,7 +139,7 @@ beforeEach(async () => {
 
 describe('files worker routing + auth', () => {
   it('401s when no bearer token is provided', async () => {
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       contentType: 'image/png',
       body: 'image',
@@ -150,7 +150,7 @@ describe('files worker routing + auth', () => {
 
   it('403s a disallowed origin', async () => {
     const token = await signToken(validClaims());
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       origin: 'https://evil.com',
@@ -162,7 +162,7 @@ describe('files worker routing + auth', () => {
   });
 
   it('sets Vary: Origin on allowed CORS preflight responses', async () => {
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'OPTIONS',
     });
 
@@ -176,10 +176,10 @@ describe('files worker routing + auth', () => {
   it('lets direct-message members upload and fetch an image', async () => {
     const uploadToken = await signToken(validClaims('user-a'));
     const getToken = await signToken(validClaims('user-b'));
-    await allowMember('user-a_user-b', 'user-a');
-    await allowMember('user-a_user-b', 'user-b');
+    await allowMember('conversation-1', 'user-a');
+    await allowMember('conversation-1', 'user-b');
 
-    const upload = await request('/conversations/user-a_user-b/files/images', {
+    const upload = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token: uploadToken,
       contentType: 'image/png',
@@ -196,11 +196,11 @@ describe('files worker routing + auth', () => {
       provider: 'r2',
       bucket: 'hangvidu-files',
     });
-    expect(metadata.key).toMatch(/^conversation-files\/user-a_user-b\/.+/);
+    expect(metadata.key).toMatch(/^conversation-files\/conversation-1\/.+/);
     expect(metadata).not.toHaveProperty('fileId');
 
     const download = await request(
-      `/conversations/user-a_user-b/files/object?key=${encodeURIComponent(
+      `/conversations/conversation-1/files/object?key=${encodeURIComponent(
         metadata.key,
       )}`,
       { token: getToken },
@@ -222,9 +222,9 @@ describe('files worker routing + auth', () => {
 
   it('accepts app check tokens while authorizing through D1 membership', async () => {
     const token = await signToken(validClaims('user-a'));
-    await allowMember('user-a_user-b', 'user-a');
+    await allowMember('conversation-1', 'user-a');
 
-    const upload = await request('/conversations/user-a_user-b/files/images', {
+    const upload = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       appCheckToken: 'app-check-token',
@@ -266,7 +266,7 @@ describe('files worker routing + auth', () => {
 
   it('403s direct-message non-members', async () => {
     const token = await signToken(validClaims('user-c'));
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       contentType: 'image/png',
@@ -278,9 +278,9 @@ describe('files worker routing + auth', () => {
 
   it('403s removed conversation members', async () => {
     const token = await signToken(validClaims('user-a'));
-    await allowMember('user-a_user-b', 'user-a');
-    await removeMember('user-a_user-b', 'user-a');
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    await allowMember('conversation-1', 'user-a');
+    await removeMember('conversation-1', 'user-a');
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       contentType: 'image/png',
@@ -296,7 +296,7 @@ describe('files worker routing + auth', () => {
       'ALTER TABLE conversation_members RENAME TO unavailable_members',
     ).run();
     try {
-      const res = await request('/conversations/user-a_user-b/files/images', {
+      const res = await request('/conversations/conversation-1/files/images', {
         method: 'POST',
         token,
         contentType: 'image/png',
@@ -328,8 +328,8 @@ describe('files worker routing + auth', () => {
 
   it('accepts svg image uploads', async () => {
     const token = await signToken(validClaims());
-    await allowMember('user-a_user-b', 'user-a');
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    await allowMember('conversation-1', 'user-a');
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       contentType: 'image/svg+xml',
@@ -341,8 +341,8 @@ describe('files worker routing + auth', () => {
 
   it('accepts small non-image file uploads', async () => {
     const token = await signToken(validClaims());
-    await allowMember('user-a_user-b', 'user-a');
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    await allowMember('conversation-1', 'user-a');
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       contentType: 'application/pdf',
@@ -354,8 +354,8 @@ describe('files worker routing + auth', () => {
 
   it('rejects oversized uploads before storing', async () => {
     const token = await signToken(validClaims());
-    await allowMember('user-a_user-b', 'user-a');
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    await allowMember('conversation-1', 'user-a');
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       contentType: 'image/png',
@@ -367,8 +367,8 @@ describe('files worker routing + auth', () => {
 
   it('rejects uploads without a supported MIME type', async () => {
     const token = await signToken(validClaims());
-    await allowMember('user-a_user-b', 'user-a');
-    const res = await request('/conversations/user-a_user-b/files/images', {
+    await allowMember('conversation-1', 'user-a');
+    const res = await request('/conversations/conversation-1/files/images', {
       method: 'POST',
       token,
       contentType: 'not-a-mime',

--- a/shared/call-mailbox/protocol.ts
+++ b/shared/call-mailbox/protocol.ts
@@ -45,7 +45,12 @@ export type MailboxEnvelope =
   | { t: 'invite'; invite: MailboxInvite }
   | { t: 'response'; response: MailboxResponse }
   | { t: 'cancel'; roomId: string; by: string }
-  | { t: 'handled'; roomId: string; by: string };
+  | { t: 'handled'; roomId: string; by: string }
+  // Fire-and-forget "a message landed in one of your conversations" ping, fanned
+  // to every member except the sender. Not persisted (no resurface on reconnect).
+  // ponytail: piggybacks the call mailbox to get per-user push with no new DO;
+  // the "call-mailbox" name is now a misnomer — rename in the refine pass.
+  | { t: 'activity'; conversationId: string; senderId: string; sentAt: number };
 
 export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
   if (!value || typeof value !== 'object') return false;
@@ -74,6 +79,13 @@ export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
   }
   if (e.t === 'cancel' || e.t === 'handled') {
     return typeof e.roomId === 'string' && typeof e.by === 'string';
+  }
+  if (e.t === 'activity') {
+    return (
+      typeof e.conversationId === 'string' &&
+      typeof e.senderId === 'string' &&
+      typeof e.sentAt === 'number'
+    );
   }
   return false;
 }

--- a/src/app/MainContent.tsx
+++ b/src/app/MainContent.tsx
@@ -162,6 +162,7 @@ export default function MainContent() {
               <ConversationPanel
                 selection={selectedConversation()}
                 myUserId={(user()?.uid as UserId | undefined) ?? null}
+                visible={activeView() === 'messaging'}
               />
             </div>
           </Show>

--- a/src/app/__tests__/auth-orchestration.test.js
+++ b/src/app/__tests__/auth-orchestration.test.js
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
     getPublicUserProfile: vi.fn(() => Promise.resolve(null)),
     registerInUserDirectory: vi.fn(() => Promise.resolve()),
     devDebug: vi.fn(),
+    stopConversationActivity: vi.fn(),
   };
 });
 
@@ -53,6 +54,9 @@ vi.mock('../../features/contacts/referrals/referral-handler.js', () => ({
 vi.mock('../../stores/contactsStore.js', () => ({
   hydrateContacts: mocks.hydrateContacts,
   resetContacts: mocks.resetContacts,
+}));
+vi.mock('../../stores/conversation-activity', () => ({
+  stopConversationActivity: mocks.stopConversationActivity,
 }));
 
 describe('wireAuthReactions', () => {
@@ -142,6 +146,7 @@ describe('wireAuthReactions', () => {
 
     expect(mocks.resetContacts).toHaveBeenCalled();
     expect(mocks.cleanupInviteListeners).toHaveBeenCalled();
+    expect(mocks.stopConversationActivity).toHaveBeenCalledOnce();
     expect(localStorageClearSpy).toHaveBeenCalled();
 
     teardown();

--- a/src/app/auth-orchestration.js
+++ b/src/app/auth-orchestration.js
@@ -11,6 +11,7 @@ import { setupInviteListener } from '../features/contacts/invites/invite-listene
 import { processReferral } from '../features/contacts/referrals/referral-handler.js';
 import { hydrateContacts, resetContacts } from '../stores/contactsStore.js';
 import { resetConversationsState } from '../stores/conversations-client.js';
+import { stopConversationActivity } from '../stores/conversation-activity';
 
 let isReady = false;
 let initPromise = null;
@@ -114,6 +115,7 @@ export function wireAuthReactions() {
 
     const runMainLogoutCleanup = () => {
       runSafe(cleanupLoginScopedListeners, 'cleanupLoginScopedListeners');
+      runSafe(stopConversationActivity, 'stopConversationActivity');
       // NOTE: Local storage is cleared on log out, while selected keys are preserved.
       clearLocalStorageOnLogout();
     };

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -1,7 +1,4 @@
-import {
-  subscribeToUserMailbox,
-  closeUserMailbox,
-} from '../../realtime/user-mailbox';
+import { subscribeToUserMailbox } from '../../realtime/user-mailbox';
 import type { MailboxEnvelope } from '../../../shared/call-mailbox/protocol';
 import type { CallInvite, CallResponse } from './model/call-schema';
 import { CALLING_TTL_MS } from '../../../shared/constants';
@@ -59,6 +56,7 @@ export class CallService {
   readonly localUID: string;
   private readonly baseUrl: string;
   private readonly getToken: () => Promise<string | null>;
+  private readonly unsubscribers = new Set<() => void>();
 
   constructor({ localUID, baseUrl, getToken }: CallServiceOptions) {
     if (!localUID || !baseUrl || !getToken) {
@@ -72,10 +70,15 @@ export class CallService {
   }
 
   private subscribe(handler: (e: MailboxEnvelope) => void): () => void {
-    return subscribeToUserMailbox(
+    const unsubscribe = subscribeToUserMailbox(
       { localUID: this.localUID, baseUrl: this.baseUrl, getToken: this.getToken },
       handler,
     );
+    this.unsubscribers.add(unsubscribe);
+    return () => {
+      unsubscribe();
+      this.unsubscribers.delete(unsubscribe);
+    };
   }
 
   private async post(path: string, body: unknown): Promise<void> {
@@ -194,6 +197,7 @@ export class CallService {
   }
 
   cleanup(): void {
-    closeUserMailbox();
+    for (const unsubscribe of this.unsubscribers) unsubscribe();
+    this.unsubscribers.clear();
   }
 }

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -1,7 +1,8 @@
 import {
-  createMailboxChannel,
-  type MailboxChannel,
-} from '../../realtime/mailbox-channel';
+  subscribeToUserMailbox,
+  closeUserMailbox,
+} from '../../realtime/user-mailbox';
+import type { MailboxEnvelope } from '../../../shared/call-mailbox/protocol';
 import type { CallInvite, CallResponse } from './model/call-schema';
 import { CALLING_TTL_MS } from '../../../shared/constants';
 import { reportApiAuthFailure } from '../../infra/api-auth-failure.js';
@@ -55,7 +56,6 @@ function notExpired(expiresAt: number | undefined): boolean {
  * `users/{uid}/calls/*` mailbox; the dead room-access write went with it.
  */
 export class CallService {
-  private channel: MailboxChannel;
   readonly localUID: string;
   private readonly baseUrl: string;
   private readonly getToken: () => Promise<string | null>;
@@ -69,7 +69,13 @@ export class CallService {
     this.localUID = localUID;
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.getToken = getToken;
-    this.channel = createMailboxChannel({ baseUrl: this.baseUrl, getToken });
+  }
+
+  private subscribe(handler: (e: MailboxEnvelope) => void): () => void {
+    return subscribeToUserMailbox(
+      { localUID: this.localUID, baseUrl: this.baseUrl, getToken: this.getToken },
+      handler,
+    );
   }
 
   private async post(path: string, body: unknown): Promise<void> {
@@ -95,7 +101,7 @@ export class CallService {
 
   /** Incoming invites and dismiss events for this user. */
   onIncomingCall(callback: (event: IncomingCallEvent) => void): () => void {
-    return this.channel.onEnvelope((envelope) => {
+    return this.subscribe((envelope) => {
       if (envelope.t === 'invite') {
         if (!notExpired(envelope.invite.expiresAt)) return;
         callback({ type: 'invite', invite: envelope.invite as CallInvite });
@@ -171,7 +177,7 @@ export class CallService {
     _calleeId: string,
     callback: (response: CallResponse | null) => void,
   ): () => void {
-    return this.channel.onEnvelope((envelope) => {
+    return this.subscribe((envelope) => {
       if (envelope.t !== 'response') return;
       if (!notExpired(envelope.response.expiresAt)) return;
       callback(envelope.response as CallResponse);
@@ -188,6 +194,6 @@ export class CallService {
   }
 
   cleanup(): void {
-    this.channel.close();
+    closeUserMailbox();
   }
 }

--- a/src/features/contacts/useContacts.ts
+++ b/src/features/contacts/useContacts.ts
@@ -1,9 +1,13 @@
-import { createEffect, onCleanup, onMount } from 'solid-js';
+import { createEffect, onMount } from 'solid-js';
 import { createStore, produce } from 'solid-js/store';
 import { getLoggedInUserId } from '../../auth/index.js';
 import { getContactsStore } from '../../stores/contactsStore.js';
-import type { ConversationActivity } from '../messaging-next/interfaces.js';
-import { createMessagingRuntime } from '../messaging-next/messaging-runtime.js';
+import {
+  conversationActivity,
+  getLastReadAt,
+  readStateVersion,
+  startConversationActivity,
+} from '../../stores/conversation-activity';
 
 type ContactRow = {
   id: string;
@@ -11,60 +15,34 @@ type ContactRow = {
   hasUnread: boolean;
 };
 
-const EMPTY_ACTIVITY: ConversationActivity = {
-  latestSentAt: 0,
-  latestSenderId: null,
-  lastReadAt: 0,
-};
-
 export function useContacts() {
   const contactsState = getContactsStore();
   const [contacts, setContacts] = createStore<ContactRow[]>([]);
-  const [activity, setActivity] = createStore<
-    Record<string, ConversationActivity>
-  >({});
-  const runtime = createMessagingRuntime();
 
-  const activityWatchers = new Map<string, () => void>();
-  let activityWatchUserId: string | null = null;
-  let activityWatchGeneration = 0;
-
-  function clearActivity() {
-    setActivity(
-      produce((current) => {
-        for (const conversationId of Object.keys(current)) {
-          delete current[conversationId];
-        }
-      }),
-    );
-  }
-
-  function stopActivityWatchers() {
-    for (const unsubscribe of activityWatchers.values()) unsubscribe();
-    activityWatchers.clear();
-  }
+  startConversationActivity();
 
   onMount(() => {
     createEffect(() => {
-      const userId = getLoggedInUserId();
+      const me = getLoggedInUserId();
+      const activity = conversationActivity(); // reactive: participant uid -> activity
+      readStateVersion(); // re-run when a conversation is marked read
 
       const rows: ContactRow[] = Object.values(contactsState.byId)
         .map((c: any) => {
-          const conversationId: string | null = c.conversationId ?? null;
-          const act = conversationId
-            ? (activity[conversationId] ?? EMPTY_ACTIVITY)
-            : EMPTY_ACTIVITY;
-          const sortKey = act.latestSentAt || c?.savedAt || 0;
+          const contactId: string = c.contactId ?? '';
+          const act = activity.get(contactId);
+          const lastReadAt = act ? getLastReadAt(act.conversationId) : 0;
           const hasUnread =
-            Boolean(userId) &&
+            !!act &&
+            Boolean(me) &&
             act.latestSenderId !== null &&
-            act.latestSenderId !== userId &&
-            act.latestSentAt > act.lastReadAt;
+            act.latestSenderId !== me &&
+            act.latestSentAt > lastReadAt;
           return {
-            id: c.contactId ?? '',
+            id: contactId,
             name: c.contactNickName ?? null,
             hasUnread,
-            _sortKey: sortKey,
+            _sortKey: act?.latestSentAt || c?.savedAt || 0,
             _name: (c?.contactNickName || '').toLowerCase(),
           };
         })
@@ -81,95 +59,6 @@ export function useContacts() {
         }),
       );
     });
-
-    createEffect(() => {
-      const userId = getLoggedInUserId();
-      const generation = ++activityWatchGeneration;
-      const conversationIds = new Set(
-        Object.values(contactsState.byId)
-          .map((c: any) => c?.conversationId as string | null | undefined)
-          .filter((id): id is string => Boolean(id)),
-      );
-
-      if (!userId) {
-        stopActivityWatchers();
-        clearActivity();
-        activityWatchUserId = null;
-        return;
-      }
-
-      if (activityWatchUserId !== userId) {
-        stopActivityWatchers();
-        clearActivity();
-        activityWatchUserId = userId;
-      }
-
-      for (const [conversationId, unsubscribe] of activityWatchers) {
-        if (!conversationIds.has(conversationId)) {
-          unsubscribe();
-          activityWatchers.delete(conversationId);
-          setActivity(produce((a) => void delete a[conversationId]));
-        }
-      }
-
-      for (const conversationId of conversationIds) {
-        if (activityWatchers.has(conversationId)) continue;
-
-        const result = runtime.messageRepository.watchConversationActivity(
-          conversationId,
-          userId,
-          (next) => {
-            if (
-              generation !== activityWatchGeneration ||
-              activityWatchUserId !== userId ||
-              !conversationIds.has(conversationId)
-            )
-              return;
-            setActivity(conversationId, next);
-          },
-          (error) => {
-            console.warn('[contacts] activity watch failed', {
-              conversationId,
-              error,
-            });
-          },
-        );
-
-        if (typeof result === 'function') {
-          activityWatchers.set(conversationId, result);
-        } else {
-          void result
-            .then((unsubscribe) => {
-              if (
-                generation === activityWatchGeneration &&
-                activityWatchUserId === userId &&
-                conversationIds.has(conversationId)
-              ) {
-                activityWatchers.set(conversationId, unsubscribe);
-              } else {
-                unsubscribe();
-              }
-            })
-            .catch((error) => {
-              if (
-                generation !== activityWatchGeneration ||
-                activityWatchUserId !== userId
-              )
-                return;
-              console.warn('[contacts] activity watch failed', {
-                conversationId,
-                error,
-              });
-            });
-        }
-      }
-    });
-  });
-
-  onCleanup(() => {
-    activityWatchGeneration += 1;
-    stopActivityWatchers();
-    clearActivity();
   });
 
   return {

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -27,6 +27,8 @@ import {
 } from '../../stores/filesStore.js';
 
 import { createMessagingRuntime } from './messaging-runtime.js';
+// Boundary note (spike): feature -> stores import; consolidate in refine pass.
+import { markConversationRead } from '../../stores/conversation-activity';
 
 import { createConversationState } from './conversation.state.js';
 import { createConversationActions } from './conversation.actions.js';
@@ -456,6 +458,8 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               queueMicrotask(focusInput);
             }
             if (latestMessageId) {
+              // Clears the conversation-list unread badge (per-device read state).
+              markConversationRead(source.conversationId);
               void Promise.resolve(
                 runtime.messageRepository.markConversationRead(
                   source.conversationId,

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -318,6 +318,11 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   const [historyLoading, setHistoryLoading] = createSignal(false);
   const [historyError, setHistoryError] = createSignal<unknown>(null);
   const [historyReady, setHistoryReady] = createSignal(false);
+  const [latestReadCandidate, setLatestReadCandidate] = createSignal<{
+    conversationId: ConversationId;
+    myUserId: UserId;
+    sentAt: number;
+  } | null>(null);
   const [filePreparing, setFilePreparing] = createSignal(false);
   const [r2AttachmentUrls, setR2AttachmentUrls] = createSignal<
     Record<string, string>
@@ -331,6 +336,30 @@ export default function ConversationPanel(props: ConversationPanelProps) {
   }
 
   createEffect(on(() => state.messages.length, followIfPinned));
+
+  createEffect(() => {
+    const candidate = latestReadCandidate();
+    if (
+      !props.visible ||
+      !candidate ||
+      candidate.conversationId !== state.conversationId
+    ) {
+      return;
+    }
+
+    markConversationRead(candidate.conversationId, candidate.sentAt);
+    void Promise.resolve(
+      runtime.messageRepository.markConversationRead(
+        candidate.conversationId,
+        candidate.myUserId,
+      ),
+    ).catch((error) => {
+      console.warn('[conversation] failed to mark conversation read', {
+        conversationId: candidate.conversationId,
+        error,
+      });
+    });
+  });
 
   createEffect(() => {
     const conversationId = state.conversationId;
@@ -422,6 +451,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
       () => historySource(),
       (source) => {
         flushDraftSave();
+        setLatestReadCandidate(null);
         setHistoryReady(false);
         suppressScroll = true;
         // The messages container remounts on switch; drop the old position so
@@ -468,6 +498,12 @@ export default function ConversationPanel(props: ConversationPanelProps) {
             }
             const latest = loadedMessages.at(-1);
             if (latest) {
+              // Only persisted watcher messages carry authoritative server time.
+              setLatestReadCandidate({
+                conversationId: source.conversationId,
+                myUserId: source.myUserId,
+                sentAt: latest.sentAt,
+              });
               // Keep the contact-list row ordered for the open conversation —
               // covers the user's own send (never echoed over the mailbox). DM
               // only: peer uid is the activity map key.
@@ -479,27 +515,6 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                   latest.sentAt,
                   latest.senderId,
                 );
-              }
-              // Clears the badge: read up to the latest SERVER timestamp (never
-              // Date.now() — unread compares against server-stamped message times).
-              // Only when the conversation is actually on screen: the panel keeps
-              // watching while hidden behind the contacts list.
-              if (props.visible) {
-                markConversationRead(source.conversationId, latest.sentAt);
-                void Promise.resolve(
-                  runtime.messageRepository.markConversationRead(
-                    source.conversationId,
-                    source.myUserId,
-                  ),
-                ).catch((error) => {
-                  console.warn(
-                    '[conversation] failed to mark conversation read',
-                    {
-                      conversationId: source.conversationId,
-                      error,
-                    },
-                  );
-                });
               }
             }
           },

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -28,7 +28,10 @@ import {
 
 import { createMessagingRuntime } from './messaging-runtime.js';
 // Boundary note (spike): feature -> stores import; consolidate in refine pass.
-import { markConversationRead } from '../../stores/conversation-activity';
+import {
+  markConversationRead,
+  recordConversationActivity,
+} from '../../stores/conversation-activity';
 
 import { createConversationState } from './conversation.state.js';
 import { createConversationActions } from './conversation.actions.js';
@@ -458,6 +461,19 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               queueMicrotask(focusInput);
             }
             if (latestMessageId) {
+              // Keep the contact-list row ordered for the open conversation —
+              // covers the user's own send (never echoed over the mailbox). DM
+              // only: peer uid is the activity map key.
+              const peers = selection.remoteParticipantIds;
+              const latest = loadedMessages.at(-1);
+              if (latest && peers?.length === 1) {
+                recordConversationActivity(
+                  peers[0],
+                  source.conversationId,
+                  latest.sentAt,
+                  latest.senderId,
+                );
+              }
               // Clears the conversation-list unread badge (per-device read state).
               markConversationRead(source.conversationId);
               void Promise.resolve(

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -182,6 +182,13 @@ function isChatMessage(message: ChatMessage | null): message is ChatMessage {
 type ConversationPanelProps = {
   selection: ConversationSelection | null;
   myUserId: UserId | null;
+  /**
+   * Whether the messaging view is the one on screen. The panel stays mounted
+   * (and watching) when nav switches away, so this gates marking-read: an
+   * incoming message must not clear the unread badge while you're looking at
+   * the contacts list.
+   */
+  visible: boolean;
 };
 
 type HistorySource = {
@@ -475,21 +482,25 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               }
               // Clears the badge: read up to the latest SERVER timestamp (never
               // Date.now() — unread compares against server-stamped message times).
-              markConversationRead(source.conversationId, latest.sentAt);
-              void Promise.resolve(
-                runtime.messageRepository.markConversationRead(
-                  source.conversationId,
-                  source.myUserId,
-                ),
-              ).catch((error) => {
-                console.warn(
-                  '[conversation] failed to mark conversation read',
-                  {
-                    conversationId: source.conversationId,
-                    error,
-                  },
-                );
-              });
+              // Only when the conversation is actually on screen: the panel keeps
+              // watching while hidden behind the contacts list.
+              if (props.visible) {
+                markConversationRead(source.conversationId, latest.sentAt);
+                void Promise.resolve(
+                  runtime.messageRepository.markConversationRead(
+                    source.conversationId,
+                    source.myUserId,
+                  ),
+                ).catch((error) => {
+                  console.warn(
+                    '[conversation] failed to mark conversation read',
+                    {
+                      conversationId: source.conversationId,
+                      error,
+                    },
+                  );
+                });
+              }
             }
           },
           (error) => {

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -445,7 +445,6 @@ export default function ConversationPanel(props: ConversationPanelProps) {
           (messages) => {
             if (source.conversationId !== state.conversationId) return;
 
-            const latestMessageId = messages.at(-1)?.messageId;
             const loadedMessages = sortMessagesBySentAt(
               messages
                 .map((msg) => envelopeToChatMessage(msg, 'persisted'))
@@ -460,13 +459,13 @@ export default function ConversationPanel(props: ConversationPanelProps) {
               scrollToEnd();
               queueMicrotask(focusInput);
             }
-            if (latestMessageId) {
+            const latest = loadedMessages.at(-1);
+            if (latest) {
               // Keep the contact-list row ordered for the open conversation —
               // covers the user's own send (never echoed over the mailbox). DM
               // only: peer uid is the activity map key.
               const peers = selection.remoteParticipantIds;
-              const latest = loadedMessages.at(-1);
-              if (latest && peers?.length === 1) {
+              if (peers?.length === 1) {
                 recordConversationActivity(
                   peers[0],
                   source.conversationId,
@@ -474,8 +473,9 @@ export default function ConversationPanel(props: ConversationPanelProps) {
                   latest.senderId,
                 );
               }
-              // Clears the conversation-list unread badge (per-device read state).
-              markConversationRead(source.conversationId);
+              // Clears the badge: read up to the latest SERVER timestamp (never
+              // Date.now() — unread compares against server-stamped message times).
+              markConversationRead(source.conversationId, latest.sentAt);
               void Promise.resolve(
                 runtime.messageRepository.markConversationRead(
                   source.conversationId,

--- a/src/features/messaging-next/adapters/in-memory-conversations.test.js
+++ b/src/features/messaging-next/adapters/in-memory-conversations.test.js
@@ -10,7 +10,7 @@ function participant(userId, joinedAt = 1) {
 
 function directConversation(overrides = {}) {
   return {
-    conversationId: 'user-a_user-b',
+    conversationId: 'conversation-1',
     kind: 'direct',
     participants: {
       'user-a': participant('user-a'),
@@ -66,7 +66,7 @@ describe('messaging-next in-memory conversation repository', () => {
     const seen = [];
 
     const unsubscribe = repository.subscribeConversation(
-      'user-a_user-b',
+      'conversation-1',
       (conversation) => seen.push(conversation),
     );
 
@@ -74,7 +74,7 @@ describe('messaging-next in-memory conversation repository', () => {
     seen[0].title = 'mutated subscriber copy';
     saved.title = 'mutated returned copy';
 
-    expect(repository.loadConversation('user-a_user-b')?.title).toBeUndefined();
+    expect(repository.loadConversation('conversation-1')?.title).toBeUndefined();
 
     unsubscribe();
     repository.upsertConversation(directConversation({ title: 'after off' }));
@@ -87,7 +87,7 @@ describe('messaging-next in-memory conversation repository', () => {
     repository.upsertConversation(directConversation({ title: 'Existing' }));
 
     const seen = [];
-    repository.subscribeConversation('user-a_user-b', (conversation) =>
+    repository.subscribeConversation('conversation-1', (conversation) =>
       seen.push(conversation),
     );
 

--- a/src/features/messaging-next/adapters/rtdb.test.js
+++ b/src/features/messaging-next/adapters/rtdb.test.js
@@ -24,7 +24,7 @@ describe('messaging-next RTDB conversation adapter', () => {
     vi.mocked(get).mockResolvedValue({
       exists: () => true,
       val: () => ({
-        conversationId: 'user-a_user-b',
+        conversationId: 'conversation-1',
         kind: 'direct',
         participants: {
           'user-a': { userId: 'user-a', joinedAt: 1 },
@@ -38,9 +38,9 @@ describe('messaging-next RTDB conversation adapter', () => {
 
     const repository = createConversationRepository();
 
-    const conversation = await repository.loadConversation('user-a_user-b');
+    const conversation = await repository.loadConversation('conversation-1');
 
-    expect(conversation?.conversationId).toBe('user-a_user-b');
+    expect(conversation?.conversationId).toBe('conversation-1');
     expect(conversation).not.toHaveProperty('draft');
   });
 });

--- a/src/features/messaging-next/schema.ts
+++ b/src/features/messaging-next/schema.ts
@@ -2,8 +2,7 @@ import { z } from 'zod';
 
 export const UserIdSchema = z.string().trim().min(1);
 
-// Group ids carry a `group:` prefix; direct ids are otherwise opaque strings
-// (legacy sorted `a_b` on rtdb, registry UUIDs on d1 — both validate).
+// Group ids carry a `group:` prefix; direct ids are otherwise opaque strings.
 // Group is listed first in the union so the prefix wins discrimination — without
 // this, Direct's permissive rule would swallow any string including `group:*`.
 export const GroupConversationIdSchema = z

--- a/src/features/messaging-next/tests/local-drafts.test.js
+++ b/src/features/messaging-next/tests/local-drafts.test.js
@@ -11,19 +11,19 @@ describe('messaging-next local drafts', () => {
   });
 
   it('scopes drafts by user and conversation', () => {
-    saveLocalDraft('user-a', 'user-a_user-b', 'private draft');
+    saveLocalDraft('user-a', 'conversation-1', 'private draft');
 
-    expect(loadLocalDraft('user-a', 'user-a_user-b')).toBe('private draft');
-    expect(loadLocalDraft('user-b', 'user-a_user-b')).toBe('');
-    expect(loadLocalDraft('user-a', 'user-a_user-c')).toBe('');
+    expect(loadLocalDraft('user-a', 'conversation-1')).toBe('private draft');
+    expect(loadLocalDraft('user-b', 'conversation-1')).toBe('');
+    expect(loadLocalDraft('user-a', 'conversation-2')).toBe('');
   });
 
   it('clears drafts by removing the local storage entry', () => {
-    saveLocalDraft('user-a', 'user-a_user-b', 'private draft');
+    saveLocalDraft('user-a', 'conversation-1', 'private draft');
 
-    clearLocalDraft('user-a', 'user-a_user-b');
+    clearLocalDraft('user-a', 'conversation-1');
 
-    expect(loadLocalDraft('user-a', 'user-a_user-b')).toBe('');
+    expect(loadLocalDraft('user-a', 'conversation-1')).toBe('');
     expect(localStorage.length).toBe(0);
   });
 });

--- a/src/features/messaging-next/tests/schema.test.js
+++ b/src/features/messaging-next/tests/schema.test.js
@@ -13,7 +13,7 @@ describe('messaging-next schema', () => {
 
   it('parses conversation metadata without shared draft state', () => {
     const node = ConversationNodeSchema.parse({
-      conversationId: 'user-a_user-b',
+      conversationId: 'conversation-1',
       kind: 'direct',
       participants: {
         'user-a': {
@@ -67,7 +67,7 @@ describe('messaging-next schema', () => {
   it('accepts R2-backed file payloads', () => {
     const message = MessageEnvelopeSchema.parse({
       messageId: 'msg-1',
-      conversationId: 'user-a_user-b',
+      conversationId: 'conversation-1',
       senderId: 'user-a',
       sentAt: 10,
       delivery: 'persistent',
@@ -79,7 +79,7 @@ describe('messaging-next schema', () => {
         storage: {
           provider: 'r2',
           bucket: 'hangvidu-files',
-          key: 'conversation-files/user-a_user-b/msg-1',
+          key: 'conversation-files/conversation-1/msg-1',
         },
       },
     });
@@ -91,7 +91,7 @@ describe('messaging-next schema', () => {
     expect(() =>
       MessageEnvelopeSchema.parse({
         messageId: 'msg-1',
-        conversationId: 'user-a_user-b',
+        conversationId: 'conversation-1',
         senderId: 'user-a',
         sentAt: 10,
         delivery: 'persistent',

--- a/src/realtime/user-mailbox.ts
+++ b/src/realtime/user-mailbox.ts
@@ -1,0 +1,60 @@
+// The logged-in user's mailbox connection — one socket, shared by every consumer
+// (call invites + conversation activity). The underlying channel already
+// multiplexes handlers, but each `createMailboxChannel` opens its own socket;
+// this singleton keeps a single socket and fans every envelope to all
+// subscribers.
+//
+// Keyed by uid: switching users must re-auth a fresh socket (the DO binds the
+// connection to whoever the upgrade token identifies). closeUserMailbox drops it
+// on logout/user-switch; consumers subscribed across that boundary must
+// resubscribe afterwards.
+
+import {
+  createMailboxChannel,
+  type MailboxChannel,
+} from './mailbox-channel';
+import type { MailboxEnvelope } from '../../shared/call-mailbox/protocol';
+
+export interface UserMailboxOptions {
+  /** Current user; null is tolerated pre-login (socket waits for a token). */
+  localUID: string | null;
+  baseUrl: string;
+  getToken: () => Promise<string | null>;
+}
+
+const handlers = new Set<(e: MailboxEnvelope) => void>();
+let channel: MailboxChannel | null = null;
+let channelUid: string | null = null;
+let unbind: (() => void) | null = null;
+
+function ensureChannel(opts: UserMailboxOptions): void {
+  if (channel && channelUid === opts.localUID) return;
+  unbind?.();
+  channel?.close();
+  channel = createMailboxChannel({
+    baseUrl: opts.baseUrl,
+    getToken: opts.getToken,
+  });
+  channelUid = opts.localUID;
+  unbind = channel.onEnvelope((e) => handlers.forEach((h) => h(e)));
+}
+
+/** Subscribe to the user's mailbox, (re)opening the socket as needed. */
+export function subscribeToUserMailbox(
+  opts: UserMailboxOptions,
+  handler: (e: MailboxEnvelope) => void,
+): () => void {
+  ensureChannel(opts);
+  handlers.add(handler);
+  return () => handlers.delete(handler);
+}
+
+/** Tear down the socket and drop all subscriptions (logout/user-switch). */
+export function closeUserMailbox(): void {
+  unbind?.();
+  unbind = null;
+  channel?.close();
+  channel = null;
+  channelUid = null;
+  handlers.clear();
+}

--- a/src/storage/conversations/data-client.ts
+++ b/src/storage/conversations/data-client.ts
@@ -36,6 +36,10 @@ export interface Conversation {
   title: string | null;
   created_at: number;
   updated_at: number;
+  // Latest-message meta for the conversation list (present on `list()`); null
+  // when the conversation has no messages yet.
+  latest_sent_at?: number | null;
+  latest_sender_id?: string | null;
 }
 
 export interface ConversationsClient {

--- a/src/storage/files/files-client.test.js
+++ b/src/storage/files/files-client.test.js
@@ -91,7 +91,9 @@ describe('files client', () => {
   });
 
   it('reports a 401 to the auth-failure helper', async () => {
-    const fetchMock = vi.fn(async () => new Response('unauthorized', { status: 401 }));
+    const fetchMock = vi.fn(
+      async () => new Response('unauthorized', { status: 401 }),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const client = createFilesClient({
@@ -105,7 +107,7 @@ describe('files client', () => {
         bucket: 'hangvidu-files',
         key: 'conversation-files/conversation-1/object-1',
       }),
-    ).rejects.toThrow('image download failed: 401 unauthorized');
+    ).rejects.toThrow('file download failed: 401 unauthorized');
 
     expect(mocks.reportApiAuthFailure).toHaveBeenCalledWith(
       'files download conversation-1',
@@ -115,7 +117,9 @@ describe('files client', () => {
   });
 
   it('reports a 401 on upload to the auth-failure helper', async () => {
-    const fetchMock = vi.fn(async () => new Response('unauthorized', { status: 401 }));
+    const fetchMock = vi.fn(
+      async () => new Response('unauthorized', { status: 401 }),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const client = createFilesClient({
@@ -124,8 +128,11 @@ describe('files client', () => {
     });
 
     await expect(
-      client.uploadImage('conversation-1', new File(['x'], 'x.png', { type: 'image/png' })),
-    ).rejects.toThrow('image upload failed: 401 unauthorized');
+      client.uploadFile(
+        'conversation-1',
+        new File(['x'], 'x.png', { type: 'image/png' }),
+      ),
+    ).rejects.toThrow('file upload failed: 401 unauthorized');
 
     expect(mocks.reportApiAuthFailure).toHaveBeenCalledWith(
       'files upload conversation-1',
@@ -135,7 +142,9 @@ describe('files client', () => {
   });
 
   it('reports a 401 on delete to the auth-failure helper', async () => {
-    const fetchMock = vi.fn(async () => new Response('unauthorized', { status: 401 }));
+    const fetchMock = vi.fn(
+      async () => new Response('unauthorized', { status: 401 }),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const client = createFilesClient({

--- a/src/storage/files/files-client.ts
+++ b/src/storage/files/files-client.ts
@@ -44,7 +44,9 @@ export function createFilesClient({
   async function authHeaders() {
     const token = await getToken();
     if (!token) throw new Error('files client requires an authenticated user');
-    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
     const appCheckToken = await getAppCheckToken?.();
     if (appCheckToken) {
       headers['X-Firebase-AppCheck'] = appCheckToken;
@@ -68,18 +70,21 @@ export function createFilesClient({
   }
 
   return {
-    async uploadImage(
+    async uploadFile(
       conversationId: string,
       file: File,
     ): Promise<R2StorageDescriptor> {
-      const response = await fetch(`${conversationFilesUrl(conversationId)}/images`, {
-        method: 'POST',
-        headers: {
-          ...(await authHeaders()),
-          'Content-Type': file.type || 'application/octet-stream',
+      const response = await fetch(
+        `${conversationFilesUrl(conversationId)}/images`, // ! TODO: Change endpoint from "images" since this is for all files!
+        {
+          method: 'POST',
+          headers: {
+            ...(await authHeaders()),
+            'Content-Type': file.type || 'application/octet-stream',
+          },
+          body: file,
         },
-        body: file,
-      });
+      );
       if (!response.ok) {
         if (response.status === 401) {
           const detail = await response.text().catch(() => '');
@@ -88,9 +93,9 @@ export function createFilesClient({
             response.status,
             detail,
           );
-          throw new Error(`image upload failed: ${response.status} ${detail}`);
+          throw new Error(`file upload failed: ${response.status} ${detail}`);
         }
-        throw new Error(`image upload failed: ${response.status}`);
+        throw new Error(`file upload failed: ${response.status}`);
       }
 
       const body = (await response.json()) as Partial<UploadResponse>;
@@ -99,7 +104,7 @@ export function createFilesClient({
         typeof body.bucket !== 'string' ||
         typeof body.key !== 'string'
       ) {
-        throw new Error('image upload returned invalid storage metadata');
+        throw new Error('file upload returned invalid storage metadata');
       }
       return {
         provider: 'r2',
@@ -113,10 +118,13 @@ export function createFilesClient({
       storage: R2StorageDescriptor,
       signal?: AbortSignal,
     ) {
-      const response = await fetch(conversationFileObjectUrl(conversationId, storage), {
-        headers: await authHeaders(),
-        signal,
-      });
+      const response = await fetch(
+        conversationFileObjectUrl(conversationId, storage),
+        {
+          headers: await authHeaders(),
+          signal,
+        },
+      );
       if (!response.ok) {
         if (response.status === 401) {
           const detail = await response.text().catch(() => '');
@@ -125,19 +133,22 @@ export function createFilesClient({
             response.status,
             detail,
           );
-          throw new Error(`image download failed: ${response.status} ${detail}`);
+          throw new Error(`file download failed: ${response.status} ${detail}`);
         }
-        throw new Error(`image download failed: ${response.status}`);
+        throw new Error(`file download failed: ${response.status}`);
       }
 
       return URL.createObjectURL(await response.blob());
     },
 
     async deleteFile(conversationId: string, storage: R2StorageDescriptor) {
-      const response = await fetch(conversationFileObjectUrl(conversationId, storage), {
-        method: 'DELETE',
-        headers: await authHeaders(),
-      });
+      const response = await fetch(
+        conversationFileObjectUrl(conversationId, storage),
+        {
+          method: 'DELETE',
+          headers: await authHeaders(),
+        },
+      );
       if (!response.ok && response.status !== 404) {
         if (response.status === 401) {
           const detail = await response.text().catch(() => '');

--- a/src/stores/conversation-activity.test.js
+++ b/src/stores/conversation-activity.test.js
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../auth/index.js', () => ({
+  getLoggedInUserId: vi.fn(),
+  getLoggedInUserToken: vi.fn(),
+}));
+vi.mock('./conversations-client', () => ({ getConversationsClient: vi.fn() }));
+vi.mock('../realtime/user-mailbox', () => ({
+  subscribeToUserMailbox: vi.fn(),
+}));
+vi.mock('../infra/hangvidu-api-url', () => ({
+  getHangViduApiBaseUrl: vi.fn(),
+}));
+
+import { getLastReadAt, markConversationRead } from './conversation-activity';
+
+describe('markConversationRead', () => {
+  beforeEach(() => {
+    const values = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, String(value)),
+    });
+  });
+
+  it('does not move the read timestamp backward', () => {
+    markConversationRead('conversation-1', 2000);
+    markConversationRead('conversation-1', 1000);
+
+    expect(getLastReadAt('conversation-1')).toBe(2000);
+  });
+});

--- a/src/stores/conversation-activity.test.js
+++ b/src/stores/conversation-activity.test.js
@@ -19,9 +19,14 @@ vi.mock('../infra/hangvidu-api-url', () => ({
   getHangViduApiBaseUrl: vi.fn(),
 }));
 
+import { getLoggedInUserId } from '../auth/index.js';
+import { getConversationsClient } from './conversations-client';
 import {
+  conversationActivity,
   getLastReadAt,
   markConversationRead,
+  recordConversationActivity,
+  refreshConversationActivity,
   startConversationActivity,
   stopConversationActivity,
 } from './conversation-activity';
@@ -43,6 +48,26 @@ describe('markConversationRead', () => {
     markConversationRead('conversation-1', 1000);
 
     expect(getLastReadAt('conversation-1')).toBe(2000);
+  });
+
+  it('does not overwrite newer live activity with a stale refresh', async () => {
+    vi.mocked(getLoggedInUserId).mockReturnValue('me');
+    vi.mocked(getConversationsClient).mockReturnValue({
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 'conversation-1',
+          kind: 'direct',
+          members: [{ user_id: 'me' }, { user_id: 'peer' }],
+          latest_sent_at: 1000,
+          latest_sender_id: 'peer',
+        },
+      ]),
+    });
+
+    recordConversationActivity('peer', 'conversation-1', 2000, 'me');
+    await refreshConversationActivity();
+
+    expect(conversationActivity().get('peer')?.latestSentAt).toBe(2000);
   });
 
   it('can subscribe again after being stopped', () => {

--- a/src/stores/conversation-activity.test.js
+++ b/src/stores/conversation-activity.test.js
@@ -1,18 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  unsubscribe: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
 vi.mock('../auth/index.js', () => ({
   getLoggedInUserId: vi.fn(),
   getLoggedInUserToken: vi.fn(),
 }));
 vi.mock('./conversations-client', () => ({ getConversationsClient: vi.fn() }));
 vi.mock('../realtime/user-mailbox', () => ({
-  subscribeToUserMailbox: vi.fn(),
+  closeUserMailbox: mocks.close,
+  subscribeToUserMailbox: mocks.subscribe,
 }));
 vi.mock('../infra/hangvidu-api-url', () => ({
   getHangViduApiBaseUrl: vi.fn(),
 }));
 
-import { getLastReadAt, markConversationRead } from './conversation-activity';
+import {
+  getLastReadAt,
+  markConversationRead,
+  startConversationActivity,
+  stopConversationActivity,
+} from './conversation-activity';
 
 describe('markConversationRead', () => {
   beforeEach(() => {
@@ -21,6 +33,9 @@ describe('markConversationRead', () => {
       getItem: (key) => values.get(key) ?? null,
       setItem: (key, value) => values.set(key, String(value)),
     });
+    mocks.subscribe.mockReturnValue(mocks.unsubscribe);
+    stopConversationActivity();
+    vi.clearAllMocks();
   });
 
   it('does not move the read timestamp backward', () => {
@@ -28,5 +43,15 @@ describe('markConversationRead', () => {
     markConversationRead('conversation-1', 1000);
 
     expect(getLastReadAt('conversation-1')).toBe(2000);
+  });
+
+  it('can subscribe again after being stopped', () => {
+    startConversationActivity();
+    stopConversationActivity();
+    startConversationActivity();
+
+    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
+    expect(mocks.close).toHaveBeenCalledOnce();
+    expect(mocks.subscribe).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -1,0 +1,127 @@
+// Conversation-list activity: drives MRU reorder + the unread badge.
+//
+// Two inputs, one reactive map keyed by the OTHER participant's uid (DMs):
+//   - seed: GET /conversations once on start (and on demand), carrying each
+//     conversation's latest message time + sender.
+//   - live: the per-user mailbox pushes an `activity` envelope on every message
+//     to a conversation you're in (see shared/call-mailbox/protocol). For a DM
+//     the envelope only reaches the *other* member, so senderId is exactly the
+//     participant we key on.
+//
+// Read state (lastReadAt) is per-device localStorage for now; markConversationRead
+// bumps a version signal so the unread derivation re-runs without a refetch.
+//
+// MINIMAL SPIKE (verify-then-refine): opens its own mailbox socket separate from
+// CallService's — a second per-user connection to the same DO. Consolidate to one
+// shared mailbox subscription in the refine pass.
+
+import { createSignal } from 'solid-js';
+import { getLoggedInUserId, getLoggedInUserToken } from '../auth/index.js';
+import { getConversationsClient } from './conversations-client';
+import { createMailboxChannel } from '../realtime/mailbox-channel';
+import { getHangViduApiBaseUrl } from '../infra/hangvidu-api-url';
+
+export interface ParticipantActivity {
+  conversationId: string;
+  latestSentAt: number;
+  latestSenderId: string | null;
+}
+
+const [activity, setActivity] = createSignal<Map<string, ParticipantActivity>>(
+  new Map(),
+);
+const [readVersion, setReadVersion] = createSignal(0);
+
+/** Reactive: participant uid -> latest activity. Read in useContacts. */
+export const conversationActivity = activity;
+/** Reactive tick: bumped on markConversationRead so unread re-derives. */
+export const readStateVersion = readVersion;
+
+// ── per-device read state ────────────────────────────────────────────────────
+const readKey = (conversationId: string) => `hangvidu:lastRead:${conversationId}`;
+
+export function getLastReadAt(conversationId: string): number {
+  try {
+    return Number(localStorage.getItem(readKey(conversationId))) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function markConversationRead(conversationId: string): void {
+  try {
+    localStorage.setItem(readKey(conversationId), String(Date.now()));
+  } catch {
+    // localStorage unavailable: read state is best-effort.
+  }
+  setReadVersion((v) => v + 1);
+}
+
+// ── seed + live wiring ───────────────────────────────────────────────────────
+function upsert(participantId: string, next: ParticipantActivity): void {
+  setActivity((prev) => {
+    const cur = prev.get(participantId);
+    if (cur && cur.latestSentAt >= next.latestSentAt) return prev; // older: ignore
+    return new Map(prev).set(participantId, next);
+  });
+}
+
+/** Refetch the current activity snapshot (seed). */
+export async function refreshConversationActivity(): Promise<void> {
+  const me = getLoggedInUserId();
+  if (!me) {
+    setActivity(new Map());
+    return;
+  }
+  try {
+    const conversations = await getConversationsClient().list();
+    const map = new Map<string, ParticipantActivity>();
+    for (const c of conversations) {
+      if (c.kind !== 'direct') continue; // contacts list is DMs only for now
+      const other = c.members.find((m) => m.user_id !== me);
+      if (!other) continue;
+      map.set(other.user_id, {
+        conversationId: c.id,
+        latestSentAt: c.latest_sent_at ?? c.updated_at,
+        latestSenderId: c.latest_sender_id ?? null,
+      });
+    }
+    setActivity(map);
+  } catch (error) {
+    console.warn('[conversation-activity] seed failed', error);
+  }
+}
+
+let started = false;
+
+/** Idempotent: seed once + open the live mailbox subscription. */
+export function startConversationActivity(): void {
+  if (started) return;
+  started = true;
+
+  void refreshConversationActivity();
+
+  const channel = createMailboxChannel({
+    baseUrl: getHangViduApiBaseUrl(),
+    getToken: getLoggedInUserToken,
+  });
+  channel.onEnvelope((envelope) => {
+    if (envelope.t !== 'activity') return; // ignore call invites/responses
+    // DM: the envelope reaches only the other member, so senderId IS the
+    // participant this row is keyed on.
+    upsert(envelope.senderId, {
+      conversationId: envelope.conversationId,
+      latestSentAt: envelope.sentAt,
+      latestSenderId: envelope.senderId,
+    });
+  });
+
+  // Cheap liveness for anything missed while disconnected (seed is authoritative).
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        void refreshConversationActivity();
+      }
+    });
+  }
+}

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -47,9 +47,18 @@ export function getLastReadAt(conversationId: string): number {
   }
 }
 
-export function markConversationRead(conversationId: string): void {
+/**
+ * Mark read up to `latestSentAt` — the SERVER timestamp of the newest seen
+ * message. Must be server-clock, not Date.now(): unread compares against
+ * server-stamped message times, so a client clock running ahead of the server
+ * would otherwise suppress every later message's badge.
+ */
+export function markConversationRead(
+  conversationId: string,
+  latestSentAt: number,
+): void {
   try {
-    localStorage.setItem(readKey(conversationId), String(Date.now()));
+    localStorage.setItem(readKey(conversationId), String(latestSentAt));
   } catch {
     // localStorage unavailable: read state is best-effort.
   }

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -102,6 +102,8 @@ export async function refreshConversationActivity(): Promise<void> {
   }
   try {
     const conversations = await getConversationsClient().list();
+    if (getLoggedInUserId() !== me) return;
+
     const map = new Map<string, ParticipantActivity>();
     for (const c of conversations) {
       if (c.kind !== 'direct') continue; // contacts list is DMs only for now
@@ -113,7 +115,15 @@ export async function refreshConversationActivity(): Promise<void> {
         latestSenderId: c.latest_sender_id ?? null,
       });
     }
-    setActivity(map);
+    setActivity((current) => {
+      for (const [participantId, existing] of current) {
+        const fetched = map.get(participantId);
+        if (fetched && existing.latestSentAt > fetched.latestSentAt) {
+          map.set(participantId, existing);
+        }
+      }
+      return map;
+    });
   } catch (error) {
     console.warn('[conversation-activity] seed failed', error);
   }

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -11,14 +11,13 @@
 // Read state (lastReadAt) is per-device localStorage for now; markConversationRead
 // bumps a version signal so the unread derivation re-runs without a refetch.
 //
-// MINIMAL SPIKE (verify-then-refine): opens its own mailbox socket separate from
-// CallService's — a second per-user connection to the same DO. Consolidate to one
-// shared mailbox subscription in the refine pass.
+// Live push rides the user's shared mailbox socket (subscribeToUserMailbox), the
+// same connection CallService uses — no second per-user socket.
 
 import { createSignal } from 'solid-js';
 import { getLoggedInUserId, getLoggedInUserToken } from '../auth/index.js';
 import { getConversationsClient } from './conversations-client';
-import { createMailboxChannel } from '../realtime/mailbox-channel';
+import { subscribeToUserMailbox } from '../realtime/user-mailbox';
 import { getHangViduApiBaseUrl } from '../infra/hangvidu-api-url';
 
 export interface ParticipantActivity {
@@ -66,6 +65,20 @@ function upsert(participantId: string, next: ParticipantActivity): void {
   });
 }
 
+/**
+ * Record activity for a DM from the open conversation's message stream. Covers
+ * the sender's OWN send, which never comes back over the mailbox (the server
+ * fans `activity` to other members only). `participantId` is the peer's uid.
+ */
+export function recordConversationActivity(
+  participantId: string,
+  conversationId: string,
+  latestSentAt: number,
+  latestSenderId: string | null,
+): void {
+  upsert(participantId, { conversationId, latestSentAt, latestSenderId });
+}
+
 /** Refetch the current activity snapshot (seed). */
 export async function refreshConversationActivity(): Promise<void> {
   const me = getLoggedInUserId();
@@ -101,20 +114,23 @@ export function startConversationActivity(): void {
 
   void refreshConversationActivity();
 
-  const channel = createMailboxChannel({
-    baseUrl: getHangViduApiBaseUrl(),
-    getToken: getLoggedInUserToken,
-  });
-  channel.onEnvelope((envelope) => {
-    if (envelope.t !== 'activity') return; // ignore call invites/responses
-    // DM: the envelope reaches only the other member, so senderId IS the
-    // participant this row is keyed on.
-    upsert(envelope.senderId, {
-      conversationId: envelope.conversationId,
-      latestSentAt: envelope.sentAt,
-      latestSenderId: envelope.senderId,
-    });
-  });
+  subscribeToUserMailbox(
+    {
+      localUID: getLoggedInUserId(),
+      baseUrl: getHangViduApiBaseUrl(),
+      getToken: getLoggedInUserToken,
+    },
+    (envelope) => {
+      if (envelope.t !== 'activity') return; // ignore call invites/responses
+      // DM: the envelope reaches only the other member, so senderId IS the
+      // participant this row is keyed on.
+      upsert(envelope.senderId, {
+        conversationId: envelope.conversationId,
+        latestSentAt: envelope.sentAt,
+        latestSenderId: envelope.senderId,
+      });
+    },
+  );
 
   // Cheap liveness for anything missed while disconnected (seed is authoritative).
   if (typeof document !== 'undefined') {

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -57,12 +57,14 @@ export function markConversationRead(
   conversationId: string,
   latestSentAt: number,
 ): void {
+  const lastReadAt = getLastReadAt(conversationId);
+  const nextLastReadAt = Math.max(lastReadAt, latestSentAt);
   try {
-    localStorage.setItem(readKey(conversationId), String(latestSentAt));
+    localStorage.setItem(readKey(conversationId), String(nextLastReadAt));
   } catch {
     // localStorage unavailable: read state is best-effort.
   }
-  setReadVersion((v) => v + 1);
+  if (nextLastReadAt !== lastReadAt) setReadVersion((v) => v + 1);
 }
 
 // ── seed + live wiring ───────────────────────────────────────────────────────

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -17,7 +17,10 @@
 import { createSignal } from 'solid-js';
 import { getLoggedInUserId, getLoggedInUserToken } from '../auth/index.js';
 import { getConversationsClient } from './conversations-client';
-import { subscribeToUserMailbox } from '../realtime/user-mailbox';
+import {
+  closeUserMailbox,
+  subscribeToUserMailbox,
+} from '../realtime/user-mailbox';
 import { getHangViduApiBaseUrl } from '../infra/hangvidu-api-url';
 
 export interface ParticipantActivity {
@@ -117,6 +120,25 @@ export async function refreshConversationActivity(): Promise<void> {
 }
 
 let started = false;
+let unsubscribeMailbox: (() => void) | undefined;
+
+function refreshWhenVisible(): void {
+  if (document.visibilityState === 'visible') {
+    void refreshConversationActivity();
+  }
+}
+
+/** Release login-scoped activity state and the shared mailbox. */
+export function stopConversationActivity(): void {
+  unsubscribeMailbox?.();
+  unsubscribeMailbox = undefined;
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', refreshWhenVisible);
+  }
+  closeUserMailbox();
+  started = false;
+  setActivity(new Map());
+}
 
 /** Idempotent: seed once + open the live mailbox subscription. */
 export function startConversationActivity(): void {
@@ -125,7 +147,7 @@ export function startConversationActivity(): void {
 
   void refreshConversationActivity();
 
-  subscribeToUserMailbox(
+  unsubscribeMailbox = subscribeToUserMailbox(
     {
       localUID: getLoggedInUserId(),
       baseUrl: getHangViduApiBaseUrl(),
@@ -145,10 +167,6 @@ export function startConversationActivity(): void {
 
   // Cheap liveness for anything missed while disconnected (seed is authoritative).
   if (typeof document !== 'undefined') {
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        void refreshConversationActivity();
-      }
-    });
+    document.addEventListener('visibilitychange', refreshWhenVisible);
   }
 }

--- a/src/stores/filesStore.ts
+++ b/src/stores/filesStore.ts
@@ -17,18 +17,11 @@ function getFilesClient() {
   }));
 }
 
-export function uploadConversationImage(
-  conversationId: ConversationId,
-  file: File,
-) {
-  return getFilesClient().uploadImage(conversationId, file);
-}
-
 export function uploadConversationFile(
   conversationId: ConversationId,
   file: File,
 ) {
-  return uploadConversationImage(conversationId, file);
+  return getFilesClient().uploadFile(conversationId, file);
 }
 
 export function createConversationFileObjectUrl(


### PR DESCRIPTION
## What

Live contact/conversation-list reorder (MRU) + unread badge, in real time, no reload. Backend-agnostic at the mailbox seam.

## How

- **Push:** on message store, the data worker fans an `activity` envelope to every *other* member over the existing per-user `UserMailbox` DO (no new DO). Client maps it to a reactive `Map<participantUid, activity>`.
- **Seed:** `GET /conversations` returns `latest_sent_at` / `latest_sender_id` for correct first-paint order + unread.
- **Single socket:** `src/realtime/user-mailbox.ts` is a uid-keyed singleton over `createMailboxChannel`; `CallService` and `conversation-activity` both subscribe through it — one WS per user, not two.
- **Sender's own send:** `recordConversationActivity` bumps the open conversation's row from the existing `watchRecentMessages` callback (DM-only, keyed on peer uid), so the sender's list reorders without a refetch.
- **Read-state:** per-device localStorage for now (cross-device is #563).

## Deploy / compat

Wire changes are additive and backward-compatible in either deploy order:
- `t:'activity'` envelope — old clients reject the unknown type and drop it.
- `latest_sent_at` / `latest_sender_id` — additive seed fields; client falls back to `updated_at`. No D1 schema change (seed uses subqueries).

## Verification

- `tsc --noEmit` clean; `call-service` unit tests pass.
- Spike behavior verified in-browser via `pnpm dev:local` (two users, one DM): send from one, other's list reorders + badges live with no conversation open.

## Deferred (flagged in code + handoff, not blockers)

- Groups (live path is DM-only)
- `call-mailbox` protocol rename to a general per-user event channel
- Server N+1 in seed (two subqueries/conversation)
- Cross-device read-state (#563)
- Activity stops after logout/user-switch until reload (latched start)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversation list now updates in real time for MRU ordering and unread badges (no page reload), using live DM activity.

* **Improvements**
  * Unread tracking for DMs is now driven by the latest-message timestamp, and conversations are marked as read only while the conversation panel is visible.
  * File uploads now support all file types with a unified size limit and expanded file-route handling (including more consistent messaging).

* **Bug Fixes**
  * Real-time updates now propagate to all conversation members, keeping MRU/unread badges consistent across participants, including improved “latest” tie handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->