### PR TITLE
Clarify homepage Google data use

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,18 @@
   </head>
   <body>
     <!-- Static content for crawlers/no-JS (Google OAuth homepage verification); removed when the app mounts -->
-    <div id="static-home">
+    <div
+      id="static-home"
+      style="
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        place-self: center;
+        gap: 16px;
+        padding: 16px;
+        max-width: 500px;
+      "
+    >
       <h1>HangVidU</h1>
       <p>
         HangVidU is a messaging app for peer-to-peer video calls, chat, and

--- a/index.html
+++ b/index.html
@@ -20,12 +20,23 @@
     <div id="static-home">
       <h1>HangVidU</h1>
       <p>
-        HangVidU is a peer-to-peer video chat and messaging app with real-time
-        synced media playback. Google sign-in is used only for authentication.
+        HangVidU is a messaging app for peer-to-peer video calls, chat, and
+        shared media playback.
+      </p>
+      <p>
+        If you choose Google import, HangVidU requests read-only Google Contacts
+        access to import your contacts and show which contacts are already using
+        HangVidU.
+      </p>
+      <p>
+        If you choose Send Email Invite, HangVidU requests Gmail send permission
+        only to send the invite emails you select. HangVidU does not read your
+        inbox.
       </p>
       <p>
         <a href="/privacy-policy.html">Privacy Policy</a> ·
-        <a href="/terms-of-service.html">Terms of Service</a>
+        <a href="/terms-of-service.html">Terms of Service</a> ·
+        <a href="mailto:kristinnroach@gmail.com">Contact</a>
       </p>
       <noscript><p>HangVidU requires JavaScript to run.</p></noscript>
     </div>

--- a/src/components/app/PublicHomepage.tsx
+++ b/src/components/app/PublicHomepage.tsx
@@ -24,7 +24,7 @@ export default function PublicHomepage(props: ParentProps) {
 
         {props.children}
 
-        <p>
+        <p class="public-homepage__support">
           Support:{' '}
           <a href="mailto:kristinnroach@gmail.com">kristinnroach@gmail.com</a>
         </p>

--- a/src/components/app/PublicHomepage.tsx
+++ b/src/components/app/PublicHomepage.tsx
@@ -10,6 +10,8 @@ export default function PublicHomepage(props: ParentProps) {
       <div class="public-homepage__content">
         <h2 id="public-homepage-title">{t('home.title')}</h2>
         <p>{t('home.description')}</p>
+        <p>{t('contact.disclosure.import')}</p>
+        <p>{t('contact.disclosure.gmail_send')}</p>
 
         <p class="public-homepage__login_prompt">
           <LoginButton
@@ -21,6 +23,11 @@ export default function PublicHomepage(props: ParentProps) {
         </p>
 
         {props.children}
+
+        <p>
+          Support:{' '}
+          <a href="mailto:kristinnroach@gmail.com">kristinnroach@gmail.com</a>
+        </p>
 
         <div class="public-homepage__links" aria-label={t('home.links')}>
           <a href="/privacy-policy.html">{t('nav.privacy')}</a>

--- a/src/components/app/PublicHomepage.tsx
+++ b/src/components/app/PublicHomepage.tsx
@@ -23,7 +23,7 @@ export default function PublicHomepage(props: ParentProps) {
         {props.children}
 
         <p class="public-homepage__support">
-          Support:{' '}
+          {t('home.contact')}:{' '}
           <a href="mailto:kristinnroach@gmail.com">kristinnroach@gmail.com</a>
         </p>
 

--- a/src/components/app/PublicHomepage.tsx
+++ b/src/components/app/PublicHomepage.tsx
@@ -10,8 +10,6 @@ export default function PublicHomepage(props: ParentProps) {
       <div class="public-homepage__content">
         <h2 id="public-homepage-title">{t('home.title')}</h2>
         <p>{t('home.description')}</p>
-        <p>{t('contact.disclosure.import')}</p>
-        <p>{t('contact.disclosure.gmail_send')}</p>
 
         <p class="public-homepage__login_prompt">
           <LoginButton
@@ -28,6 +26,9 @@ export default function PublicHomepage(props: ParentProps) {
           Support:{' '}
           <a href="mailto:kristinnroach@gmail.com">kristinnroach@gmail.com</a>
         </p>
+
+        <p>{t('contact.disclosure.import')}</p>
+        <p>{t('contact.disclosure.gmail_send')}</p>
 
         <div class="public-homepage__links" aria-label={t('home.links')}>
           <a href="/privacy-policy.html">{t('nav.privacy')}</a>

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -37,7 +37,7 @@
   "call.lobby.error.media_blocked": "Camera or microphone access was blocked. Allow access in your browser and try again.",
   "call.lobby.error.generic": "Could not join the call. Please try again.",
   "home.title": "HangVidU",
-  "home.description": "Instant messaging, peer-to-peer video calls, and media sharing.",
+  "home.description": "HangVidU is a messaging app for peer-to-peer video calls, chat, and shared media playback.",
   "home.links": "Legal links",
   "handle.claim.title": "Choose a username",
   "handle.claim.input": "Username",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -38,6 +38,7 @@
   "call.lobby.error.generic": "Could not join the call. Please try again.",
   "home.title": "HangVidU",
   "home.description": "HangVidU is a messaging app for peer-to-peer video calls, chat, and shared media playback.",
+  "home.contact": "Contact",
   "home.links": "Legal links",
   "handle.claim.title": "Choose a username",
   "handle.claim.input": "Username",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -37,7 +37,7 @@
   "call.lobby.error.media_blocked": "Aðgangur að myndavél eða hljóðnema var hindraður. Leyfðu aðgang í vafranum og reyndu aftur.",
   "call.lobby.error.generic": "Ekki tókst að tengjast símtalinu. Reyndu aftur.",
   "home.title": "HangVidU",
-  "home.description": "Samskiptaforrit með spjall, myndsímtöl og samáhorf.",
+  "home.description": "HangVidU er samskiptaforrit fyrir spjall, jafningja-myndsímtöl og samstillta miðlunarspilun.",
   "home.links": "Lagalegir tenglar",
   "handle.claim.title": "Veldu notandanafn",
   "handle.claim.input": "Notandanafn",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -38,6 +38,7 @@
   "call.lobby.error.generic": "Ekki tókst að tengjast símtalinu. Reyndu aftur.",
   "home.title": "HangVidU",
   "home.description": "HangVidU er samskiptaforrit fyrir spjall, jafningja-myndsímtöl og samstillta miðlunarspilun.",
+  "home.contact": "Hafa samband",
   "home.links": "Lagalegir tenglar",
   "handle.claim.title": "Veldu notandanafn",
   "handle.claim.input": "Notandanafn",

--- a/src/styles/components/call-lobby.css
+++ b/src/styles/components/call-lobby.css
@@ -17,6 +17,8 @@
 
 .call-lobby__cta,
 .call-lobby__secondary {
+  border: rgb(151, 200, 238) 2px solid;
+  background-color: rgba(124, 190, 208, 0.234);
   padding: var(--spacing-sm) var(--spacing-xl);
   border-radius: var(--radius-md);
   font-weight: 700;

--- a/src/styles/components/public-homepage.css
+++ b/src/styles/components/public-homepage.css
@@ -1,28 +1,16 @@
 .public-homepage {
-  display: flex;
-  flex-direction: column;
-
-  flex: 1;
-  min-height: 0;
   margin-inline: auto;
-  width: 100%;
-  height: 100%;
+  max-width: 90svw;
+  max-height: 90svh;
+  font-size: 16px;
+  font-weight: 300;
+  overflow: hidden;
 }
 
 .public-homepage__content {
-  position: relative;
-
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-
-  flex: 1;
-  min-height: 0;
-  width: 100%;
-  height: 100%;
-
-  padding: clamp(18px, 6dvh, 36px) var(--spacing-xl) var(--spacing-2xl);
-
+  padding: 1rem;
   color: var(--text-primary);
   text-align: center;
 }
@@ -30,7 +18,7 @@
 .public-homepage h2 {
   margin: 0;
   font-size: 2rem;
-  line-height: 1.1;
+  font-weight: 500;
   text-shadow: var(--text-shadow-medium);
 
   color: var(--color-primary);
@@ -55,13 +43,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  /* text-wrap: none; */
+  gap: 0.5em;
+  flex-wrap: wrap;
 }
 
 button.public-homepage__login {
   text-transform: capitalize;
   text-shadow: var(--text-shadow-medium);
   white-space: nowrap;
+
+  border: rgb(151, 200, 238) 2px solid;
+  background-color: rgba(124, 190, 208, 0.234);
 
   &:hover {
     text-decoration: underline;
@@ -70,10 +62,6 @@ button.public-homepage__login {
 }
 
 .public-homepage__links {
-  position: absolute;
-  bottom: 2rem;
-  inset-inline: 0;
-
   display: flex;
   justify-content: center;
   gap: var(--spacing-xl);

--- a/src/styles/components/public-homepage.css
+++ b/src/styles/components/public-homepage.css
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: column;
   padding: 1rem;
+  gap: clamp(4px, 16px, 32px);
   color: var(--text-primary);
   text-align: center;
 }

--- a/src/styles/components/public-homepage.css
+++ b/src/styles/components/public-homepage.css
@@ -47,6 +47,10 @@
   line-height: 1.5;
 }
 
+.public-homepage p.public-homepage__support {
+  gap: 0.4em;
+}
+
 .public-homepage__login_prompt {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- make the homepage describe HangVidU's purpose in plain language
- state the exact Google Contacts and Gmail uses on the public homepage
- add a visible contact link alongside the existing legal links

## Validation
- `vp check`
- `vp test` (passes, with one sandbox `listen EPERM` unhandled error on `::1` during Vitest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the public homepage messaging to better describe peer-to-peer video calls, chat, and shared media playback.
  * Added clearer contact and support links, including a direct email option.

* **Documentation**
  * Expanded the homepage with clearer disclosures about contact import and email invite permissions.
  * Refined English and Icelandic homepage copy for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->