### PR TITLE
Reuse setup helper for contacts and PWA

### DIFF
--- a/src/features/contacts/__tests__/setup.test.js
+++ b/src/features/contacts/__tests__/setup.test.js
@@ -146,6 +146,28 @@ describe('contacts setup', () => {
     expect(mocks.setupInviteListener).not.toHaveBeenCalled();
   });
 
+  it('does not start an invite listener after teardown', async () => {
+    let finishReferral;
+    mocks.processReferral.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishReferral = resolve;
+        }),
+    );
+    const { setup } = await import('../index');
+    const teardown = await setup();
+    mocks.hydrateContacts.mockClear();
+
+    const login = mocks.handlers.get('evt:auth:session:logged-in')();
+    await Promise.resolve();
+    teardown();
+    finishReferral();
+    await login;
+
+    expect(mocks.hydrateContacts).not.toHaveBeenCalled();
+    expect(mocks.setupInviteListener).not.toHaveBeenCalled();
+  });
+
   it('aborts subscriptions on teardown', async () => {
     const { setup } = await import('../index');
     const teardown = await setup();

--- a/src/features/contacts/index.ts
+++ b/src/features/contacts/index.ts
@@ -1,4 +1,5 @@
 import { subscribe } from '../../shared/events/index.js';
+import { createSingleFlightSetup } from '../../shared/utils/create-single-flight-setup.js';
 import {
   captureReferral,
   processReferral,
@@ -6,11 +7,78 @@ import {
 import { setupInviteListener } from './invites/invite-listener.js';
 import { hydrateContacts, resetContacts } from '../../stores/contactsStore.js';
 
-let isReady = false;
-let initPromise: Promise<() => void> | null = null;
-let cleanup: () => void = () => {
-  isReady = false;
-};
+let inviteCleanup: () => void = () => {};
+let authSessionVersion = 0;
+
+function runInviteCleanup() {
+  try {
+    inviteCleanup();
+  } catch (error) {
+    console.warn('[contacts] invite cleanup failed:', error);
+  }
+  inviteCleanup = () => {};
+}
+
+async function handleLoggedIn() {
+  const sessionVersion = ++authSessionVersion;
+  runInviteCleanup();
+  try {
+    await processReferral().catch((e) =>
+      console.warn('[contacts] processReferral failed:', e),
+    );
+    if (sessionVersion !== authSessionVersion) return;
+
+    await hydrateContacts().catch((e) =>
+      console.warn('[contacts] hydrate on login failed:', e),
+    );
+    if (sessionVersion !== authSessionVersion) return;
+
+    const maybeInviteCleanup = setupInviteListener();
+    if (typeof maybeInviteCleanup === 'function') {
+      inviteCleanup = maybeInviteCleanup;
+    }
+  } catch (error) {
+    console.warn('[contacts] logged-in handler failed:', error);
+  }
+}
+
+function handleLoggedOut() {
+  try {
+    authSessionVersion += 1;
+    runInviteCleanup();
+    resetContacts();
+  } catch (error) {
+    console.warn('[contacts] logout teardown failed:', error);
+  }
+}
+
+function stopContacts() {
+  authSessionVersion += 1;
+  runInviteCleanup();
+}
+
+async function hydrateOnReady() {
+  try {
+    await hydrateContacts();
+  } catch (error) {
+    console.warn('[contacts] hydrate on ready failed:', error);
+  }
+}
+
+async function startContacts() {
+  // Anonymous boot: capture referral from URL → localStorage, hydrate guest
+  // contacts. (processReferral applies the captured referral once logged in.)
+  try {
+    await captureReferral();
+  } catch (error) {
+    console.warn('[contacts] captureReferral failed:', error);
+  }
+  try {
+    await hydrateContacts();
+  } catch (error) {
+    console.warn('[contacts] initial hydrate failed:', error);
+  }
+}
 
 /**
  * Setup contract:
@@ -22,106 +90,27 @@ let cleanup: () => void = () => {
  * Owns the contacts reactions to auth lifecycle (hydrate, referrals, invites)
  * plus the anonymous-boot referral capture + initial hydrate.
  */
-export function setup(): Promise<() => void> {
-  if (isReady) {
-    return Promise.resolve(cleanup);
-  }
-  if (initPromise) {
-    return initPromise;
-  }
-
-  initPromise = (async () => {
-    const ac = new AbortController();
-
-    // Per-login-scoped invite listener: replaced on each login, torn down on
-    // logout and on full teardown.
-    let inviteCleanup: () => void = () => {};
-    let authEpoch = 0;
-    const runInviteCleanup = () => {
-      try {
-        inviteCleanup();
-      } catch (error) {
-        console.warn('[contacts] invite cleanup failed:', error);
-      }
-      inviteCleanup = () => {};
-    };
-
+export const setup = createSingleFlightSetup({
+  label: '[contacts]',
+  register: (signal) => {
     subscribe(
       'evt:auth:session:ready',
-      async () => {
-        try {
-          await hydrateContacts();
-        } catch (error) {
-          console.warn('[contacts] hydrate on ready failed:', error);
-        }
-      },
-      { signal: ac.signal },
+      hydrateOnReady,
+      { signal },
     );
 
     subscribe(
       'evt:auth:session:logged-in',
-      async () => {
-        const epoch = ++authEpoch;
-        runInviteCleanup();
-        try {
-          await processReferral().catch((e) =>
-            console.warn('[contacts] processReferral failed:', e),
-          );
-          if (epoch !== authEpoch) return;
-
-          await hydrateContacts().catch((e) =>
-            console.warn('[contacts] hydrate on login failed:', e),
-          );
-          if (epoch !== authEpoch) return;
-
-          const maybeInviteCleanup = setupInviteListener();
-          if (typeof maybeInviteCleanup === 'function') {
-            inviteCleanup = maybeInviteCleanup;
-          }
-        } catch (error) {
-          console.warn('[contacts] logged-in handler failed:', error);
-        }
-      },
-      { signal: ac.signal },
+      handleLoggedIn,
+      { signal },
     );
 
     subscribe(
       'evt:auth:session:logged-out',
-      () => {
-        try {
-          authEpoch += 1;
-          runInviteCleanup();
-          resetContacts();
-        } catch (error) {
-          console.warn('[contacts] logout teardown failed:', error);
-        }
-      },
-      { signal: ac.signal },
+      handleLoggedOut,
+      { signal },
     );
-
-    // Anonymous boot: capture referral from URL → localStorage, hydrate guest
-    // contacts. (processReferral applies the captured referral once logged in.)
-    try {
-      await captureReferral();
-    } catch (error) {
-      console.warn('[contacts] captureReferral failed:', error);
-    }
-    try {
-      await hydrateContacts();
-    } catch (error) {
-      console.warn('[contacts] initial hydrate failed:', error);
-    }
-
-    cleanup = () => {
-      runInviteCleanup();
-      ac.abort();
-      isReady = false;
-    };
-    isReady = true;
-    return cleanup;
-  })().finally(() => {
-    initPromise = null;
-  });
-
-  return initPromise;
-}
+  },
+  start: startContacts,
+  stop: stopContacts,
+});

--- a/src/features/pwa/__tests__/setup.test.js
+++ b/src/features/pwa/__tests__/setup.test.js
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setupUpdateHandler: vi.fn(() => Promise.resolve()),
+  stopUpdateChecks: vi.fn(),
+}));
+
+vi.mock('../update-handlers.js', () => ({
+  setupUpdateHandler: mocks.setupUpdateHandler,
+  stopUpdateChecks: mocks.stopUpdateChecks,
+}));
+
+describe('pwa setup', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('starts update checks once and stops them on teardown', async () => {
+    const { setup } = await import('../index');
+    const teardown = await setup();
+
+    expect(mocks.setupUpdateHandler).toHaveBeenCalledOnce();
+    expect(await setup()).toBe(teardown);
+
+    teardown();
+    expect(mocks.stopUpdateChecks).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/pwa/index.ts
+++ b/src/features/pwa/index.ts
@@ -1,13 +1,8 @@
+import { createSingleFlightSetup } from '../../shared/utils/create-single-flight-setup.js';
 import {
   setupUpdateHandler,
   stopUpdateChecks,
 } from './update-handlers.js';
-
-let isReady = false;
-let initPromise: Promise<() => void> | null = null;
-let cleanup: () => void = () => {
-  isReady = false;
-};
 
 /**
  * Setup contract:
@@ -19,33 +14,8 @@ let cleanup: () => void = () => {
  * new versions (startup check, onNeedRefresh, visibility check, 30-min poll).
  * No-op when VITE_ENABLE_PWA === '0'.
  */
-export function setup(): Promise<() => void> {
-  if (isReady) {
-    return Promise.resolve(cleanup);
-  }
-  if (initPromise) {
-    return initPromise;
-  }
-
-  initPromise = Promise.resolve()
-    .then(async () => {
-      await setupUpdateHandler();
-
-      cleanup = () => {
-        try {
-          stopUpdateChecks();
-        } catch (error) {
-          console.warn('[pwa] cleanup failed:', error);
-        } finally {
-          isReady = false;
-        }
-      };
-      isReady = true;
-      return cleanup;
-    })
-    .finally(() => {
-      initPromise = null;
-    });
-
-  return initPromise;
-}
+export const setup = createSingleFlightSetup({
+  label: '[pwa]',
+  start: setupUpdateHandler,
+  stop: stopUpdateChecks,
+});

--- a/src/shared/utils/create-single-flight-setup.js
+++ b/src/shared/utils/create-single-flight-setup.js
@@ -61,8 +61,13 @@ export function createSingleFlightSetup(options) {
       .then(async () => {
         const ac = new AbortController();
 
-        register?.(ac.signal);
-        await start(ac.signal);
+        try {
+          register?.(ac.signal);
+          await start(ac.signal);
+        } catch (error) {
+          ac.abort();
+          throw error;
+        }
 
         cleanup = () => {
           try {

--- a/src/shared/utils/create-single-flight-setup.js
+++ b/src/shared/utils/create-single-flight-setup.js
@@ -11,8 +11,12 @@
  * @param {object} options
  * @param {string} options.label - log prefix used in teardown warnings,
  *   e.g. `[presence]`.
- * @param {(signal: AbortSignal) => void} options.register - registers
+ * @param {(signal: AbortSignal) => void} [options.register] - registers
  *   handlers/subscriptions against the provided abort signal.
+ * @param {(signal: AbortSignal) => (void|Promise<void>)} [options.start] - runs
+ *   setup work before the setup is marked ready.
+ * @param {() => void} [options.stop] - runs extra teardown work
+ *   before aborting registered handlers.
  * @returns {() => Promise<() => void>} the memoized setup function.
  */
 export function createSingleFlightSetup(options) {
@@ -21,14 +25,22 @@ export function createSingleFlightSetup(options) {
   }
 
   const { label, register } = options;
+  const start = options.start ?? (() => {});
+  const stop = options.stop ?? (() => {});
 
   if (typeof label !== 'string' || label.trim() === '') {
     throw new TypeError(
       'createSingleFlightSetup: label must be a non-empty string',
     );
   }
-  if (typeof register !== 'function') {
+  if (register !== undefined && typeof register !== 'function') {
     throw new TypeError('createSingleFlightSetup: register must be a function');
+  }
+  if (typeof start !== 'function') {
+    throw new TypeError('createSingleFlightSetup: start must be a function');
+  }
+  if (typeof stop !== 'function') {
+    throw new TypeError('createSingleFlightSetup: stop must be a function');
   }
 
   let isReady = false;
@@ -46,12 +58,18 @@ export function createSingleFlightSetup(options) {
     }
 
     initPromise = Promise.resolve()
-      .then(() => {
+      .then(async () => {
         const ac = new AbortController();
 
-        register(ac.signal);
+        register?.(ac.signal);
+        await start(ac.signal);
 
         cleanup = () => {
+          try {
+            stop();
+          } catch (error) {
+            console.warn(`${label} cleanup failed:`, error);
+          }
           ac.abort();
           isReady = false;
         };

--- a/src/shared/utils/create-single-flight-setup.test.js
+++ b/src/shared/utils/create-single-flight-setup.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSingleFlightSetup } from './create-single-flight-setup.js';
+
+describe('createSingleFlightSetup', () => {
+  it('aborts registered handlers when start fails', async () => {
+    const abortHandler = vi.fn();
+    const error = new Error('boom');
+    const setup = createSingleFlightSetup({
+      label: '[test]',
+      register: (signal) => signal.addEventListener('abort', abortHandler),
+      start: () => Promise.reject(error),
+    });
+
+    await expect(setup()).rejects.toBe(error);
+    expect(abortHandler).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add optional start/stop hooks to createSingleFlightSetup
- convert contacts and PWA setup to the shared helper
- add PWA setup coverage and a contacts teardown stale-login guard test

## Review note
- Contacts teardown now increments authSessionVersion before cleaning the invite listener. This intentionally prevents an already-running login handler from starting a new invite listener after setup teardown. Please review that final behavior decision explicitly.

## Tests
- pnpm vitest --run src/features/contacts/__tests__/setup.test.js src/features/pwa/__tests__/setup.test.js src/features/conversations/__tests__/setup.test.js src/features/presence/__tests__/setup.test.js src/features/notifications/__tests__/setup.test.js src/features/push-notifications/__tests__/setup.test.js
- pnpm ts
- git diff --check
- pnpm exec fallow audit --base main --format json --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app startup and session handling so repeated setup calls behave consistently across contacts and PWA features.

* **Bug Fixes**
  * Fixed cases where in-progress contact login work could continue after teardown.
  * Improved cleanup during PWA update checks to avoid duplicate or stale initialization.
  * Added stronger safeguards around setup and teardown behavior for more reliable app lifecycle handling.

* **Tests**
  * Added coverage for teardown behavior and repeated setup calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->