### PR TITLE
Enable message push notifications (sender-triggered)

### DIFF
--- a/backend/firebase/index.js
+++ b/backend/firebase/index.js
@@ -1,5 +1,4 @@
 const { onRequest } = require('firebase-functions/v2/https');
-const { onValueCreated } = require('firebase-functions/v2/database');
 const { initializeApp } = require('firebase-admin/app');
 
 const { REGION } = require('./push-notifications/config');
@@ -58,9 +57,9 @@ exports.deleteAccount = onRequest(
   handleDeleteAccount,
 );
 
-exports.sendMessageNotification = onValueCreated(
+exports.sendMessageNotification = onRequest(
   {
-    ref: '/conversations/{conversationId}/messages/{messageId}',
+    cors: true,
     region: REGION,
   },
   handleSendMessageNotification,

--- a/backend/firebase/push-notifications/register-push-subscription-handler.js
+++ b/backend/firebase/push-notifications/register-push-subscription-handler.js
@@ -10,6 +10,7 @@ const {
 const MAX_PLATFORM_LENGTH = 100;
 const MAX_LANGUAGE_LENGTH = 32;
 const MAX_USER_AGENT_LENGTH = 512;
+const MAX_ORIGIN_LENGTH = 256;
 
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim() !== '';
@@ -50,6 +51,7 @@ function sanitizeDeviceInfo(deviceInfo) {
     platform: sanitizeString(deviceInfo.platform, MAX_PLATFORM_LENGTH),
     userAgent: sanitizeString(deviceInfo.userAgent, MAX_USER_AGENT_LENGTH),
     language: sanitizeString(deviceInfo.language, MAX_LANGUAGE_LENGTH),
+    origin: sanitizeString(deviceInfo.origin, MAX_ORIGIN_LENGTH),
   };
 
   return Object.fromEntries(

--- a/backend/firebase/push-notifications/send-message-notification-handler.js
+++ b/backend/firebase/push-notifications/send-message-notification-handler.js
@@ -1,49 +1,49 @@
+const { verifyAuthHeader } = require('./auth');
 const { buildMessagePayload } = require('./notification-payload-builder');
 const { sendWebPushToUser } = require('./web-push-delivery');
 
 /**
- * RTDB trigger that fans out message push notifications to the other participant.
+ * Authenticated HTTP handler for message push sends. Called by the sender's
+ * client after a message persists (messages live on the D1/Worker spine now, so
+ * the old RTDB trigger no longer fires). Best-effort: trusts the authenticated
+ * caller and pushes to each provided recipient. Recipient resolution happens
+ * client-side via the conversation's remoteParticipantIds.
  */
-async function handleSendMessageNotification(event) {
-  const message = event.data.val();
-  if (!message || !message.from) return;
-
-  const { conversationId } = event.params;
-  const senderId = message.from;
-  const senderName = message.fromName || 'Someone';
-
-  if (message.type === 'event') {
-    return;
-  }
-
-  const userIds = conversationId.split('_');
-  const recipientId = userIds.find((id) => id !== senderId);
-
-  if (!recipientId) {
-    console.warn('[Push-msg] Could not determine recipient from', conversationId);
-    return;
-  }
-
-  const text = typeof message.text === 'string' ? message.text.trim() : '';
-  const fileLabel = message.type === 'file' ? 'Sent a file' : '';
-  const previewSource = text || fileLabel;
-  const preview =
-    previewSource.length > 50
-      ? previewSource.substring(0, 47) + '...'
-      : previewSource;
-
+async function handleSendMessageNotification(req, res) {
   try {
-    await sendWebPushToUser(
-      recipientId,
-      buildMessagePayload({
-        conversationId,
-        senderId,
-        senderName,
-        messagePreview: preview,
-      }),
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method not allowed' });
+    }
+
+    await verifyAuthHeader(req);
+
+    const { recipientIds, conversationId, senderId, senderName, messagePreview } =
+      req.body || {};
+    if (!Array.isArray(recipientIds) || recipientIds.length === 0) {
+      return res.status(400).json({ error: 'Missing recipientIds' });
+    }
+
+    const payload = buildMessagePayload({
+      conversationId,
+      senderId,
+      senderName,
+      messagePreview,
+    });
+
+    await Promise.all(
+      recipientIds.map((userId) =>
+        sendWebPushToUser(userId, payload).catch((error) => {
+          console.error('[Push-msg] delivery failed for', userId, error);
+        }),
+      ),
     );
+
+    return res.json({ success: true });
   } catch (error) {
-    console.error('[Push-msg] Error sending message notification:', error);
+    console.error('[Push] Error sending message notification:', error);
+    return res
+      .status(error.statusCode || 500)
+      .json({ error: error.message || 'Internal server error' });
   }
 }
 

--- a/backend/firebase/push-notifications/send-message-notification-handler.js
+++ b/backend/firebase/push-notifications/send-message-notification-handler.js
@@ -5,9 +5,9 @@ const { sendWebPushToUser } = require('./web-push-delivery');
 /**
  * Authenticated HTTP handler for message push sends. Called by the sender's
  * client after a message persists (messages live on the D1/Worker spine now, so
- * the old RTDB trigger no longer fires). Best-effort: trusts the authenticated
- * caller and pushes to each provided recipient. Recipient resolution happens
- * client-side via the conversation's remoteParticipantIds.
+ * the old RTDB trigger no longer fires). Best-effort: binds the sender to the
+ * authenticated caller and pushes to each provided recipient. Recipient
+ * resolution happens client-side via the conversation's remoteParticipantIds.
  */
 async function handleSendMessageNotification(req, res) {
   try {
@@ -15,23 +15,30 @@ async function handleSendMessageNotification(req, res) {
       return res.status(405).json({ error: 'Method not allowed' });
     }
 
-    await verifyAuthHeader(req);
+    const authenticatedUid = await verifyAuthHeader(req);
 
     const { recipientIds, conversationId, senderId, senderName, messagePreview } =
       req.body || {};
-    if (!Array.isArray(recipientIds) || recipientIds.length === 0) {
+    if (senderId && senderId !== authenticatedUid) {
+      return res.status(403).json({ error: 'Forbidden: sender mismatch' });
+    }
+
+    const uniqueRecipientIds = Array.isArray(recipientIds)
+      ? [...new Set(recipientIds)].filter(Boolean)
+      : [];
+    if (uniqueRecipientIds.length === 0) {
       return res.status(400).json({ error: 'Missing recipientIds' });
     }
 
     const payload = buildMessagePayload({
       conversationId,
-      senderId,
+      senderId: authenticatedUid,
       senderName,
       messagePreview,
     });
 
     await Promise.all(
-      recipientIds.map((userId) =>
+      uniqueRecipientIds.map((userId) =>
         sendWebPushToUser(userId, payload).catch((error) => {
           console.error('[Push-msg] delivery failed for', userId, error);
         }),

--- a/backend/firebase/push-notifications/web-push-delivery.js
+++ b/backend/firebase/push-notifications/web-push-delivery.js
@@ -14,8 +14,18 @@ const PUSH_TTL_SECONDS = {
   default: 60,
 };
 
+// User-visible, time-sensitive pushes that must wake the device immediately even
+// in Doze. Normal-urgency pushes are deferred to a Doze maintenance window (or
+// dropped past TTL), which is why messages were unreliable on Android while calls
+// were fine. missed_call is a deferrable follow-up, so it stays normal.
+const HIGH_URGENCY_TYPES = new Set(['incoming_call', 'message']);
+
 function getPushTtlSeconds(type) {
   return PUSH_TTL_SECONDS[type] || PUSH_TTL_SECONDS.default;
+}
+
+function getPushUrgency(type) {
+  return HIGH_URGENCY_TYPES.has(type) ? 'high' : 'normal';
 }
 
 /**
@@ -68,7 +78,7 @@ async function sendWebPushToUser(userId, payload) {
       try {
         await webpush.sendNotification(value.subscription, payloadJson, {
           TTL: getPushTtlSeconds(payload.data?.type),
-          urgency: isIncomingCallType(payload.data?.type) ? 'high' : 'normal',
+          urgency: getPushUrgency(payload.data?.type),
           topic:
             isIncomingCallType(payload.data?.type) &&
             payload.data?.notificationId

--- a/src/features/messaging-next/ConversationPanel.tsx
+++ b/src/features/messaging-next/ConversationPanel.tsx
@@ -579,6 +579,7 @@ export default function ConversationPanel(props: ConversationPanelProps) {
     store,
     actions,
     getSenderName: getUserName,
+    getRecipientIds: () => props.selection?.remoteParticipantIds ?? [],
   });
 
   function persistReaction(

--- a/src/features/messaging-next/tests/use-conversation.test.js
+++ b/src/features/messaging-next/tests/use-conversation.test.js
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createConversationActions } from '../conversation.actions.js';
 import { createConversationState } from '../conversation.state.js';
+
+const pushMocks = vi.hoisted(() => ({
+  sendMessageNotification: vi.fn(),
+}));
+
+vi.mock('../../push-notifications/index.js', () => ({
+  getPushNotifications: () => ({
+    sendMessageNotification: pushMocks.sendMessageNotification,
+  }),
+}));
+
 import {
   loadConversationHistory,
   useConversation,
@@ -22,6 +33,38 @@ function envelope(overrides) {
 }
 
 describe('messaging-next useConversation', () => {
+  it('snapshots push recipients before persistence and isolates push failures', async () => {
+    const store = createConversationState();
+    const actions = createConversationActions(store);
+    actions.startConversation({ conversationId: 'conversation-1' }, 'me');
+    actions.setDraft('hello');
+    const callOrder = [];
+    const repository = {
+      createMessageId: () => 'reserved-1',
+      send: vi.fn(() => {
+        callOrder.push('send');
+        return { id: 'reserved-1', sentAt: 10 };
+      }),
+    };
+    pushMocks.sendMessageNotification.mockImplementationOnce(() => {
+      throw new Error('push unavailable');
+    });
+
+    const result = await useConversation({
+      repository,
+      store,
+      actions,
+      getRecipientIds: () => {
+        callOrder.push('recipients');
+        return ['user-a'];
+      },
+    }).send();
+
+    expect(callOrder).toEqual(['recipients', 'send']);
+    expect(result).toBe(true);
+    expect(store.state.messages[0].status).toBe('sent');
+  });
+
   it('loads message history in chronological order regardless of repository order', async () => {
     const repository = {
       loadMessages: () => [

--- a/src/features/messaging-next/use-conversation.ts
+++ b/src/features/messaging-next/use-conversation.ts
@@ -17,12 +17,15 @@ import type {
 import type { ConversationStateStore } from './conversation.state.js';
 import type { ConversationActions } from './conversation.actions.js';
 import { sortMessagesBySentAt } from './message-ordering.js';
+import { getPushNotifications } from '../push-notifications/index.js';
 
 type UseConversationOptions = {
   repository: MessageRepository;
   store: ConversationStateStore;
   actions: ConversationActions;
   getSenderName?: () => string | null | undefined;
+  /** Recipient user ids for best-effort message push (persistent sends only). */
+  getRecipientIds?: () => UserId[];
   /** Optional datachannel transport for private mode. Without it, private sends fail. */
   privateTransport?: PrivateMessageTransport;
 };
@@ -117,6 +120,7 @@ export function useConversation({
   store,
   actions,
   getSenderName,
+  getRecipientIds,
   privateTransport,
 }: UseConversationOptions) {
   const { state } = store;
@@ -234,6 +238,21 @@ export function useConversation({
           payload,
         });
         actions.markSent(tempId, saved.id);
+
+        const recipientIds = getRecipientIds?.() ?? [];
+        if (recipientIds.length > 0) {
+          const messageText =
+            payload.type === 'text'
+              ? payload.text
+              : payload.text || 'Sent a file';
+          void getPushNotifications()?.sendMessageNotification({
+            recipientIds,
+            conversationId,
+            senderId: myUserId,
+            senderName,
+            messageText,
+          });
+        }
         return true;
       }
     } catch {

--- a/src/features/messaging-next/use-conversation.ts
+++ b/src/features/messaging-next/use-conversation.ts
@@ -205,6 +205,17 @@ export function useConversation({
     actions.clearDraft();
     actions.setSending(true);
 
+    let recipientIds: UserId[] = [];
+    if (transportMode !== 'private') {
+      try {
+        recipientIds = getRecipientIds?.() ?? [];
+      } catch (error) {
+        console.warn('[conversation] failed to resolve push recipients', error);
+      }
+    }
+
+    let sent = false;
+
     try {
       if (transportMode === 'private') {
         if (!privateTransport) {
@@ -226,7 +237,7 @@ export function useConversation({
         };
         privateTransport.send(JSON.stringify(envelope));
         actions.markSent(tempId, tempId);
-        return true;
+        sent = true;
       } else {
         const saved = await repository.send({
           messageId: tempId,
@@ -238,29 +249,33 @@ export function useConversation({
           payload,
         });
         actions.markSent(tempId, saved.id);
-
-        const recipientIds = getRecipientIds?.() ?? [];
-        if (recipientIds.length > 0) {
-          const messageText =
-            payload.type === 'text'
-              ? payload.text
-              : payload.text || 'Sent a file';
-          void getPushNotifications()?.sendMessageNotification({
-            recipientIds,
-            conversationId,
-            senderId: myUserId,
-            senderName,
-            messageText,
-          });
-        }
-        return true;
+        sent = true;
       }
     } catch {
       actions.markFailed(tempId);
-      return false;
     } finally {
       actions.setSending(false);
     }
+
+    if (!sent) return false;
+    if (recipientIds.length > 0) {
+      const messageText =
+        payload.type === 'text'
+          ? payload.text
+          : payload.text || 'Sent a file';
+      try {
+        void getPushNotifications()?.sendMessageNotification({
+          recipientIds,
+          conversationId,
+          senderId: myUserId,
+          senderName,
+          messageText,
+        });
+      } catch (error) {
+        console.warn('[conversation] failed to enqueue message push', error);
+      }
+    }
+    return true;
   }
 
   return { send, handleIncomingPrivateData };

--- a/src/features/push-notifications/__tests__/push-event-handler.test.js
+++ b/src/features/push-notifications/__tests__/push-event-handler.test.js
@@ -25,63 +25,20 @@ import { handlePushEvent } from '../sw/push-event-handler.js';
 
 describe('handlePushEvent', () => {
   let showNotification;
-  let matchAll;
 
   beforeEach(() => {
     showNotification = vi.fn().mockResolvedValue(undefined);
-    matchAll = vi.fn().mockResolvedValue([]);
 
     globalThis.self = {
       registration: {
         showNotification,
       },
-      clients: {
-        matchAll,
-      },
     };
   });
 
-  it('suppresses native notification display when a focused visible app client exists', async () => {
-    matchAll.mockResolvedValueOnce([
-      {
-        focused: true,
-        visibilityState: 'visible',
-        url: TEST_APP_URL,
-      },
-    ]);
-
-    const event = {
-      data: {
-        json: () => ({
-          title: 'Incoming call',
-          body: 'Caller is ringing',
-          data: {
-            type: 'incoming_call',
-            roomId: 'room-1',
-            targetUserId: 'target-user',
-          },
-        }),
-      },
-    };
-
-    await handlePushEvent(event);
-
-    expect(matchAll).toHaveBeenCalledWith({
-      type: 'window',
-      includeUncontrolled: true,
-    });
-    expect(showNotification).not.toHaveBeenCalled();
-  });
-
-  it('shows the native notification when no focused visible app client exists', async () => {
-    matchAll.mockResolvedValueOnce([
-      {
-        focused: false,
-        visibilityState: 'hidden',
-        url: TEST_APP_URL,
-      },
-    ]);
-
+  // Always shows — no foreground suppression. Skipping showNotification under
+  // userVisibleOnly burns Chrome's silent-push budget and throttles delivery.
+  it('always shows the native notification, even with a focused visible client', async () => {
     const event = {
       data: {
         json: () => ({

--- a/src/features/push-notifications/__tests__/push-notifications.browser.test.js
+++ b/src/features/push-notifications/__tests__/push-notifications.browser.test.js
@@ -136,6 +136,13 @@ describe('PushNotifications', () => {
     expect(controller.getPermissionState()).toBe('granted');
   });
 
+  it('rejects message notifications without sender and conversation ids', async () => {
+    await expect(
+      controller.sendMessageNotification({ recipientIds: ['user-a'] }),
+    ).resolves.toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('enables notifications by registering the current subscription', async () => {
     await controller.initialize();
     const result = await controller.enable();

--- a/src/features/push-notifications/push-notifications.js
+++ b/src/features/push-notifications/push-notifications.js
@@ -432,14 +432,36 @@ export class PushNotifications {
   }
 
   /**
-   * Message push delivery remains backend-owned in V1.
-   * App code should not call this method as a real send path.
+   * Sends a message push to each recipient via the authenticated cloud function.
+   * Best-effort, fire-and-forget from the sender's client. Recipients come from
+   * the conversation's remoteParticipantIds.
    */
-  async sendMessageNotification(_targetUserId, _messageData) {
-    console.warn(
-      '[Push Notifications] Message notifications are not implemented in this phase',
-    );
-    return false;
+  async sendMessageNotification(messageData) {
+    const { recipientIds, conversationId, ...rest } = messageData || {};
+
+    if (!this.options.enableMessageNotifications) {
+      return false;
+    }
+    if (!Array.isArray(recipientIds) || recipientIds.length === 0) {
+      return false;
+    }
+
+    try {
+      const formatted = await this.formatMessageNotification(rest);
+      return await callCloudFunction('sendMessageNotification', {
+        recipientIds,
+        conversationId,
+        senderId: rest.senderId,
+        senderName: formatted.senderName,
+        messagePreview: formatted.messageText,
+      });
+    } catch (error) {
+      console.error(
+        '[Push Notifications] Failed to send message notification:',
+        error,
+      );
+      return false;
+    }
   }
 
   /**
@@ -643,6 +665,7 @@ export class PushNotifications {
         platform: navigator.platform || 'unknown',
         userAgent: navigator.userAgent,
         language: navigator.language,
+        origin: window.location.origin,
       },
     });
   }

--- a/src/features/push-notifications/push-notifications.js
+++ b/src/features/push-notifications/push-notifications.js
@@ -757,6 +757,18 @@ export const initPushNotifications = async (options = {}) => {
         dispatchCommand('cmd:app-notifications:show:enable-push');
       }
     });
+
+    // The SW re-subscribes on pushsubscriptionchange but can't authenticate to the
+    // backend itself; it pings us to re-register the new endpoint via enable().
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener('message', (event) => {
+        if (event.data?.type === 'PUSH_SUBSCRIPTION_CHANGED') {
+          instance.enable().catch((e) => {
+            console.warn('[Push Notifications] re-register failed:', e);
+          });
+        }
+      });
+    }
   }
 
   return instance;

--- a/src/features/push-notifications/push-notifications.js
+++ b/src/features/push-notifications/push-notifications.js
@@ -445,6 +445,14 @@ export class PushNotifications {
     if (!Array.isArray(recipientIds) || recipientIds.length === 0) {
       return false;
     }
+    if (
+      typeof conversationId !== 'string' ||
+      !conversationId.trim() ||
+      typeof rest.senderId !== 'string' ||
+      !rest.senderId.trim()
+    ) {
+      return false;
+    }
 
     try {
       const formatted = await this.formatMessageNotification(rest);

--- a/src/features/push-notifications/sw/notification-presentation.js
+++ b/src/features/push-notifications/sw/notification-presentation.js
@@ -85,6 +85,10 @@ export function buildNotificationPresentation(payload, baseUrl) {
       data,
       tag,
       requireInteraction: isIncomingCallType(data.type),
+      // Re-alert (sound/vibrate/heads-up) when a tagged notification is replaced.
+      // Without this, the 2nd+ message from the same sender (same tag) updates
+      // silently on Android even on an Alerting channel.
+      renotify: true,
       actions,
       vibrate: getVibrationPattern(data.type),
     },

--- a/src/features/push-notifications/sw/notification-presentation.js
+++ b/src/features/push-notifications/sw/notification-presentation.js
@@ -83,12 +83,13 @@ export function buildNotificationPresentation(payload, baseUrl) {
       icon: iconUrl,
       badge: iconUrl,
       data,
-      tag,
-      requireInteraction: isIncomingCallType(data.type),
+      requireInteraction:
+        isIncomingCallType(data.type) || data.type === 'message', // ! TEMP requireInteraction on 'message' until Android issues resolved // TODO: Reconsider when working
+      // tag, // ! TEMP disable tag  until Android issues resolved // TODO: Reconsider when working
       // Re-alert (sound/vibrate/heads-up) when a tagged notification is replaced.
       // Without this, the 2nd+ message from the same sender (same tag) updates
       // silently on Android even on an Alerting channel.
-      renotify: true,
+      // renotify: true, // ! TEMP disable tag  until Android issues resolved // TODO: Reconsider when working
       actions,
       vibrate: getVibrationPattern(data.type),
     },

--- a/src/features/push-notifications/sw/push-event-handler.js
+++ b/src/features/push-notifications/sw/push-event-handler.js
@@ -12,23 +12,14 @@ function parsePushPayload(event) {
 }
 
 /**
- * Returns a foreground app client that should suppress native push display.
- */
-async function findFocusedVisibleWindowClient() {
-  const clients = await self.clients.matchAll({
-    type: 'window',
-    includeUncontrolled: true,
-  });
-
-  return (
-    clients.find(
-      (client) => client?.focused && client?.visibilityState === 'visible',
-    ) || null
-  );
-}
-
-/**
  * Service-worker push entrypoint for native notification presentation.
+ *
+ * Always shows the notification — no foreground suppression. Under
+ * userVisibleOnly, skipping showNotification consumes Chrome's per-origin
+ * silent-push budget, which eventually throttles/stops delivery (a prime suspect
+ * for notifications "suddenly stopping" on Android).
+ * ponytail: if foreground de-dup is wanted later, do it server-side (skip the
+ * push when the recipient has a live ConversationChannel socket), not here.
  */
 export async function handlePushEvent(event) {
   const payload = parsePushPayload(event);
@@ -36,11 +27,6 @@ export async function handlePushEvent(event) {
     payload,
     import.meta.env.BASE_URL,
   );
-
-  const focusedVisibleClient = await findFocusedVisibleWindowClient();
-  if (focusedVisibleClient) {
-    return;
-  }
 
   try {
     await self.registration.showNotification(

--- a/src/sw.js
+++ b/src/sw.js
@@ -45,6 +45,45 @@ self.addEventListener('push', (event) => {
 });
 self.addEventListener('notificationclick', handleNotificationClickEvent);
 
+// The browser can rotate/expire the push subscription (common on Android over
+// time). Without re-subscribing, delivery silently stops until the next app open
+// re-registers — a prime suspect for notifications "suddenly stopping".
+// Re-subscribe immediately so the browser-side subscription persists, then ping
+// any open client to re-register the new endpoint via the authenticated path
+// (the SW has no Firebase token of its own). With no client open, the next app
+// open self-heals through ensureEnabledIfGranted.
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  return Uint8Array.from(raw, (char) => char.charCodeAt(0));
+}
+
+self.addEventListener('pushsubscriptionchange', (event) => {
+  const vapidKey = import.meta.env.VITE_PUSH_VAPID_KEY;
+  event.waitUntil(
+    (async () => {
+      if (vapidKey) {
+        try {
+          await self.registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(vapidKey),
+          });
+        } catch (error) {
+          console.error('[SW] pushsubscriptionchange re-subscribe failed', error);
+        }
+      }
+      const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of clients) {
+        client.postMessage({ type: 'PUSH_SUBSCRIPTION_CHANGED' });
+      }
+    })(),
+  );
+});
+
 // ============================================================================
 // MESSAGE HANDLING FROM MAIN THREAD
 // ============================================================================


### PR DESCRIPTION
## What

Message push notifications never worked: the `sendMessageNotification` Firebase function was an RTDB `onValueCreated` trigger on `/conversations/{id}/messages/{messageId}`, but messages moved to the D1/Worker spine, so that path no longer fires.

This converts it to an authenticated HTTP function called from the sender's client right after a persistent send — mirroring the existing call-notification flow.

## Changes

- **`send-message-notification-handler.js`**: RTDB trigger -> authenticated `onRequest`. Takes `{recipientIds, conversationId, senderId, senderName, messagePreview}`, pushes to each recipient via the existing `sendWebPushToUser` + `buildMessagePayload`. Drops the broken `conversationId.split('_')` recipient guess.
- **`index.js`**: `sendMessageNotification` export `onValueCreated` -> `onRequest`.
- **`push-notifications.js`**: replaces the no-op `sendMessageNotification` stub with a real cloud-function call; reuses `formatMessageNotification` (privacy mode + truncation).
- **`use-conversation.ts`**: adds a `getRecipientIds` seam; fires the push fire-and-forget after a successful **persistent** send only (private/datachannel sends skip it). Wrapped so push failures never affect message delivery.
- **`ConversationPanel.tsx`**: passes `selection.remoteParticipantIds` as recipients.
- **deviceInfo `origin`**: subscriptions now record `window.location.origin` so old-origin installs (web.app / firebaseapp.com vs hangvidu.com) are queryable going forward.

## Deploy notes

- Function trigger type changes background -> HTTP. Firebase rejects in-place conversion: run `firebase functions:delete sendMessageNotification --region europe-west1 --force` once, then deploy. The old trigger was dead, so deletion is safe.
- **Sender-triggered**: the client must run this build to fire pushes; deploying only the function does nothing on its own.
- Recipient SW + subscription store are unchanged (message-type handling already shipped).

## Known limitations (deferred to the planned refactor)

- Sender-client-triggered: a push may not fire if the sender closes the tab immediately after sending (calls have the same property).
- No conversation-membership check in the handler; trusts the authenticated caller, same as the call handler.
- File messages preview as "Sent a file" with no per-type richness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated, best-effort “sent-message” push notifications sent to conversation recipients.
  * Added automatic re-subscription for Web Push when `pushsubscriptionchange` occurs.
  * Captures and sanitizes an additional device origin during push subscription registration.
* **Bug Fixes**
  * Web push notifications are now always displayed (foreground suppression removed).
* **Refactor**
  * Moved sent-message notification delivery from database events to authenticated HTTPS requests.
  * Updated web-push urgency mapping for message/incoming-call notifications.
* **Tests**
  * Added/updated unit coverage for recipient resolution and push notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->