### PR TITLE
Avoid overwriting D1 profiles on login

### DIFF
--- a/src/app/__tests__/auth-orchestration.test.js
+++ b/src/app/__tests__/auth-orchestration.test.js
@@ -114,6 +114,11 @@ describe('wireAuthReactions', () => {
       email: 'ada@example.com',
       photoURL: null,
     };
+    mocks.getPublicUserProfile.mockResolvedValue({
+      displayName: null,
+      photoURL: null,
+      username: null,
+    });
     mocks.ensureHandle.mockResolvedValue({ handle: 'ada', assigned: false });
 
     const teardown = await wireAuthReactions({ lobbyElement });
@@ -125,6 +130,7 @@ describe('wireAuthReactions', () => {
 
     expect(mocks.processReferral).toHaveBeenCalled();
     expect(mocks.hydrateContacts).toHaveBeenCalled();
+    expect(mocks.getPublicUserProfile).toHaveBeenCalledWith(user.uid);
     expect(mocks.savePublicUserProfile).toHaveBeenCalledWith(user);
     // Login guarantees a handle via ensureHandle, then indexes the email→account
     // entry with that handle (replaces the old getPublicUserProfile read).
@@ -133,6 +139,39 @@ describe('wireAuthReactions', () => {
       username: 'ada',
     });
     expect(mocks.setupInviteListener).toHaveBeenCalledWith();
+
+    teardown();
+  });
+
+  it('does not overwrite an existing D1 profile with provider profile data on login', async () => {
+    const { wireAuthReactions } = await import('../auth-orchestration.js');
+    const user = {
+      uid: 'user-1',
+      displayName: 'Kristinn Roach',
+      email: 'crystalquicksand@gmail.com',
+      photoURL: 'https://example.test/google-photo.jpg',
+    };
+    mocks.getPublicUserProfile.mockResolvedValue({
+      displayName: 'Crystal Quicksand',
+      photoURL: null,
+      username: 'crystal_quicksand',
+    });
+    mocks.ensureHandle.mockResolvedValue({
+      handle: 'crystal_quicksand',
+      assigned: false,
+    });
+
+    const teardown = await wireAuthReactions({ lobbyElement: { id: 'lobby' } });
+
+    await mocks.handlers.get('evt:auth:session:logged-in')({
+      state: { user },
+    });
+
+    expect(mocks.savePublicUserProfile).not.toHaveBeenCalled();
+    expect(mocks.ensureHandle).toHaveBeenCalledWith(user);
+    expect(mocks.registerInUserDirectory).toHaveBeenCalledWith(user, {
+      username: 'crystal_quicksand',
+    });
 
     teardown();
   });

--- a/src/app/auth-orchestration.js
+++ b/src/app/auth-orchestration.js
@@ -167,9 +167,13 @@ export function wireAuthReactions() {
             const user = state?.user;
             if (user) {
               try {
-                const profile = await getPublicUserProfile(user.uid);
-                if (!profile?.displayName && !profile?.photoURL) {
-                  await savePublicUserProfile(user);
+                try {
+                  const profile = await getPublicUserProfile(user.uid);
+                  if (!profile?.displayName && !profile?.photoURL) {
+                    await savePublicUserProfile(user);
+                  }
+                } catch (e) {
+                  console.warn('[AUTH] Failed to sync public profile on login:', e);
                 }
                 const { handle } = await ensureHandle(user);
                 // Directory entry is the email→account index; skip when the

--- a/src/app/auth-orchestration.js
+++ b/src/app/auth-orchestration.js
@@ -2,6 +2,7 @@ import { subscribe } from '../shared/events/index.js';
 import { initAuth } from '../auth/index.js';
 import { devDebug } from '../shared/utils/dev/dev-utils.js';
 import {
+  getPublicUserProfile,
   savePublicUserProfile,
   registerInUserDirectory,
   ensureHandle,
@@ -166,10 +167,10 @@ export function wireAuthReactions() {
             const user = state?.user;
             if (user) {
               try {
-                // Serialize: write the profile row, guarantee a handle exists
-                // (auto-assign for accounts without one), then index the
-                // email→account entry with that handle. Each is non-fatal.
-                await savePublicUserProfile(user);
+                const profile = await getPublicUserProfile(user.uid);
+                if (!profile?.displayName && !profile?.photoURL) {
+                  await savePublicUserProfile(user);
+                }
                 const { handle } = await ensureHandle(user);
                 // Directory entry is the email→account index; skip when the
                 // user has no email (e.g. username-only password accounts).


### PR DESCRIPTION
## Summary
- Read the existing D1 profile before seeding provider profile data on login
- Only save Firebase display/photo data when D1 has no profile display/photo yet
- Add a regression test for preserving an existing D1 display name and username

## Validation
- pnpm vitest --run src/app/__tests__/auth-orchestration.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login now preserves an existing public profile instead of overwriting it with newly received account details.
  * Public profile updates are only saved when profile information is missing, reducing unexpected changes after sign-in.
  * Added coverage to ensure the login flow checks for an existing profile before saving and keeps handle/directory updates working as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->