### PR TITLE
Clarify conversation list state naming

### DIFF
--- a/src/app/ConversationsList.test.jsx
+++ b/src/app/ConversationsList.test.jsx
@@ -24,8 +24,8 @@ vi.mock('../stores/contactsStore.js', () => ({
     contact.nickname || contact.displayName || contact.username || null,
 }));
 
-vi.mock('../stores/conversation-activity', () => ({
-  conversationActivity: () => mocks.activity,
+vi.mock('../stores/conversation-list-state', () => ({
+  conversationListState: () => mocks.activity,
   getLastReadAt: () => 0,
 }));
 

--- a/src/app/ConversationsList.tsx
+++ b/src/app/ConversationsList.tsx
@@ -8,9 +8,9 @@ import {
   type Contact,
 } from '../stores/contactsStore.js';
 import {
-  conversationActivity,
+  conversationListState,
   getLastReadAt,
-} from '../stores/conversation-activity';
+} from '../stores/conversation-list-state';
 import { openDirectConversation } from '../stores/conversationStore';
 import PresenceIndicator from '../features/presence/components/PresenceIndicator';
 import { StartCallButton } from '../features/call/components/CallControls';
@@ -38,12 +38,12 @@ function createConversationRows() {
 
   return createMemo<ConversationRow[]>(() => {
     const me = getLoggedInUserId();
-    const activity = conversationActivity(); // reactive: participant uid -> activity
+    const listState = conversationListState(); // reactive: row id -> list state
 
     return Object.values(contactsState.byId)
       .map((contact: Contact) => {
         const id = contact.contactId ?? '';
-        const act = activity.get(id);
+        const act = listState.get(id);
         const lastReadAt = act ? getLastReadAt(act.conversationId) : 0;
         const hasUnread =
           !!act &&

--- a/src/app/MainContent.tsx
+++ b/src/app/MainContent.tsx
@@ -28,7 +28,7 @@ import { StartCallButton } from '../features/call/components/CallControls';
 import { LoadBoundary } from '../components/app/LoadBoundary';
 import { Spinner } from '../components/app/Spinner';
 import IdentityBadge from '../components/app/IdentityBadge';
-import { conversationActivity } from '../stores/conversation-activity';
+import { conversationListState } from '../stores/conversation-list-state';
 import {
   getContactById,
   getContactLabel,
@@ -85,7 +85,7 @@ export default function MainContent() {
   );
 
   function getDefaultContact(): Contact | null {
-    const activity = conversationActivity();
+    const listState = conversationListState();
     return (
       Object.values(contactsState.byId)
         .filter((contact): contact is Contact =>
@@ -93,9 +93,9 @@ export default function MainContent() {
         )
         .sort((a, b) => {
           const aSortKey =
-            activity.get(a.contactId)?.latestSentAt || a.savedAt || 0;
+            listState.get(a.contactId)?.latestSentAt || a.savedAt || 0;
           const bSortKey =
-            activity.get(b.contactId)?.latestSentAt || b.savedAt || 0;
+            listState.get(b.contactId)?.latestSentAt || b.savedAt || 0;
           if (aSortKey !== bSortKey) return bSortKey - aSortKey;
 
           return (

--- a/src/features/contacts/docs/CURRENT_STATE.md
+++ b/src/features/contacts/docs/CURRENT_STATE.md
@@ -6,5 +6,5 @@
   handles small contact metadata updates such as `updateContact()` and
   `handleHangUp()`.
 
-- Conversation-list activity (sort key and unread badge) comes from
-  `stores/conversation-activity`, not the contacts store.
+- Conversation-list state (sort key and unread badge) comes from
+  `stores/conversation-list-state`, not the contacts store.

--- a/src/features/conversations/__tests__/setup.test.js
+++ b/src/features/conversations/__tests__/setup.test.js
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => {
   return {
     handlers,
     subscribe: vi.fn(register),
-    stopConversationActivity: vi.fn(),
+    startConversationListSync: vi.fn(),
+    stopConversationListSync: vi.fn(),
     resetConversationsState: vi.fn(),
     resetConversationStore: vi.fn(),
   };
@@ -24,8 +25,9 @@ const mocks = vi.hoisted(() => {
 vi.mock('../../../shared/events/index.js', () => ({
   subscribe: mocks.subscribe,
 }));
-vi.mock('../../../stores/conversation-activity', () => ({
-  stopConversationActivity: mocks.stopConversationActivity,
+vi.mock('../../../stores/conversation-list-state', () => ({
+  startConversationListSync: mocks.startConversationListSync,
+  stopConversationListSync: mocks.stopConversationListSync,
 }));
 vi.mock('../../../stores/conversations-client.js', () => ({
   resetConversationsState: mocks.resetConversationsState,
@@ -47,14 +49,14 @@ describe('conversations setup', () => {
 
     await mocks.handlers.get('evt:auth:session:logged-out')();
 
-    expect(mocks.stopConversationActivity).toHaveBeenCalledOnce();
+    expect(mocks.stopConversationListSync).toHaveBeenCalledOnce();
     expect(mocks.resetConversationStore).toHaveBeenCalledOnce();
     expect(mocks.resetConversationsState).toHaveBeenCalledOnce();
   });
 
   it('resets conversation state when activity teardown throws', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    mocks.stopConversationActivity.mockImplementation(() => {
+    mocks.stopConversationListSync.mockImplementation(() => {
       throw new Error('stop failed');
     });
 
@@ -64,7 +66,7 @@ describe('conversations setup', () => {
 
       await mocks.handlers.get('evt:auth:session:logged-out')();
 
-      expect(mocks.stopConversationActivity).toHaveBeenCalledOnce();
+      expect(mocks.stopConversationListSync).toHaveBeenCalledOnce();
       expect(mocks.resetConversationsState).toHaveBeenCalledOnce();
     } finally {
       warn.mockRestore();

--- a/src/features/conversations/adapters/d1.ts
+++ b/src/features/conversations/adapters/d1.ts
@@ -211,7 +211,7 @@ export function createD1MessageRepository(
     },
 
     // Durable cross-device read marker (#563). The store's local optimistic
-    // clear (conversation-activity) covers the in-tab badge; this persists it
+    // clear (conversation-list-state) covers the in-tab badge; this persists it
     // server-side so other devices clear on their next conversation-list load.
     async markConversationRead(conversationId) {
       await client.markRead(conversationId);

--- a/src/features/conversations/index.ts
+++ b/src/features/conversations/index.ts
@@ -1,8 +1,8 @@
 import { subscribe } from '../../shared/events/index.js';
 import {
-  startConversationActivity,
-  stopConversationActivity,
-} from '../../stores/conversation-activity';
+  startConversationListSync,
+  stopConversationListSync,
+} from '../../stores/conversation-list-state';
 import { resetConversationsState } from '../../stores/conversations-client.js';
 import { resetConversationStore } from '../../stores/conversationStore';
 import { createSingleFlightSetup } from '../../shared/utils/create-single-flight-setup.js';
@@ -23,9 +23,9 @@ export const setup = createSingleFlightSetup({
       'evt:auth:session:logged-in',
       () => {
         try {
-          startConversationActivity();
+          startConversationListSync();
         } catch (error) {
-          console.warn('[conversations] activity start failed:', error);
+          console.warn('[conversations] list sync start failed:', error);
         }
       },
       { signal },
@@ -35,9 +35,9 @@ export const setup = createSingleFlightSetup({
       'evt:auth:session:logged-out',
       () => {
         try {
-          stopConversationActivity();
+          stopConversationListSync();
         } catch (error) {
-          console.warn('[conversations] activity teardown failed:', error);
+          console.warn('[conversations] list sync teardown failed:', error);
         }
         try {
           resetConversationStore();

--- a/src/stores/conversation-list-state.test.js
+++ b/src/stores/conversation-list-state.test.js
@@ -22,14 +22,14 @@ vi.mock('../infra/hangvidu-api-url', () => ({
 import { getLoggedInUserId } from '../auth/index.js';
 import { getConversationsClient } from './conversations-client';
 import {
-  conversationActivity,
+  conversationListState,
   getLastReadAt,
   markConversationRead,
-  recordConversationActivity,
-  refreshConversationActivity,
-  startConversationActivity,
-  stopConversationActivity,
-} from './conversation-activity';
+  recordConversationListMessage,
+  refreshConversationListState,
+  startConversationListSync,
+  stopConversationListSync,
+} from './conversation-list-state';
 
 describe('markConversationRead', () => {
   beforeEach(() => {
@@ -39,7 +39,7 @@ describe('markConversationRead', () => {
       setItem: (key, value) => values.set(key, String(value)),
     });
     mocks.subscribe.mockReturnValue(mocks.unsubscribe);
-    stopConversationActivity();
+    stopConversationListSync();
     vi.clearAllMocks();
   });
 
@@ -64,16 +64,16 @@ describe('markConversationRead', () => {
       ]),
     });
 
-    recordConversationActivity('peer', 'conversation-1', 2000, 'me');
-    await refreshConversationActivity();
+    recordConversationListMessage('peer', 'conversation-1', 2000, 'me');
+    await refreshConversationListState();
 
-    expect(conversationActivity().get('peer')?.latestSentAt).toBe(2000);
+    expect(conversationListState().get('peer')?.latestSentAt).toBe(2000);
   });
 
   it('can subscribe again after being stopped', () => {
-    startConversationActivity();
-    stopConversationActivity();
-    startConversationActivity();
+    startConversationListSync();
+    stopConversationListSync();
+    startConversationListSync();
 
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
     expect(mocks.close).toHaveBeenCalledOnce();

--- a/src/stores/conversation-list-state.ts
+++ b/src/stores/conversation-list-state.ts
@@ -1,12 +1,13 @@
-// Conversation-list activity: drives MRU reorder + the unread badge.
+// Conversation-list state: drives MRU reorder + the unread badge.
 //
-// Two inputs, one reactive map keyed by the OTHER participant's uid (DMs):
+// Two inputs, one reactive map keyed by the row id. Current rows are DMs, so the
+// row id is the OTHER participant's uid:
 //   - seed: GET /conversations once on start (and on demand), carrying each
 //     conversation's latest message time + sender.
 //   - live: the per-user mailbox pushes an `activity` envelope on every message
 //     to a conversation you're in (see shared/user-mailbox/protocol). For a DM
 //     the envelope only reaches the *other* member, so senderId is exactly the
-//     participant we key on.
+//     current row id.
 //
 // Read state (lastReadAt) is per-device localStorage for now; markConversationRead
 // bumps a version signal so the unread derivation re-runs without a refetch.
@@ -23,15 +24,15 @@ import {
 } from '../realtime/user-mailbox';
 import { getHangViduApiBaseUrl } from '../infra/hangvidu-api-url';
 
-interface ParticipantActivity {
+interface ConversationListEntryState {
   conversationId: string;
   latestSentAt: number;
   latestSenderId: string | null;
 }
 
-const [activity, setActivity] = createSignal<Map<string, ParticipantActivity>>(
-  new Map(),
-);
+const [listState, setListState] = createSignal<
+  Map<string, ConversationListEntryState>
+>(new Map());
 const [readVersion, setReadVersion] = createSignal(0);
 // Server-owned read markers (conversationId -> lastReadAt), seeded from
 // GET /conversations. Makes the unread badge cross-device: a read on another
@@ -41,8 +42,8 @@ const [serverLastRead, setServerLastRead] = createSignal<Map<string, number>>(
   new Map(),
 );
 
-/** Reactive: participant uid -> latest activity. Read by app/ConversationsList. */
-export const conversationActivity = activity;
+/** Reactive: row id -> latest list state. Read by app/ConversationsList. */
+export const conversationListState = listState;
 // ── per-device read state ────────────────────────────────────────────────────
 const readKey = (conversationId: string) =>
   `hangvidu:lastRead:${conversationId}`;
@@ -80,33 +81,34 @@ export function markConversationRead(
 }
 
 // ── seed + live wiring ───────────────────────────────────────────────────────
-function upsert(participantId: string, next: ParticipantActivity): void {
-  setActivity((prev) => {
-    const cur = prev.get(participantId);
+function upsert(rowKey: string, next: ConversationListEntryState): void {
+  setListState((prev) => {
+    const cur = prev.get(rowKey);
     if (cur && cur.latestSentAt >= next.latestSentAt) return prev; // older: ignore
-    return new Map(prev).set(participantId, next);
+    return new Map(prev).set(rowKey, next);
   });
 }
 
 /**
  * Record activity for a DM from the open conversation's message stream. Covers
  * the sender's OWN send, which never comes back over the mailbox (the server
- * fans `activity` to other members only). `participantId` is the peer's uid.
+ * fans `activity` to other members only). For current DM rows, `rowKey` is the
+ * peer's uid.
  */
-export function recordConversationActivity(
-  participantId: string,
+export function recordConversationListMessage(
+  rowKey: string,
   conversationId: string,
   latestSentAt: number,
   latestSenderId: string | null,
 ): void {
-  upsert(participantId, { conversationId, latestSentAt, latestSenderId });
+  upsert(rowKey, { conversationId, latestSentAt, latestSenderId });
 }
 
-/** Refetch the current activity snapshot (seed). */
-export async function refreshConversationActivity(): Promise<void> {
+/** Refetch the current conversation-list state snapshot (seed). */
+export async function refreshConversationListState(): Promise<void> {
   const me = getLoggedInUserId();
   if (!me) {
-    setActivity(new Map());
+    setListState(new Map());
     setServerLastRead(new Map());
     return;
   }
@@ -114,7 +116,7 @@ export async function refreshConversationActivity(): Promise<void> {
     const conversations = await getConversationsClient().list();
     if (getLoggedInUserId() !== me) return;
 
-    const map = new Map<string, ParticipantActivity>();
+    const map = new Map<string, ConversationListEntryState>();
     const reads = new Map<string, number>();
     for (const c of conversations) {
       if (c.kind !== 'direct') continue; // contacts list is DMs only for now
@@ -128,17 +130,17 @@ export async function refreshConversationActivity(): Promise<void> {
       reads.set(c.id, c.last_read_at ?? 0);
     }
     setServerLastRead(reads);
-    setActivity((current) => {
-      for (const [participantId, existing] of current) {
-        const fetched = map.get(participantId);
+    setListState((current) => {
+      for (const [rowKey, existing] of current) {
+        const fetched = map.get(rowKey);
         if (fetched && existing.latestSentAt > fetched.latestSentAt) {
-          map.set(participantId, existing);
+          map.set(rowKey, existing);
         }
       }
       return map;
     });
   } catch (error) {
-    console.warn('[conversation-activity] seed failed', error);
+    console.warn('[conversation-list-state] seed failed', error);
   }
 }
 
@@ -147,12 +149,12 @@ let unsubscribeMailbox: (() => void) | undefined;
 
 function refreshWhenVisible(): void {
   if (document.visibilityState === 'visible') {
-    void refreshConversationActivity();
+    void refreshConversationListState();
   }
 }
 
-/** Release login-scoped activity state and the shared mailbox. */
-export function stopConversationActivity(): void {
+/** Release login-scoped list state and the shared mailbox. */
+export function stopConversationListSync(): void {
   unsubscribeMailbox?.();
   unsubscribeMailbox = undefined;
   if (typeof document !== 'undefined') {
@@ -160,16 +162,16 @@ export function stopConversationActivity(): void {
   }
   closeUserMailbox();
   started = false;
-  setActivity(new Map());
+  setListState(new Map());
   setServerLastRead(new Map());
 }
 
 /** Idempotent: seed once + open the live mailbox subscription. */
-export function startConversationActivity(): void {
+export function startConversationListSync(): void {
   if (started) return;
   started = true;
 
-  void refreshConversationActivity();
+  void refreshConversationListState();
 
   unsubscribeMailbox = subscribeToUserMailbox(
     {
@@ -180,7 +182,7 @@ export function startConversationActivity(): void {
     (envelope) => {
       if (envelope.t !== 'activity') return; // ignore call invites/responses
       // DM: the envelope reaches only the other member, so senderId IS the
-      // participant this row is keyed on.
+      // row id.
       upsert(envelope.senderId, {
         conversationId: envelope.conversationId,
         latestSentAt: envelope.sentAt,

--- a/src/stores/conversationStore.test.js
+++ b/src/stores/conversationStore.test.js
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   getLoggedInUserProfile: vi.fn(),
   createD1MessageRepositoryFromEnv: vi.fn(),
   markConversationRead: vi.fn(),
-  recordConversationActivity: vi.fn(),
+  recordConversationListMessage: vi.fn(),
   resolveDirectConversationId: vi.fn(),
   getContactById: vi.fn(),
   cacheContactConversationId: vi.fn(),
@@ -24,9 +24,9 @@ vi.mock('./userProfileStore', () => ({
 vi.mock('./message-repository', () => ({
   createD1MessageRepositoryFromEnv: mocks.createD1MessageRepositoryFromEnv,
 }));
-vi.mock('./conversation-activity', () => ({
+vi.mock('./conversation-list-state', () => ({
   markConversationRead: mocks.markConversationRead,
-  recordConversationActivity: mocks.recordConversationActivity,
+  recordConversationListMessage: mocks.recordConversationListMessage,
 }));
 vi.mock('./conversations-client', () => ({
   resolveDirectConversationId: mocks.resolveDirectConversationId,
@@ -176,7 +176,7 @@ describe('conversationStore', () => {
 
     watch.emit([envelope({ messageId: 'msg-1', sentAt: 5 })]);
 
-    expect(mocks.recordConversationActivity).toHaveBeenCalledWith(
+    expect(mocks.recordConversationListMessage).toHaveBeenCalledWith(
       'contact-1',
       'conversation-1',
       5,

--- a/src/stores/conversationStore.ts
+++ b/src/stores/conversationStore.ts
@@ -11,8 +11,8 @@ import { getLoggedInUserProfile } from './userProfileStore';
 import { createD1MessageRepositoryFromEnv } from './message-repository';
 import {
   markConversationRead,
-  recordConversationActivity,
-} from './conversation-activity';
+  recordConversationListMessage,
+} from './conversation-list-state';
 import { resolveDirectConversationId } from './conversations-client';
 import { cacheContactConversationId, getContactById } from './contactsStore.js';
 import {
@@ -307,7 +307,7 @@ function startWatch(
         // only: peer uid is the activity map key.
         const peers = sel.remoteParticipantIds;
         if (peers?.length === 1) {
-          recordConversationActivity(
+          recordConversationListMessage(
             peers[0],
             conversationId,
             latest.sentAt,


### PR DESCRIPTION
## Summary
- rename conversation-activity to conversation-list-state
- rename public APIs around list state/sync instead of vague activity
- keep row-key wording so group conversation rows are not blocked by DM-specific naming

## Validation
- vp test
- vp check

## Remaining concerns
- mailbox live updates still key by senderId, which is DM-only; groups should key rows by conversationId
- list seeding still filters to direct conversations
- conversation rows still derive from contacts, so groups need their own row source or a combined list projection