### PR TITLE
Allow PATCH/DELETE in worker CORS preflight

### DIFF
--- a/backend/cloudflare/src/cors.ts
+++ b/backend/cloudflare/src/cors.ts
@@ -23,8 +23,10 @@ export function corsHeaders(
   env: CorsEnv,
 ): Record<string, string> {
   const headers: Record<string, string> = {
-    'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
-    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers':
+      'Authorization, Content-Type, X-Firebase-AppCheck',
+    'Access-Control-Expose-Headers': 'Content-Length, Content-Type, ETag',
     'Access-Control-Max-Age': '86400',
     Vary: 'Origin',
   };

--- a/backend/cloudflare/src/files/handlers.ts
+++ b/backend/cloudflare/src/files/handlers.ts
@@ -1,5 +1,5 @@
 import { authenticate, type Identity } from '../auth';
-import { allowedOrigin } from '../cors';
+import { allowedOrigin, corsHeaders } from '../cors';
 import { isMember } from '../data/repo';
 import type { WorkerEnv } from '../types';
 import type { FileObjectStore } from './file-object-store';
@@ -15,18 +15,6 @@ const IMAGE_UPLOAD_PATH = /^\/conversations\/([^/]+)\/files\/images$/;
 const FILE_UPLOAD_PATH = /^\/conversations\/([^/]+)\/files$/;
 
 const authorizationCache = new Map<string, number>();
-
-function corsHeaders(origin: string): HeadersInit {
-  return {
-    'Access-Control-Allow-Origin': origin,
-    'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
-    'Access-Control-Allow-Headers':
-      'Authorization,Content-Type,X-Firebase-AppCheck',
-    'Access-Control-Expose-Headers': 'Content-Length,Content-Type,ETag',
-    'Access-Control-Max-Age': '86400',
-    Vary: 'Origin',
-  };
-}
 
 function appendVaryOrigin(headers: Headers) {
   const vary = headers.get('Vary');
@@ -50,7 +38,7 @@ function response(
   const headers = new Headers(init.headers);
   const origin = allowedOrigin(request, env);
   if (origin) {
-    for (const [key, value] of Object.entries(corsHeaders(origin))) {
+    for (const [key, value] of Object.entries(corsHeaders(origin, env))) {
       if (key.toLowerCase() === 'vary') continue;
       headers.set(key, value);
     }
@@ -318,7 +306,7 @@ export async function handleFilesRequest(
   const origin = allowedOrigin(request, env);
   if (request.method === 'OPTIONS') {
     if (!origin) return new Response('Forbidden origin', { status: 403 });
-    const headers = new Headers(corsHeaders(origin));
+    const headers = new Headers(corsHeaders(origin, env));
     appendVaryOrigin(headers);
     return new Response(null, { status: 204, headers });
   }

--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -213,7 +213,10 @@ describe('message reactions', () => {
     );
 
     expect(res.status).toBe(204);
-    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('PUT');
+    const allowedMethods = res.headers.get('Access-Control-Allow-Methods');
+    for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(allowedMethods).toContain(method);
+    }
   });
 
   it('persists, hydrates, and broadcasts authoritative reaction counts', async () => {


### PR DESCRIPTION
The shared `cors.ts` advertised only `GET, POST, PUT, OPTIONS`, so browser preflights rejected the contacts routes added with the D1 contacts migration: `PATCH /users/me/contacts/:id` (conversationId cache write) and `DELETE /users/me/contacts/:id` (contact removal). Both failed silently in dev and prod; DELETE is the user-visible one.

- `cors.ts`: add `PATCH, DELETE` to `Access-Control-Allow-Methods`; absorb `X-Firebase-AppCheck` allow-header and `Expose-Headers` from the files handler's list
- `files/handlers.ts`: delete its duplicate local `corsHeaders` and use the shared one, so the two lists can't drift again
- `data-worker.test.ts`: preflight test now asserts all five methods instead of just PUT

All 79 worker tests pass; `tsc --noEmit` clean.