### PR TITLE
Clean up activity and file compatibility seams

### DIFF
--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
   }),
   respondToIncomingCallInvite: vi.fn(),
   sendOutgoingCallInvite: vi.fn(),
-  onCalleeResponse: vi.fn((_calleeId, callback) => {
+  cancelOutgoingCall: vi.fn(),
+  onCalleeResponse: vi.fn((callback) => {
     mocks.responseCallback = callback;
     return vi.fn();
   }),
@@ -74,6 +75,7 @@ describe('CallHandshakeController', () => {
       onIncomingCall: mocks.onIncomingCall,
       respondToIncomingCallInvite: mocks.respondToIncomingCallInvite,
       sendOutgoingCallInvite: mocks.sendOutgoingCallInvite,
+      cancelOutgoingCall: mocks.cancelOutgoingCall,
       onCalleeResponse: mocks.onCalleeResponse,
       ackCallResponse: mocks.ackCallResponse,
     };

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -191,43 +191,40 @@ export class CallHandshakeController {
 
     let responseReceived = false;
     this.unsubCalleeResponse?.();
-    this.unsubCalleeResponse = svc.onCalleeResponse(
-      calleeId,
-      async (response) => {
-        if (!response || response.roomId !== roomId) return;
-        responseReceived = true;
-        this.clearOutgoingCallTracking();
-        try {
-          if (response.responseType === 'accepted') {
-            await this.enterRoom(
-              response.roomId,
-              localUID,
-              nextOutgoingCall.audioOnly,
-            );
-          } else if (response.responseType === 'busy') {
-            this.setCalleeBusy(true);
-            this.clearCalleeBusyResetTimeout();
-            this.calleeBusyResetTimeoutId = setTimeout(() => {
-              this.calleeBusyResetTimeoutId = undefined;
-              this.setCalleeBusy(false);
-            }, 2_500);
-          }
-        } catch (err) {
-          console.error('Error entering room on callee accept:', err);
-          this.exitActiveRoom();
-        } finally {
-          svc
-            .ackCallResponse(response.roomId)
-            .catch((err) =>
-              console.warn(
-                '[CallHandshake] Failed to acknowledge call response:',
-                err,
-              ),
-            );
-          this.setHandshakeState(null);
+    this.unsubCalleeResponse = svc.onCalleeResponse(async (response) => {
+      if (!response || response.roomId !== roomId) return;
+      responseReceived = true;
+      this.clearOutgoingCallTracking();
+      try {
+        if (response.responseType === 'accepted') {
+          await this.enterRoom(
+            response.roomId,
+            localUID,
+            nextOutgoingCall.audioOnly,
+          );
+        } else if (response.responseType === 'busy') {
+          this.setCalleeBusy(true);
+          this.clearCalleeBusyResetTimeout();
+          this.calleeBusyResetTimeoutId = setTimeout(() => {
+            this.calleeBusyResetTimeoutId = undefined;
+            this.setCalleeBusy(false);
+          }, 2_500);
         }
-      },
-    );
+      } catch (err) {
+        console.error('Error entering room on callee accept:', err);
+        this.exitActiveRoom();
+      } finally {
+        svc
+          .ackCallResponse(response.roomId)
+          .catch((err) =>
+            console.warn(
+              '[CallHandshake] Failed to acknowledge call response:',
+              err,
+            ),
+          );
+        this.setHandshakeState(null);
+      }
+    });
 
     try {
       await svc.sendOutgoingCallInvite({
@@ -325,7 +322,7 @@ export class CallHandshakeController {
       this.setHandshakeState(null);
       this.clearOutgoingCallTracking();
       callService
-        .timeoutOutgoingCall({
+        .cancelOutgoingCall({
           recipientUID: call.calleeId,
           roomId: call.roomId,
         })

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -168,16 +168,8 @@ export class CallService {
     });
   }
 
-  timeoutOutgoingCall(args: {
-    recipientUID: string;
-    roomId: string;
-  }): Promise<void> {
-    return this.cancelOutgoingCall(args);
-  }
-
   /** Responses addressed to this user (the caller); filters expired/stale. */
   onCalleeResponse(
-    _calleeId: string,
     callback: (response: CallResponse | null) => void,
   ): () => void {
     return this.subscribe((envelope) => {
@@ -189,11 +181,6 @@ export class CallService {
 
   ackCallResponse(roomId: string): Promise<void> {
     return this.post('/calls/response/ack', { conversationId: roomId });
-  }
-
-  /** No stored invite to clear in the mailbox model; cancel is explicit. */
-  clearIncomingCallInvite(): Promise<void> {
-    return Promise.resolve();
   }
 
   cleanup(): void {

--- a/src/features/contacts/useContacts.ts
+++ b/src/features/contacts/useContacts.ts
@@ -5,7 +5,6 @@ import { getContactsStore } from '../../stores/contactsStore.js';
 import {
   conversationActivity,
   getLastReadAt,
-  readStateVersion,
   startConversationActivity,
 } from '../../stores/conversation-activity';
 
@@ -25,7 +24,6 @@ export function useContacts() {
     createEffect(() => {
       const me = getLoggedInUserId();
       const activity = conversationActivity(); // reactive: participant uid -> activity
-      readStateVersion(); // re-run when a conversation is marked read
 
       const rows: ContactRow[] = Object.values(contactsState.byId)
         .map((c: any) => {

--- a/src/storage/files/files-client.test.js
+++ b/src/storage/files/files-client.test.js
@@ -134,6 +134,11 @@ describe('files client', () => {
       ),
     ).rejects.toThrow('file upload failed: 401 unauthorized');
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/conversations/conversation-1/files',
+      expect.objectContaining({ method: 'POST' }),
+    );
+
     expect(mocks.reportApiAuthFailure).toHaveBeenCalledWith(
       'files upload conversation-1',
       401,

--- a/src/storage/files/files-client.ts
+++ b/src/storage/files/files-client.ts
@@ -75,7 +75,7 @@ export function createFilesClient({
       file: File,
     ): Promise<R2StorageDescriptor> {
       const response = await fetch(
-        `${conversationFilesUrl(conversationId)}/images`, // ! TODO: Change endpoint from "images" since this is for all files!
+        conversationFilesUrl(conversationId),
         {
           method: 'POST',
           headers: {

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -23,7 +23,7 @@ import {
 } from '../realtime/user-mailbox';
 import { getHangViduApiBaseUrl } from '../infra/hangvidu-api-url';
 
-export interface ParticipantActivity {
+interface ParticipantActivity {
   conversationId: string;
   latestSentAt: number;
   latestSenderId: string | null;
@@ -36,13 +36,11 @@ const [readVersion, setReadVersion] = createSignal(0);
 
 /** Reactive: participant uid -> latest activity. Read in useContacts. */
 export const conversationActivity = activity;
-/** Reactive tick: bumped on markConversationRead so unread re-derives. */
-export const readStateVersion = readVersion;
-
 // ── per-device read state ────────────────────────────────────────────────────
 const readKey = (conversationId: string) => `hangvidu:lastRead:${conversationId}`;
 
 export function getLastReadAt(conversationId: string): number {
+  readVersion();
   try {
     return Number(localStorage.getItem(readKey(conversationId))) || 0;
   } catch {


### PR DESCRIPTION
## Summary

- remove obsolete call-service compatibility methods and unused callback parameter
- hide conversation activity's internal reactivity signal
- switch uploads to the generic `/files` endpoint while retaining the server compatibility route

## Impact

Reduces legacy API surface and removes the client-side image-specific upload path without breaking older deployed clients.

## Checks

- `pnpm ts`
- focused Vitest suite: 17 tests passed
- ESLint on changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file upload endpoint handling.
* **Tests**
  * Expanded test coverage for file upload and call operations.
* **Improvements**
  * Refined call response subscription logic and optimized conversation state tracking for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->