### PR TITLE
Fix stale architecture docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ docs/misc/
 docs/WIP_Architecture/REFERENCE_WebDevSimplified.md
 docs/WIP_Architecture/references/solidjs.llms.txt
 database.rules.TODO.md
+src/shared/events/STALE?_WIP_EVENT_DRIVEN_STANDARDIZATION_DOCS/
 
 # Scripts
 scripts/migrate-usersbyemail-display-name-to-user-name.js

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Peer-to-peer video chat app with text messaging and synced media sharing capabil
 
 ## Usage
 
-1. Login via Google
+1. Login
 2. Click "Add Contacts" button in top bar
 3. Send invite link to add contacts and/or import your Google contacts and select bulk invite
 4. Video call, send messages and watch videos with your contacts

--- a/docs/WIP_Architecture/NAMING.md
+++ b/docs/WIP_Architecture/NAMING.md
@@ -2,9 +2,10 @@
 
 ## Files
 
-- State file: `<module>-state.js`.
-- Never use the word **store** for in-memory state. `store` is reserved for persistence (`contacts-store`, `message-store`).
-- Module barrel: `src/<module>/index.js`.
+- `src/stores/` holds in-memory Solid reactive state — name files `<x>Store.ts` (`contactsStore.ts`, `filesStore.ts`).
+- `src/storage/` holds persistence — name files `<x>-repository` / `<x>-adapter`, never "store".
+- In-memory module state observed via the event bus → `<module>-state.js`.
+- Module barrel: `src/<module>/index.{js,ts}`.
 
 ## Events
 

--- a/docs/WIP_Architecture/README.md
+++ b/docs/WIP_Architecture/README.md
@@ -2,25 +2,13 @@
 
 Where to find each rule category. All docs use bullet lists, no long prose.
 
-| File                    | Covers                                                              |
-| ----------------------- | ------------------------------------------------------------------- |
-| [`NAMING.md`](./NAMING.md)             | File names, event names, payload shapes                  |
-| [`STRUCTURE.md`](./STRUCTURE.md)       | Folder layout, where files live, barrel exports          |
-| [`STATE_RULES.md`](./STATE_RULES.md)   | In-memory state pattern (`*-state.js`)                   |
-| [`SOLID_UI_STATE_RULES.md`](./SOLID_UI_STATE_RULES.md) | Solid UI-only reactive state in `src/components/` |
-| [`MIGRATE_COMPONENT_TO_SOLIDJS.md`](./MIGRATE_COMPONENT_TO_SOLIDJS.md) | Minimal checklist for migrating one UI surface to Solid |
-| [`EVENTS.md`](./EVENTS.md)             | Event bus usage, single-bus rule                         |
-| [`LINT_ENFORCEMENT.md`](./LINT_ENFORCEMENT.md) | What is enforced in lint today                   |
+| File                             | Covers                                                   |
+| -------------------------------- | -------------------------------------------------------- |
+| [`NAMING.md`](./NAMING.md)       | File names, event names, payload shapes                  |
+| [`STRUCTURE.md`](./STRUCTURE.md) | Folder layout, layers, where files live, barrel exports  |
+| [`STATE_RULES.md`](./STATE_RULES.md) | In-memory state pattern (`*-state.js`)               |
+| [`EVENTS.md`](./EVENTS.md)       | Event bus usage, single-bus rule                         |
+
+Layer import rules are enforced by [`eslint.boundaries.config.js`](../../eslint.boundaries.config.js) — that config is the source of truth for the allow-table.
 
 Each doc ends with an **Under Consideration** section for open questions. Nothing there is binding yet.
-
-## Supporting material
-
-| Folder              | Contains                                       |
-| ------------------- | ---------------------------------------------- |
-| `handoffs/`         | Narrative logs of in-flight rollouts           |
-| `audit/`            | Point-in-time codebase audits                  |
-| `lint/`             | Generated boundary reports                     |
-| `references/`       | External docs and inspirations                 |
-
-Legacy WIP docs (`WIP_HANGVIDU_ARCHITECTURE.md`, `WIP_HANGVIDU_REFERENCE_ARCHITECTURE.md`) will be updated to align with these files.

--- a/docs/WIP_Architecture/STATE_RULES.md
+++ b/docs/WIP_Architecture/STATE_RULES.md
@@ -11,12 +11,16 @@ See also: [`NAMING.md`](./NAMING.md), [`STRUCTURE.md`](./STRUCTURE.md), [`EVENTS
 
 ## When to use a dedicated state file
 
-A `src/<module>/<module>-state.js` file is **optional**. Use one only when:
+**Default: a Solid store** (`createStore`) is the reactive in-memory mirror —
+either in `src/stores/` (`contactsStore.ts`) or inside the module for
+feature-local state. Read it directly or via a `use<X>()` hook. Most modules need
+nothing more.
 
-- ≥1 non-Solid consumer must observe changes via the event bus, **or**
+A `src/<module>/<module>-state.js` file is the **exception**, used only when:
+
+- ≥1 non-Solid consumer must observe changes via the event bus (currently only
+  `auth`), **or**
 - the module owns coordinating behavior beyond mirroring storage into a reactive store.
-
-When the only consumers are Solid surfaces in the same feature, a Solid store (`createStore`) inside the module is sufficient — it is the reactive in-memory mirror. Read it directly or via a `use<X>()` hook.
 
 ## Shape (when a dedicated state file is used)
 

--- a/docs/WIP_Architecture/STATE_RULES.md
+++ b/docs/WIP_Architecture/STATE_RULES.md
@@ -2,10 +2,10 @@
 
 Pattern for module state that other modules observe (`isLoggedIn`, `isInCall`, `contactsById`, …).
 
-This file is for domain/module state only.
-Solid UI-only reactive state in `src/components/` is covered by [`SOLID_UI_STATE_RULES.md`](./SOLID_UI_STATE_RULES.md).
+This file is for domain/module state only. Solid reactive stores live in
+`src/stores/` and are mirrors over the persistence/realtime layers.
 
-See also: [`NAMING.md`](./NAMING.md), [`STRUCTURE.md`](./STRUCTURE.md), [`EVENTS.md`](./EVENTS.md), [`LINT_ENFORCEMENT.md`](./LINT_ENFORCEMENT.md).
+See also: [`NAMING.md`](./NAMING.md), [`STRUCTURE.md`](./STRUCTURE.md), [`EVENTS.md`](./EVENTS.md).
 
 ---
 
@@ -56,10 +56,10 @@ It exposes:
 
 | Module    | Shape                                  | Notes                                                              |
 | --------- | -------------------------------------- | ------------------------------------------------------------------ |
-| auth      | dedicated `auth-state.js`              | non-Solid consumers subscribe to `evt:auth:session:*`              |
-| contacts  | Solid store in `contacts-store.ts`     | Solid-only consumers; no `evt:contacts:state:changed`              |
-| messaging | —                                      |                                                                    |
-| call      | —                                      |                                                                    |
+| auth           | dedicated `auth-state.js`                  | non-Solid consumers subscribe to `evt:auth:session:*`         |
+| contacts       | Solid store in `stores/contactsStore.ts`   | Solid-only consumers; no `evt:contacts:state:changed`         |
+| messaging-next | —                                          |                                                              |
+| call           | —                                          |                                                              |
 
 ## Migration notes
 

--- a/docs/WIP_Architecture/STRUCTURE.md
+++ b/docs/WIP_Architecture/STRUCTURE.md
@@ -2,70 +2,74 @@
 
 ## Layers
 
-Import rules between layers are enforced by `eslint.boundaries.config.js`; the
-full allow-table lives in [`BOUNDARY_MAP.md`](BOUNDARY_MAP.md).
-The two foundational layers:
+Import rules between layers are enforced by `eslint.boundaries.config.js` — that
+config is the source of truth for the allow-table. The enforced element types and
+their direction of allowed imports:
 
-- **`src/lib/`** — the bottom layer: framework-agnostic primitives with **zero
-  app knowledge** (e.g. `event-emitter/`, `utils/`, `media/`). Importable by any
-  layer; may only import from `lib` itself. Think "could be published to npm".
-- **`src/shared/`** — app-aware cross-cutting code that knows HangVidU concepts
-  (canonical event names, i18n, invite/room/conversation helpers). May import
-  only `shared` and `lib`.
+| Layer (dir)        | Role                                                                                   | May import                                                        |
+| ------------------ | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `src/lib/`         | Framework-agnostic primitives, **zero app knowledge** (`event-emitter/`, `media/`, `utils/`). "Could be published to npm." | `lib` only                                                       |
+| `src/shared/`      | App-aware cross-cutting code that knows HangVidU concepts (`events/`, `i18n/`, `p2p-context`, `utils/`). | `shared`, `lib`                                                 |
+| `src/infra/`       | External-SDK wiring: Firebase init, App Check, RTDB client, Sentry.                    | `infra`, `lib`                                                   |
+| `src/storage/`     | Durable persistence ports (`contacts/`, `conversations/`, `files/`, `user/`). D1 + R2 spine; RTDB for contacts/profile/presence (migrating). | `storage`, `shared`, `lib`, `infra`                             |
+| `src/realtime/`    | Ephemeral coordination (WebRTC signaling, conversation channel, user mailbox). Backed by Cloudflare Durable Objects in `backend/cloudflare/`. | `realtime`, `shared`, `lib`, `infra`, `auth`                   |
+| `src/stores/`      | Solid reactive mirrors over storage/realtime (`contactsStore`, `filesStore`, `selectedConversationStore`, …). | `stores`, `auth`, `shared`, `lib`, `storage`, `realtime`, `infra`, `feature` |
+| `src/auth/`        | Session/auth state and helpers.                                                        | `auth`, `shared`, `lib`, `infra`, `components`                  |
+| `src/features/<x>/`| Feature modules. Each has a barrel, optional `components/`, and optional `setup()`.    | `auth`, `shared`, `lib`, `feature`, `components`, `infra`, `stores`, `realtime` |
+| `src/components/`  | App-level + shared/primitive UI (`app/`, `base-legacy/`, `dialogs/`, `media/`). **Not** feature UI. | `components`, `auth`, `shared`, `lib`                          |
+| `src/app/`         | Composition/orchestration root (`MainContent`, `auth-orchestration`).                  | `app`, `auth`, `stores`, `feature`, `components`, `shared`, `lib` |
 
 Rule of thumb for placing a util: if it has no app/domain knowledge and no
 imports outside `lib`, it belongs in `src/lib/utils/`; otherwise `src/shared/utils/`.
 
-Two sibling infrastructure layers sit below features, splitting state by lifetime:
+`storage` and `realtime` are siblings split by data lifetime: persistence
+(durable) vs ephemeral coordination. Both are backend-agnostic behind their ports;
+features consume realtime directly and persistence via `stores`.
 
-- **`src/storage/`** — persistence (durable data: contacts, messages, user). Backed by RTDB.
-- **`src/realtime/`** — ephemeral coordination (WebRTC signaling; later media-sync). Backed by a Cloudflare Durable Object (`workers/signaling/`). Holds the DO transport, wire protocol, and `P2PRoomSignaling` adapters behind one barrel.
+## Bootstrap
 
-Both are backend-agnostic behind their ports; features import them (realtime directly, storage via `stores`).
+There is **no `setup/` layer**. App startup lives in:
+
+- `src/main.tsx` — entry point: mounts `App.tsx`, runs each feature's `setup()`
+  export, and `wireAuthReactions()`; tears them down on cleanup.
+- `src/App.tsx` — the SolidJS root component (providers + `MainContent`).
+- `src/app/` — composition/orchestration that wires domain events into UI
+  (`auth-orchestration.js`, `MainContent.tsx`).
+- `src/features/<x>/index` — each feature exposes an optional `setup()` for its
+  own cross-feature wiring (e.g. `contacts`, `presence`, `notifications`, `pwa`).
 
 ## Module layout
 
-- Every module has one barrel: `src/<module>/index.js` (or `index.ts`).
-- **Cross-feature** imports go through the barrel. Same-feature subpath imports (e.g. helpers/components reaching into siblings inside `src/features/<x>/`) are allowed.
-- Tests live in `src/<module>/tests/`.
+- Every module has one barrel: `src/<module>/index.{js,ts}`.
+- **Cross-feature** imports go through the barrel. Same-feature subpath imports
+  (helpers/components reaching into siblings inside `src/features/<x>/`) are allowed.
+- Tests live next to the file under test, or in `src/<module>/tests/` for
+  module-root domain tests.
 
 ## UI layer layout
 
-- `src/App.jsx` is the SolidJS root component.
-- `src/mount-app.jsx` is the imperative mount/cleanup surface called by the bootstrap sequence.
-- `src/components/` holds all Solid UI.
-- `src/components/` may import `auth`, `feature`, and `shared` — but **not** `setup`. UI composes over data/events; bridges live in `setup/`.
-- `src/components/` is **not** a second domain layer. Domain logic stays in the owning module.
-
-### `src/components/` structure
-
-| Subpath                      | Rule                                                                                                                                 | Examples                                                                |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| `components/*.jsx`           | Generic primitives. **No** imports from `features/*`. Eventually absorbs `shared/components/base/`.                                  | `Button`, `Dialog`, `Toast`, `Icon` (none yet; seed on first migration) |
-| `components/<feature>/*.jsx` | Feature-scoped UI + self-subscribing widgets. May import `features/<feature>/`. Eventually absorbs `features/<feature>/components/`. | `contacts/ContactsList.jsx`, `presence/PresenceIndicator.jsx`           |
-
-Rule of thumb: if a component imports from any `features/<x>/` module, it belongs in `components/<x>/`, not at `components/` top level.
-
-### UI bridges live in `setup/`
-
-Imperative-to-reactive bridges (files that subscribe to events, dispatch commands, or orchestrate modals around service writes) are **not** components. They live in `src/setup/`:
-
-- `setup/setupAppRoot.js` — wires domain events into the Solid UI store.
-- `setup/setupContactsAppBusHandlers.js` — handles `cmd:contacts:*` commands that open UI.
+- Feature UI lives in **`src/features/<feature>/components/`** (e.g.
+  `contacts/components/ContactsList.tsx`, `presence/components/PresenceIndicator.jsx`).
+- `src/components/` holds **app-level and shared/primitive** UI only
+  (`components/app/`, `components/dialogs/`, `components/media/`,
+  `components/base-legacy/`). It must **not** import `features/*`.
+- `src/components/` is **not** a domain layer. Domain logic stays in the owning module.
 
 ### Naming conventions
 
-- **PascalCase `.jsx`** for files that render JSX components (`ContactsList.jsx`, `PresenceIndicator.jsx`).
-- **kebab-case `.js/.jsx`** for bridges, command handlers, and stores-only files (`setupAppRoot.js`, `edit-contact-modal.jsx`).
-- **Dialog vs modal**: `XyzDialog.jsx` is the component; `xyz-modal.jsx` is the imperative `openSolidDialog(...)` bridge that returns a Promise.
-- **Tests colocate** next to the file under test (`ContactsList.test.jsx` next to `ContactsList.jsx`). The `tests/` subfolder convention applies to module-root domain tests, not UI tests.
+- **PascalCase `.tsx`/`.jsx`** for files that render JSX components
+  (`ContactsList.tsx`, `PresenceIndicator.jsx`).
+- **kebab-case** for bridges, command handlers, and stores-only files
+  (`auth-orchestration.js`, `edit-contact-modal.jsx`).
+- **Dialog vs modal**: `XyzDialog.jsx` is the component; `xyz-modal.jsx` is the
+  imperative `openSolidDialog(...)` bridge that returns a Promise.
+- Prefer `.ts`/`.tsx` for new files; existing `.js`/`.jsx` migrate opportunistically.
 
 ## State files
 
 - One `<module>-state.js` per module, at module root.
-- No `state/` subfolder.
-- No split state files within a module. Split the module before splitting state.
-- These rules apply to domain/module state, not Solid UI state in `src/components/`.
+- No `state/` subfolder; no split state files within a module (split the module first).
+- These rules apply to domain/module state, not Solid reactive stores in `src/stores/`.
 
 ## Barrel exports
 
@@ -76,18 +80,13 @@ Imperative-to-reactive bridges (files that subscribe to events, dispatch command
 ## Imports
 
 - `<module>-state.js` is importable only from files inside its own module directory.
-- `<module>-state.js` must not import Firebase, RTDB, or storage layers. State mirrors what the persistence layer feeds it.
-
-## Setup vs main
-
-- `setup/*` is the bootstrap/lifecycle root: startup sequencing, cross-feature command/event wiring, and UI bridges.
-- `src/App.jsx` + `src/components/` form the UI composition root.
-- `main.js` is app-runtime orchestration only, not initialization sequencing.
-- Thin out `main.js` opportunistically as setup modules absorb sequencing.
+- `<module>-state.js` must not import Firebase, RTDB, or storage layers. State
+  mirrors what the persistence layer feeds it.
 
 ---
 
 ## Under Consideration
 
-- Whether service-level writers exported from barrels (e.g., `contactsService.saveContact`) should eventually migrate to `cmd:*` commands, reserving barrel exports for read-only APIs only.
-- Whether non-component DOM utilities in `shared/components/ui/utils/` should move to a non-component path (`shared/dom/`) as primitives migrate into `src/components/`.
+- Whether service-level writers exported from barrels (e.g.,
+  `contactsService.saveContact`) should eventually migrate to `cmd:*` commands,
+  reserving barrel exports for read-only APIs only.

--- a/src/shared/events/DOMAINS.md
+++ b/src/shared/events/DOMAINS.md
@@ -8,20 +8,18 @@ Reference list for the second segment of `<kind>:<domain>:<entity>:<action>`.
 
 ## Distinction
 
-- `notifications`: in-app notification UI and notification-list behavior
+- `app-notifications`: in-app notification UI and notification-list behavior
 - `push`: web push subscription / delivery behavior
 
-Do not use `push` for in-app notification commands, and do not use `notifications`
-for browser push subscription or delivery concerns.
+Do not use `push` for in-app notification commands, and do not use
+`app-notifications` for browser push subscription or delivery concerns.
 
 ## Currently Used `cmd` Domains
 
+- `app-notifications`
 - `auth`
-- `call`
-- `contacts`
 - `dialog`
 - `messaging`
-- `notifications`
 - `push`
 - `user`
 
@@ -29,12 +27,10 @@ for browser push subscription or delivery concerns.
 
 - `auth`
 - `call`
-- `contacts`
+- `media`
 - `messaging`
-- `room`
 
 ## Notes
 
-- `contacts` currently includes room/contact lookup and contact lifecycle facts.
 - `dialog` is the target domain for app-modal state.
-- `room` is currently used only for room lifecycle facts.
+- `media` is currently used only for local-stream lifecycle facts.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture guidance for app structure, state handling, naming, imports, and startup flow.
  * Clarified event domain usage and separated notification-related behavior from push-related behavior.
  * Simplified README usage steps and refreshed WIP architecture references.

* **Chores**
  * Added an ignore rule for a new work-in-progress documentation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->