### PR TITLE
Cross-device unread badge: server-owned read marker (load path)

### DIFF
--- a/backend/cloudflare/migrations/0007_member_last_read.sql
+++ b/backend/cloudflare/migrations/0007_member_last_read.sql
@@ -1,0 +1,5 @@
+-- Per-member, per-conversation read marker. Drives the conversation-list unread
+-- badge cross-device (server-owned, replacing the per-device localStorage value
+-- as the durable source). 0 = never read. Compared against message.created_at,
+-- so it lives in the same server-clock domain.
+ALTER TABLE conversation_members ADD COLUMN last_read_at INTEGER NOT NULL DEFAULT 0;

--- a/backend/cloudflare/schema.snapshot.sql
+++ b/backend/cloudflare/schema.snapshot.sql
@@ -35,6 +35,7 @@ CREATE TABLE conversation_members (
   conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
   user_id         TEXT NOT NULL REFERENCES users(id)         ON DELETE CASCADE,
   joined_at       INTEGER NOT NULL,
+  last_read_at    INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (conversation_id, user_id)
 );
 CREATE INDEX idx_members_user ON conversation_members(user_id);

--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -20,6 +20,7 @@ import {
   loadMessages,
   lookupByEmailHash,
   lookupByHandle,
+  markConversationRead,
   patchContact,
   putContact,
   removeContact,
@@ -486,6 +487,23 @@ export async function handleDataRequest(
   if (request.method === 'GET' && url.pathname === '/conversations') {
     const conversations = await listConversations(env.DB, callerId);
     return json({ conversations }, 200, cors);
+  }
+
+  // PUT /conversations/:id/read -> advance caller's read marker (membership-guarded).
+  // Server-clock authoritative: ignores any client-supplied time so a skewed
+  // client clock can't suppress later messages' badges.
+  const readMatch = url.pathname.match(/^\/conversations\/([^/]+)\/read$/);
+  if (request.method === 'PUT' && readMatch) {
+    const conversationId = decodeURIComponent(readMatch[1]);
+    const lastReadAt = await markConversationRead(
+      env.DB,
+      conversationId,
+      callerId,
+      Date.now(),
+    );
+    // null = no member row updated: hide existence (same as GET).
+    if (lastReadAt === null) return json({ error: 'not_found' }, 404, cors);
+    return json({ lastReadAt }, 200, cors);
   }
 
   // GET /conversations/:id -> conversation + members (membership-guarded)

--- a/backend/cloudflare/src/data/repo.ts
+++ b/backend/cloudflare/src/data/repo.ts
@@ -930,6 +930,29 @@ export async function isMember(
   return row != null;
 }
 
+/**
+ * Advance the caller's read marker for a conversation to `readAt` (server clock).
+ * MAX() guards against regressing on out-of-order/concurrent reads. Returns the
+ * resulting marker, or null if the user is not a member (no row updated).
+ */
+export async function markConversationRead(
+  db: D1Database,
+  conversationId: string,
+  userId: string,
+  readAt: number,
+): Promise<number | null> {
+  const row = await db
+    .prepare(
+      `UPDATE conversation_members
+          SET last_read_at = MAX(last_read_at, ?)
+        WHERE conversation_id = ? AND user_id = ?
+      RETURNING last_read_at`,
+    )
+    .bind(readAt, conversationId, userId)
+    .first<{ last_read_at: number }>();
+  return row ? row.last_read_at : null;
+}
+
 export async function getConversation(
   db: D1Database,
   conversationId: string,
@@ -966,14 +989,19 @@ export async function listConversations(
     members: MemberRow[];
     latest_sent_at: number | null;
     latest_sender_id: string | null;
+    last_read_at: number;
   })[]
 > {
   // latest_* feed the conversation list's MRU sort + unread badge (last message
-  // time + who sent it). ponytail: per-conversation correlated subqueries —
-  // fine at current scale; fold into a grouped join if the list grows large.
+  // time + who sent it). last_read_at is the caller's own read marker (the JOIN
+  // is on m.user_id = caller), so the client can compute unread server-side
+  // rather than from per-device localStorage. ponytail: per-conversation
+  // correlated subqueries — fine at current scale; fold into a grouped join if
+  // the list grows large.
   const { results } = await db
     .prepare(
       `SELECT c.*,
+              m.last_read_at AS last_read_at,
               (SELECT msg.created_at FROM messages msg
                 WHERE msg.conversation_id = c.id
                 ORDER BY msg.created_at DESC, msg.id DESC LIMIT 1) AS latest_sent_at,
@@ -990,6 +1018,7 @@ export async function listConversations(
       ConversationRow & {
         latest_sent_at: number | null;
         latest_sender_id: string | null;
+        last_read_at: number;
       }
     >();
 
@@ -1004,6 +1033,7 @@ export async function listConversations(
       updated_at: c.updated_at,
       latest_sent_at: c.latest_sent_at,
       latest_sender_id: c.latest_sender_id,
+      last_read_at: c.last_read_at,
       members: await getMembers(db, c.id),
     })),
   );

--- a/backend/cloudflare/src/index.ts
+++ b/backend/cloudflare/src/index.ts
@@ -27,7 +27,7 @@ const DATA_PATHS = [
   /^\/referrals\/connect$/,
   /^\/conversations$/,
   /^\/conversations\/resolve-direct$/,
-  /^\/conversations\/[^/]+\/(?:messages|ws)$/,
+  /^\/conversations\/[^/]+\/(?:messages|ws|read)$/,
   /^\/conversations\/[^/]+\/messages\/[^/]+\/reaction$/,
   /^\/conversations\/[^/]+$/,
 ];

--- a/backend/cloudflare/test/data-repo.test.ts
+++ b/backend/cloudflare/test/data-repo.test.ts
@@ -8,6 +8,7 @@ import {
   isMember,
   listConversations,
   loadMessages,
+  markConversationRead,
   resolveOrCreateDirect,
   setMyReaction,
   upsertUser,
@@ -233,5 +234,29 @@ describe('listConversations', () => {
     const [conversation] = await listConversations(db, 'user-a');
     expect(conversation.latest_sent_at).toBe(2000);
     expect(conversation.latest_sender_id).toBe('user-b');
+  });
+
+  it("surfaces the caller's own read marker, defaulting to 0", async () => {
+    const convoId = await resolveOrCreateDirect(db, 'user-a', 'user-b', 1000);
+    const [fresh] = await listConversations(db, 'user-a');
+    expect(fresh.last_read_at).toBe(0);
+
+    await markConversationRead(db, convoId, 'user-a', 5000);
+    const [aView] = await listConversations(db, 'user-a');
+    const [bView] = await listConversations(db, 'user-b');
+    expect(aView.last_read_at).toBe(5000); // per-member: only the reader advances
+    expect(bView.last_read_at).toBe(0);
+  });
+});
+
+describe('markConversationRead', () => {
+  it('never regresses the marker and returns null for non-members', async () => {
+    const convoId = await resolveOrCreateDirect(db, 'user-a', 'user-b', 1000);
+
+    expect(await markConversationRead(db, convoId, 'user-a', 5000)).toBe(5000);
+    // Older read must not move the marker backwards.
+    expect(await markConversationRead(db, convoId, 'user-a', 3000)).toBe(5000);
+    // Non-member: no row updated.
+    expect(await markConversationRead(db, convoId, 'user-c', 9000)).toBeNull();
   });
 });

--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -332,6 +332,47 @@ describe('auth + membership guard on GET /conversations/:id/messages', () => {
   });
 });
 
+describe('PUT /conversations/:id/read round-trip', () => {
+  it('persists the marker and surfaces it on GET /conversations for the reader only', async () => {
+    const convoId = await resolveOrCreateDirect(env.DB, 'user-a', 'user-b', 1000);
+    await insertMessage(env.DB, convoId, 'm1', 'user-b', 'text', 'hi', null, 2000);
+    const aToken = await signToken(validClaims('user-a'));
+    const bToken = await signToken(validClaims('user-b'));
+
+    const put = await jsonPut(`/conversations/${convoId}/read`, aToken, {});
+    expect(put.status).toBe(200);
+    const { lastReadAt } = (await put.json()) as { lastReadAt: number };
+    expect(lastReadAt).toBeGreaterThan(0);
+
+    const listA = await SELF.fetch('https://data/conversations', {
+      headers: { Authorization: `Bearer ${aToken}`, Origin: ORIGIN },
+    });
+    const aBody = (await listA.json()) as {
+      conversations: { id: string; last_read_at: number }[];
+    };
+    expect(aBody.conversations.find((c) => c.id === convoId)?.last_read_at).toBe(
+      lastReadAt,
+    );
+
+    const listB = await SELF.fetch('https://data/conversations', {
+      headers: { Authorization: `Bearer ${bToken}`, Origin: ORIGIN },
+    });
+    const bBody = (await listB.json()) as {
+      conversations: { id: string; last_read_at: number }[];
+    };
+    expect(bBody.conversations.find((c) => c.id === convoId)?.last_read_at).toBe(
+      0,
+    );
+  });
+
+  it('404s a non-member', async () => {
+    const convoId = await resolveOrCreateDirect(env.DB, 'user-a', 'user-b', 1000);
+    const token = await signToken(validClaims('user-c'));
+    const res = await jsonPut(`/conversations/${convoId}/read`, token, {});
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('call cancel mailbox route', () => {
   it('404s when the caller is not a conversation member', async () => {
     const convoId = await resolveOrCreateDirect(env.DB, 'user-a', 'user-b', 1000);

--- a/src/features/conversations/adapters/d1.test.js
+++ b/src/features/conversations/adapters/d1.test.js
@@ -73,4 +73,20 @@ describe('D1 message reactions', () => {
 
     expect(client.setMyReaction).toHaveBeenCalledWith('c1', 'm1', 'laugh');
   });
+
+  it('persists a read marker via the client', async () => {
+    const client = {
+      getUserId: () => 'me',
+      loadMessages: vi.fn(),
+      sendMessage: vi.fn(),
+      setMyReaction: vi.fn(),
+      markRead: vi.fn(async () => {}),
+      subscribe: vi.fn(),
+    };
+    const repository = createD1MessageRepository(client);
+
+    await repository.markConversationRead('c1', 'me');
+
+    expect(client.markRead).toHaveBeenCalledWith('c1');
+  });
 });

--- a/src/features/conversations/adapters/d1.ts
+++ b/src/features/conversations/adapters/d1.ts
@@ -52,6 +52,8 @@ export interface D1MessageClient {
     messageId: string,
     reactionKey: string | null,
   ): Promise<ReactionSummary[]>;
+  /** Advance the caller's server-owned read marker for a conversation. */
+  markRead(conversationId: string): Promise<void>;
   getUserId(): string | null;
   /** Subscribe to live broadcasts for a conversation. Returns unsubscribe. */
   subscribe(
@@ -208,8 +210,12 @@ export function createD1MessageRepository(
       return { id: stored.id, sentAt: stored.sentAt };
     },
 
-    // Read receipts are deferred (decision #5); marking is a no-op for now.
-    markConversationRead() {},
+    // Durable cross-device read marker (#563). The store's local optimistic
+    // clear (conversation-activity) covers the in-tab badge; this persists it
+    // server-side so other devices clear on their next conversation-list load.
+    async markConversationRead(conversationId) {
+      await client.markRead(conversationId);
+    },
 
     async setMyReaction(conversationId, messageId, _userId, reactionKey) {
       await client.setMyReaction(conversationId, messageId, reactionKey);

--- a/src/storage/conversations/data-client.ts
+++ b/src/storage/conversations/data-client.ts
@@ -43,6 +43,9 @@ export interface Conversation {
   // when the conversation has no messages yet.
   latest_sent_at?: number | null;
   latest_sender_id?: string | null;
+  // Caller's own server-owned read marker (present on `list()`); drives the
+  // cross-device unread badge. 0 = never read.
+  last_read_at?: number;
 }
 
 export interface ConversationsClient {
@@ -67,6 +70,8 @@ export interface ConversationsClient {
     messageId: string,
     reactionKey: string | null,
   ): Promise<WireReactionSummary[]>;
+  /** Advance the caller's server-owned read marker; resolves with the new marker. */
+  markRead(conversationId: string): Promise<number>;
 }
 
 export interface ConversationsClientOptions {
@@ -161,6 +166,12 @@ export function createConversationsClient(
         `/conversations/${encodeURIComponent(conversationId)}/messages/${encodeURIComponent(messageId)}/reaction`,
         { reactionKey },
       ).then((r) => r.reactions);
+    },
+    markRead(conversationId) {
+      return request<{ lastReadAt: number }>(
+        'PUT',
+        `/conversations/${encodeURIComponent(conversationId)}/read`,
+      ).then((r) => r.lastReadAt);
     },
   };
 }

--- a/src/stores/conversation-activity.ts
+++ b/src/stores/conversation-activity.ts
@@ -33,6 +33,13 @@ const [activity, setActivity] = createSignal<Map<string, ParticipantActivity>>(
   new Map(),
 );
 const [readVersion, setReadVersion] = createSignal(0);
+// Server-owned read markers (conversationId -> lastReadAt), seeded from
+// GET /conversations. Makes the unread badge cross-device: a read on another
+// device clears here on the next seed. localStorage stays as the optimistic
+// in-tab layer; getLastReadAt returns the max of the two.
+const [serverLastRead, setServerLastRead] = createSignal<Map<string, number>>(
+  new Map(),
+);
 
 /** Reactive: participant uid -> latest activity. Read in useContacts. */
 export const conversationActivity = activity;
@@ -41,11 +48,14 @@ const readKey = (conversationId: string) => `hangvidu:lastRead:${conversationId}
 
 export function getLastReadAt(conversationId: string): number {
   readVersion();
+  const server = serverLastRead().get(conversationId) ?? 0;
+  let local = 0;
   try {
-    return Number(localStorage.getItem(readKey(conversationId))) || 0;
+    local = Number(localStorage.getItem(readKey(conversationId))) || 0;
   } catch {
-    return 0;
+    local = 0;
   }
+  return Math.max(local, server);
 }
 
 /**
@@ -96,6 +106,7 @@ export async function refreshConversationActivity(): Promise<void> {
   const me = getLoggedInUserId();
   if (!me) {
     setActivity(new Map());
+    setServerLastRead(new Map());
     return;
   }
   try {
@@ -103,6 +114,7 @@ export async function refreshConversationActivity(): Promise<void> {
     if (getLoggedInUserId() !== me) return;
 
     const map = new Map<string, ParticipantActivity>();
+    const reads = new Map<string, number>();
     for (const c of conversations) {
       if (c.kind !== 'direct') continue; // contacts list is DMs only for now
       const other = c.members.find((m) => m.user_id !== me);
@@ -112,7 +124,9 @@ export async function refreshConversationActivity(): Promise<void> {
         latestSentAt: c.latest_sent_at ?? c.updated_at,
         latestSenderId: c.latest_sender_id ?? null,
       });
+      reads.set(c.id, c.last_read_at ?? 0);
     }
+    setServerLastRead(reads);
     setActivity((current) => {
       for (const [participantId, existing] of current) {
         const fetched = map.get(participantId);
@@ -146,6 +160,7 @@ export function stopConversationActivity(): void {
   closeUserMailbox();
   started = false;
   setActivity(new Map());
+  setServerLastRead(new Map());
 }
 
 /** Idempotent: seed once + open the live mailbox subscription. */

--- a/src/stores/message-repository.ts
+++ b/src/stores/message-repository.ts
@@ -24,6 +24,9 @@ export function createD1MessageRepositoryFromEnv(): MessageRepository {
       http.sendMessage(conversationId, input),
     setMyReaction: (conversationId, messageId, reactionKey) =>
       http.setMyReaction(conversationId, messageId, reactionKey),
+    markRead: async (conversationId) => {
+      await http.markRead(conversationId);
+    },
     getUserId: getLoggedInUserId,
     subscribe: (conversationId, onEvent) => {
       const channel = createConversationChannel({


### PR DESCRIPTION
Incremental slice of #563. Delivers the most-noticed symptom — open the app on another device and the unread badge is already cleared — without the transport rework.

## What this does
Unread badges were derived from per-device `localStorage` (`hangvidu:lastRead:*`), so a read on device A never reached device B. This adds a durable per-member read marker as the cross-device source of truth, surfaced on the conversation-list load.

## Changes
- **D1**: `conversation_members.last_read_at` (migration `0007`). Per-member, so it's already group-compatible. `listConversations` surfaces the caller's own marker; `markConversationRead` advances it with a `MAX()` guard (never regresses) and returns null for non-members.
- **Worker**: `PUT /conversations/:id/read`, membership-guarded, server-clock authoritative (ignores client-supplied time so a skewed client clock can't suppress later badges). 404 hides non-membership.
- **Client**: `data-client.markRead` + D1 repo seam — the existing `messageRepository.markConversationRead` call (already wired in `ConversationPanel`) now persists. The activity store seeds server markers and `getLastReadAt` returns `max(local, server)`, keeping `localStorage` as the optimistic in-tab layer (instant local clear, server reconciles on next load).

## Deliberately out of scope (deferred to #563/#587)
- **Live** cross-device clearing while both devices are open — needs the conversation channel broadened from `WireMessage`-only to a typed `message | read` stream, best bundled with the per-user activity-stream/transport rework.
- `unreadCount` / `markAllRead` stay local-only (still flagged `// TODO: integrate or remove`).

## Tests
- Backend (`data-repo.test.ts`): marker defaults to 0, is per-member, never regresses, null for non-members.
- Frontend (`d1.test.js`): repo persists the marker via the client.
- `tsc --noEmit` clean both sides; full conversations suite green.

## Deploy note
Apply migration `0007` to dev (`pnpm dev:data`'s local D1) and prod (`hangvidu-data`) before/with deploy — `listConversations` selects `m.last_read_at`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now support cross-device read/unread synchronization.
  * Added an API to mark a conversation as read and return the updated read marker.
  * Conversation lists now include caller-specific read state.
* **Bug Fixes**
  * Read markers no longer regress, keeping unread badges accurate.
  * Non-members can’t update read status (returns not found).
* **Tests**
  * Added coverage for read marker persistence, visibility rules, and non-regression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->