### PR TITLE
Preflight caller media before call invite

### DIFF
--- a/src/components/app/Spinner.tsx
+++ b/src/components/app/Spinner.tsx
@@ -7,6 +7,7 @@ const DEFAULT_SIZE = 64;
 export function Spinner(props: SpinnerProps) {
   return (
     <svg
+      class="spinner"
       width={props.size ?? DEFAULT_SIZE}
       height={props.size ?? DEFAULT_SIZE}
       viewBox="0 0 50 50"
@@ -22,16 +23,7 @@ export function Spinner(props: SpinnerProps) {
         stroke-width="4"
         stroke-linecap="round"
         stroke-dasharray="80 40"
-      >
-        <animateTransform
-          attributeName="transform"
-          type="rotate"
-          from="0 25 25"
-          to="360 25 25"
-          dur="1s"
-          repeatCount="indefinite"
-        />
-      </circle>
+      />
     </svg>
   );
 }

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -289,4 +289,38 @@ describe('CallHandshakeController', () => {
     expect(mocks.onCalleeResponse).not.toHaveBeenCalled();
     expect(p2p.join).not.toHaveBeenCalled();
   });
+
+  it('stops stale caller media when cleanup wins the permission race', async () => {
+    const media = deferred();
+    const stop = vi.fn();
+    mocks.getUserMedia.mockReturnValue(media.promise);
+    const p2p = {
+      join: vi.fn(),
+      close: vi.fn(),
+      state: vi.fn(() => 'idle'),
+      room: vi.fn(),
+    };
+    const controller = new CallHandshakeController({
+      p2p,
+      createSignaling: vi.fn(),
+      getCallerName: () => 'Caller',
+      onStateChange: vi.fn(),
+      onCalleeBusy: vi.fn(),
+    });
+
+    const start = controller.sendOutgoingCallInvite({
+      calleeId: 'callee-id',
+      calleeName: 'Callee',
+      audioOnly: false,
+    });
+    await flushPromises();
+
+    controller.cleanup();
+    media.resolve({ getTracks: () => [{ stop }] });
+    await start;
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(mocks.sendOutgoingCallInvite).not.toHaveBeenCalled();
+    expect(mocks.onCalleeResponse).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   sendIncomingCallPushNotification: vi.fn(),
   sendMissedCallPushNotification: vi.fn(),
   resolveDirectConversationId: vi.fn(),
+  getUserMedia: vi.fn(),
 }));
 
 vi.mock('./call-service.js', () => ({
@@ -68,6 +69,19 @@ describe('CallHandshakeController', () => {
     vi.clearAllMocks();
     mocks.incomingCallback = undefined;
     mocks.responseCallback = undefined;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {
+        mediaDevices: {
+          getUserMedia: mocks.getUserMedia,
+          getSupportedConstraints: () => ({}),
+        },
+        userAgent: '',
+      },
+      configurable: true,
+    });
+    mocks.getUserMedia.mockResolvedValue({
+      getTracks: () => [{ stop: vi.fn() }],
+    });
     const service = {
       onIncomingCall: mocks.onIncomingCall,
       respondToIncomingCallInvite: mocks.respondToIncomingCallInvite,
@@ -247,5 +261,32 @@ describe('CallHandshakeController', () => {
     join.resolve({ roomId: 'room-1', members: ['caller-id'] });
     await response;
     expect(mocks.ackCallResponse).toHaveBeenCalledWith('room-1');
+  });
+
+  it('does not send the invite when caller media permission fails', async () => {
+    mocks.getUserMedia.mockRejectedValue(new Error('camera blocked'));
+    const p2p = {
+      join: vi.fn(),
+      close: vi.fn(),
+      state: vi.fn(() => 'idle'),
+      room: vi.fn(),
+    };
+    const controller = new CallHandshakeController({
+      p2p,
+      createSignaling: vi.fn(),
+      getCallerName: () => 'Caller',
+      onStateChange: vi.fn(),
+      onCalleeBusy: vi.fn(),
+    });
+
+    await controller.sendOutgoingCallInvite({
+      calleeId: 'callee-id',
+      calleeName: 'Callee',
+      audioOnly: false,
+    });
+
+    expect(mocks.sendOutgoingCallInvite).not.toHaveBeenCalled();
+    expect(mocks.onCalleeResponse).not.toHaveBeenCalled();
+    expect(p2p.join).not.toHaveBeenCalled();
   });
 });

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -212,7 +212,9 @@ export class CallHandshakeController {
       this.clearOutgoingCallTracking();
       try {
         if (response.responseType === 'accepted') {
-          this.pendingOutgoingLocalStream = undefined;
+          if (this.pendingOutgoingLocalStream === localStream) {
+            this.pendingOutgoingLocalStream = undefined;
+          }
           await this.enterRoom(
             response.roomId,
             localUID,

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -56,6 +56,7 @@ export class CallHandshakeController {
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
   private pendingOutgoingLocalStream: MediaStream | undefined;
+  private outgoingMediaAttempt = 0;
   private lastBoundUID: string | undefined;
 
   constructor({
@@ -166,6 +167,8 @@ export class CallHandshakeController {
       baseUrl: DATA_URL,
       getToken: getLoggedInUserToken,
     });
+    this.stopPendingOutgoingLocalStream();
+    const mediaAttempt = ++this.outgoingMediaAttempt;
 
     const { calleeId, calleeName, audioOnly } = details;
     const callerName = this.getCallerName();
@@ -192,7 +195,12 @@ export class CallHandshakeController {
 
     let localStream: MediaStream;
     try {
+      if (mediaAttempt !== this.outgoingMediaAttempt) return;
       localStream = await this.getCallLocalStream(audioOnly);
+      if (mediaAttempt !== this.outgoingMediaAttempt) {
+        this.stopMediaStream(localStream);
+        return;
+      }
       this.pendingOutgoingLocalStream = localStream;
     } catch (err) {
       console.error('Error getting caller media before starting call:', err);
@@ -466,6 +474,7 @@ export class CallHandshakeController {
   }
 
   cleanup(): void {
+    this.outgoingMediaAttempt += 1;
     this.unsubscribeIncomingCall?.();
     this.unsubscribeIncomingCall = undefined;
     this.clearOutgoingCallTracking();

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -55,6 +55,7 @@ export class CallHandshakeController {
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
+  private pendingOutgoingLocalStream: MediaStream | undefined;
   private lastBoundUID: string | undefined;
 
   constructor({
@@ -189,6 +190,16 @@ export class CallHandshakeController {
       audioOnly,
     };
 
+    let localStream: MediaStream;
+    try {
+      localStream = await this.getCallLocalStream(audioOnly);
+      this.pendingOutgoingLocalStream = localStream;
+    } catch (err) {
+      console.error('Error getting caller media before starting call:', err);
+      this.alertCallStartFailed();
+      return;
+    }
+
     this.setHandshakeState({ direction: 'outgoing', call: nextOutgoingCall });
     this.setCalleeBusy(false);
     this.scheduleOutgoingCallTimeout(svc, nextOutgoingCall);
@@ -201,21 +212,33 @@ export class CallHandshakeController {
       this.clearOutgoingCallTracking();
       try {
         if (response.responseType === 'accepted') {
+          this.pendingOutgoingLocalStream = undefined;
           await this.enterRoom(
             response.roomId,
             localUID,
             nextOutgoingCall.audioOnly,
+            () => Promise.resolve(localStream),
           );
         } else if (response.responseType === 'busy') {
+          this.stopMediaStream(localStream);
+          if (this.pendingOutgoingLocalStream === localStream) {
+            this.pendingOutgoingLocalStream = undefined;
+          }
           this.setCalleeBusy(true);
           this.clearCalleeBusyResetTimeout();
           this.calleeBusyResetTimeoutId = setTimeout(() => {
             this.calleeBusyResetTimeoutId = undefined;
             this.setCalleeBusy(false);
           }, 2_500);
+        } else {
+          this.stopMediaStream(localStream);
+          if (this.pendingOutgoingLocalStream === localStream) {
+            this.pendingOutgoingLocalStream = undefined;
+          }
         }
       } catch (err) {
         console.error('Error entering room on callee accept:', err);
+        this.stopMediaStream(localStream);
         this.exitActiveRoom();
       } finally {
         svc
@@ -239,6 +262,7 @@ export class CallHandshakeController {
       });
     } catch (err) {
       this.clearOutgoingCallTracking();
+      this.stopPendingOutgoingLocalStream();
       this.setHandshakeState(null);
       console.error('Error sending outgoing call invite:', err);
       this.alertCallStartFailed();
@@ -292,13 +316,7 @@ export class CallHandshakeController {
       peerId: localUserId,
       createSignaling: this.createSignaling,
       getLocalStream:
-        getLocalStream ??
-        (() =>
-          navigator.mediaDevices.getUserMedia({
-            video: audioOnly ? false : getVideoConstraints(),
-            audio:
-              import.meta.env.DEV && !audioOnly ? false : getAudioConstraints(),
-          })),
+        getLocalStream ?? (() => this.getCallLocalStream(audioOnly)),
       memberCapacity,
       dataChannel: true,
       onAlone: (detail) => {
@@ -317,6 +335,23 @@ export class CallHandshakeController {
     return room;
   }
 
+  private getCallLocalStream(audioOnly: boolean): Promise<MediaStream> {
+    return navigator.mediaDevices.getUserMedia({
+      video: audioOnly ? false : getVideoConstraints(),
+      audio: import.meta.env.DEV && !audioOnly ? false : getAudioConstraints(),
+    });
+  }
+
+  private stopMediaStream(stream: MediaStream): void {
+    stream.getTracks().forEach((track) => track.stop());
+  }
+
+  private stopPendingOutgoingLocalStream(): void {
+    if (!this.pendingOutgoingLocalStream) return;
+    this.stopMediaStream(this.pendingOutgoingLocalStream);
+    this.pendingOutgoingLocalStream = undefined;
+  }
+
   private scheduleOutgoingCallTimeout(
     callService: NonNullable<ReturnType<typeof getCallService>>,
     call: pendingOutgoingCall,
@@ -332,6 +367,7 @@ export class CallHandshakeController {
         return;
       this.setHandshakeState(null);
       this.clearOutgoingCallTracking();
+      this.stopPendingOutgoingLocalStream();
       callService
         .cancelOutgoingCall({
           recipientUID: call.calleeId,
@@ -352,6 +388,7 @@ export class CallHandshakeController {
     const svc = getCallService();
     if (!state || state.direction !== 'outgoing' || !svc) return;
     this.clearOutgoingCallTracking();
+    this.stopPendingOutgoingLocalStream();
     this.setHandshakeState(null);
     this.setCalleeBusy(false);
     svc
@@ -431,6 +468,7 @@ export class CallHandshakeController {
     this.unsubscribeIncomingCall = undefined;
     this.clearOutgoingCallTracking();
     this.clearCalleeBusyResetTimeout();
+    this.stopPendingOutgoingLocalStream();
     this.setHandshakeState(null);
     this.setCalleeBusy(false);
     this.p2p.close();

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -23,9 +23,22 @@
   .slide-left,
   .slide-right,
   .auto-animate,
+  .spinner,
   .auto-animate > * {
     transition: none !important;
     animation: none !important;
+  }
+}
+
+.spinner {
+  transform-origin: center;
+  animation: spinner-rotate 1s linear infinite;
+  will-change: transform;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- Request caller camera/mic before sending the outgoing call invite.
- Reuse that preflight stream when the callee accepts, avoiding a second permission prompt.
- Stop the pending caller stream when the call invite fails, is canceled, times out, or is rejected/busy.

## Validation
- `pnpm vitest --run src/features/call/call-handshake-controller.test.js`

Manual browser verification left to the requester.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outgoing call handling so camera/microphone access is requested earlier and cleaned up properly if the call is rejected, times out, is canceled, or fails to start.
  * Prevented call setup from continuing when media access is denied.
  * Ensured local audio/video tracks are stopped when they’re no longer needed, reducing leftover device usage.
* **Tests**
  * Added coverage for media-permission failure during outgoing call setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->