### PR TITLE
Use CSS animation for loading spinner

### DIFF
--- a/src/components/app/Spinner.tsx
+++ b/src/components/app/Spinner.tsx
@@ -7,6 +7,7 @@ const DEFAULT_SIZE = 64;
 export function Spinner(props: SpinnerProps) {
   return (
     <svg
+      class="spinner"
       width={props.size ?? DEFAULT_SIZE}
       height={props.size ?? DEFAULT_SIZE}
       viewBox="0 0 50 50"
@@ -22,16 +23,7 @@ export function Spinner(props: SpinnerProps) {
         stroke-width="4"
         stroke-linecap="round"
         stroke-dasharray="80 40"
-      >
-        <animateTransform
-          attributeName="transform"
-          type="rotate"
-          from="0 25 25"
-          to="360 25 25"
-          dur="1s"
-          repeatCount="indefinite"
-        />
-      </circle>
+      />
     </svg>
   );
 }

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -23,9 +23,22 @@
   .slide-left,
   .slide-right,
   .auto-animate,
+  .spinner,
   .auto-animate > * {
     transition: none !important;
     animation: none !important;
+  }
+}
+
+.spinner {
+  transform-origin: center;
+  animation: spinner-rotate 1s linear infinite;
+  will-change: transform;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary

- replace the spinner SVG SMIL `animateTransform` with a CSS transform animation
- keep reduced-motion behavior respected for the spinner

## Why

The loading spinner could appear frozen at startup. SMIL animation inside the SVG is a likely cause in some browser/PWA startup paths; CSS transform animation uses the normal compositor path.

## Validation

- `vp check`