### PR TITLE
Base conversation list on conversation ids

### DIFF
--- a/backend/firebase/push-notifications/notification-payload-builder.js
+++ b/backend/firebase/push-notifications/notification-payload-builder.js
@@ -74,6 +74,7 @@ function buildMessagePayload(messageData = {}) {
       senderName: messageData.senderName || 'Someone',
       messagePreview: messageData.messagePreview || '',
       conversationId: messageData.conversationId || '',
+      conversationKind: messageData.conversationKind || '',
       timestamp: Date.now().toString(),
     },
   };

--- a/backend/firebase/push-notifications/send-message-notification-handler.js
+++ b/backend/firebase/push-notifications/send-message-notification-handler.js
@@ -20,6 +20,7 @@ async function handleSendMessageNotification(req, res) {
     const {
       recipientIds,
       conversationId,
+      conversationKind,
       senderId,
       senderName,
       messagePreview,
@@ -37,6 +38,7 @@ async function handleSendMessageNotification(req, res) {
 
     const payload = buildMessagePayload({
       conversationId,
+      conversationKind,
       senderId: authenticatedUid,
       senderName,
       messagePreview,

--- a/src/app/ConversationsList.test.jsx
+++ b/src/app/ConversationsList.test.jsx
@@ -3,21 +3,18 @@ import { render, cleanup } from '@solidjs/testing-library';
 
 const mocks = vi.hoisted(() => ({
   byId: {},
-  status: 'ready',
+  seeded: true,
   activity: new Map(),
   watchUserPresence: vi.fn(() => () => {}),
   dispatchCommand: vi.fn(),
   startCall: vi.fn(),
-  openDirectConversation: vi.fn(),
+  openConversation: vi.fn(),
 }));
 
 vi.mock('../stores/contactsStore.js', () => ({
   getContactsStore: () => ({
     get byId() {
       return mocks.byId;
-    },
-    get status() {
-      return mocks.status;
     },
   }),
   getContactLabel: (contact) =>
@@ -26,6 +23,7 @@ vi.mock('../stores/contactsStore.js', () => ({
 
 vi.mock('../stores/conversation-list-state', () => ({
   conversationListState: () => mocks.activity,
+  conversationListSeeded: () => mocks.seeded,
   getLastReadAt: () => 0,
 }));
 
@@ -34,7 +32,7 @@ vi.mock('../auth/index.js', () => ({
 }));
 
 vi.mock('../stores/conversationStore', () => ({
-  openDirectConversation: mocks.openDirectConversation,
+  openConversation: mocks.openConversation,
   selection: () => null,
 }));
 
@@ -80,11 +78,34 @@ describe('ConversationsList', { timeout: 60000 }, () => {
       'contact-1': contact('contact-1', 'Alice'),
       'contact-2': contact('contact-2', 'Bob'),
     };
-    mocks.status = 'ready';
-    mocks.activity = new Map();
+    mocks.seeded = true;
+    mocks.activity = new Map([
+      [
+        'conversation-1',
+        {
+          conversationId: 'conversation-1',
+          kind: 'direct',
+          title: null,
+          members: [{ user_id: 'me' }, { user_id: 'contact-1' }],
+          latestSentAt: 100,
+          latestSenderId: 'me',
+        },
+      ],
+      [
+        'conversation-2',
+        {
+          conversationId: 'conversation-2',
+          kind: 'direct',
+          title: null,
+          members: [{ user_id: 'me' }, { user_id: 'contact-2' }],
+          latestSentAt: 50,
+          latestSenderId: 'contact-2',
+        },
+      ],
+    ]);
   });
 
-  it('renders a row per contact from hydrated state', async () => {
+  it('renders a row per conversation from hydrated state', async () => {
     const { default: ConversationsList } =
       await import('./ConversationsList.tsx');
 
@@ -100,7 +121,7 @@ describe('ConversationsList', { timeout: 60000 }, () => {
 
   it('renders loading state before hydrated empty state', async () => {
     mocks.byId = {};
-    mocks.status = 'loading';
+    mocks.seeded = false;
     const { default: ConversationsList } =
       await import('./ConversationsList.tsx');
 
@@ -121,7 +142,10 @@ describe('ConversationsList', { timeout: 60000 }, () => {
     const firstContactName = container.querySelector('.contact-name');
     firstContactName?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-    expect(mocks.openDirectConversation).toHaveBeenCalledWith('contact-1', {
+    expect(mocks.openConversation).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      kind: 'direct',
+      remoteParticipantIds: ['contact-1'],
       displayUI: true,
       nickname: 'Alice',
     });
@@ -132,17 +156,23 @@ describe('ConversationsList', { timeout: 60000 }, () => {
   it('sorts active conversations first and marks unread rows', async () => {
     mocks.activity = new Map([
       [
-        'contact-1',
+        'conversation-1',
         {
           conversationId: 'conversation-1',
+          kind: 'direct',
+          title: null,
+          members: [{ user_id: 'me' }, { user_id: 'contact-1' }],
           latestSentAt: 100,
           latestSenderId: 'me',
         },
       ],
       [
-        'contact-2',
+        'conversation-2',
         {
           conversationId: 'conversation-2',
+          kind: 'direct',
+          title: null,
+          members: [{ user_id: 'me' }, { user_id: 'contact-2' }],
           latestSentAt: 200,
           latestSenderId: 'contact-2',
         },
@@ -159,6 +189,38 @@ describe('ConversationsList', { timeout: 60000 }, () => {
     ).toEqual(['Bob', 'Alice']);
     expect(rows[0].querySelector('.unread-badge')).not.toBeNull();
     expect(rows[1].querySelector('.unread-badge')).toBeNull();
+
+    unmount();
+  });
+
+  it('renders a titled unread group row without call or presence controls', async () => {
+    mocks.activity = new Map([
+      [
+        'group-1',
+        {
+          conversationId: 'group-1',
+          kind: 'group',
+          title: 'Project Room',
+          members: [
+            { user_id: 'me', display_name: 'Me' },
+            { user_id: 'contact-1', display_name: 'Alice' },
+            { user_id: 'contact-2', display_name: 'Bob' },
+          ],
+          latestSentAt: 300,
+          latestSenderId: 'contact-2',
+        },
+      ],
+    ]);
+    const { default: ConversationsList } =
+      await import('./ConversationsList.tsx');
+
+    const { container, unmount } = render(() => <ConversationsList />);
+    const row = container.querySelector('.conversation-entry');
+
+    expect(row?.textContent).toContain('Project Room');
+    expect(row?.querySelector('.unread-badge')).not.toBeNull();
+    expect(row?.querySelector('.contact-call-btn')).toBeNull();
+    expect(row?.querySelector('.presence-indicator')).toBeNull();
 
     unmount();
   });

--- a/src/app/ConversationsList.test.jsx
+++ b/src/app/ConversationsList.test.jsx
@@ -193,14 +193,14 @@ describe('ConversationsList', { timeout: 60000 }, () => {
     unmount();
   });
 
-  it('renders a titled unread group row without call or presence controls', async () => {
+  it('renders an unread group row without self, call, or presence controls', async () => {
     mocks.activity = new Map([
       [
         'group-1',
         {
           conversationId: 'group-1',
           kind: 'group',
-          title: 'Project Room',
+          title: null,
           members: [
             { user_id: 'me', display_name: 'Me' },
             { user_id: 'contact-1', display_name: 'Alice' },
@@ -217,7 +217,8 @@ describe('ConversationsList', { timeout: 60000 }, () => {
     const { container, unmount } = render(() => <ConversationsList />);
     const row = container.querySelector('.conversation-entry');
 
-    expect(row?.textContent).toContain('Project Room');
+    expect(row?.textContent).toContain('Alice, Bob');
+    expect(row?.textContent).not.toContain('Me');
     expect(row?.querySelector('.unread-badge')).not.toBeNull();
     expect(row?.querySelector('.contact-call-btn')).toBeNull();
     expect(row?.querySelector('.presence-indicator')).toBeNull();

--- a/src/app/ConversationsList.tsx
+++ b/src/app/ConversationsList.tsx
@@ -2,22 +2,22 @@ import { For, Show, createMemo } from 'solid-js';
 import { Spinner } from '../components/app/Spinner';
 import { useI18n } from '../shared/i18n';
 import { getLoggedInUserId } from '../auth/index.js';
+import { getContactLabel, getContactsStore } from '../stores/contactsStore.js';
 import {
-  getContactLabel,
-  getContactsStore,
-  type Contact,
-} from '../stores/contactsStore.js';
-import {
+  conversationListSeeded,
   conversationListState,
   getLastReadAt,
 } from '../stores/conversation-list-state';
-import { openDirectConversation } from '../stores/conversationStore';
+import { openConversation } from '../stores/conversationStore';
 import PresenceIndicator from '../features/presence/components/PresenceIndicator';
 import { StartCallButton } from '../features/call/components/CallControls';
 
 type ConversationRow = {
-  id: string;
+  conversationId: string;
+  kind: 'direct' | 'group';
   label: string | null;
+  peerUserId?: string;
+  remoteParticipantIds: string[];
   hasUnread: boolean;
 };
 
@@ -29,35 +29,58 @@ function shortName(name: string): string {
     : name;
 }
 
-/**
- * Contacts × conversation activity × read markers → MRU-sorted rows with
- * unread flags. DM-only for now: one row per contact.
- */
+function memberNameJoin(members: { display_name: string | null }[]): string {
+  return members
+    .map((member) => member.display_name)
+    .filter((name): name is string => Boolean(name))
+    .map(shortName)
+    .join(', ');
+}
+
 function createConversationRows() {
   const contactsState = getContactsStore();
 
   return createMemo<ConversationRow[]>(() => {
     const me = getLoggedInUserId();
-    const listState = conversationListState(); // reactive: row id -> list state
+    const listState = conversationListState();
 
-    return Object.values(contactsState.byId)
-      .map((contact: Contact) => {
-        const id = contact.contactId ?? '';
-        const act = listState.get(id);
-        const lastReadAt = act ? getLastReadAt(act.conversationId) : 0;
+    return [...listState.values()]
+      .flatMap((summary) => {
+        if (!summary.kind) return [];
+        const remoteParticipantIds = summary.members
+          .map((member) => member.user_id)
+          .filter((id) => id !== me);
+        const peer = summary.members.find((member) => member.user_id !== me);
+        const peerUserId =
+          summary.kind === 'direct' ? peer?.user_id : undefined;
+        const contact = peerUserId ? contactsState.byId[peerUserId] : null;
+        const label =
+          summary.kind === 'direct'
+            ? (contact ? getContactLabel(contact) : null) ||
+              peer?.display_name ||
+              null
+            : summary.title || memberNameJoin(summary.members) || null;
+        const lastReadAt = getLastReadAt(summary.conversationId);
         const hasUnread =
-          !!act &&
           Boolean(me) &&
-          act.latestSenderId !== null &&
-          act.latestSenderId !== me &&
-          act.latestSentAt > lastReadAt;
-        const label = getContactLabel(contact);
+          summary.latestSenderId !== null &&
+          summary.latestSenderId !== me &&
+          summary.latestSentAt > lastReadAt;
 
-        return {
-          row: { id, label, hasUnread },
-          sortKey: act?.latestSentAt || contact.savedAt || 0,
-          sortLabel: (label ?? '').toLowerCase(),
-        };
+        return [
+          {
+            row: {
+              conversationId: summary.conversationId,
+              kind: summary.kind,
+              label,
+              peerUserId,
+              remoteParticipantIds,
+              hasUnread,
+            },
+            sortKey: summary.latestSentAt,
+            sortLabel: (label ?? '').toLowerCase(),
+          },
+        ];
       })
       .sort(
         (a, b) =>
@@ -69,10 +92,8 @@ function createConversationRows() {
 
 export default function ConversationsList() {
   const { t } = useI18n();
-  const contactsState = getContactsStore();
   const rows = createConversationRows();
-  const isLoading = () =>
-    contactsState.status === 'idle' || contactsState.status === 'loading';
+  const isLoading = () => !conversationListSeeded();
 
   return (
     <div class="conversations-container">
@@ -94,16 +115,16 @@ export default function ConversationsList() {
   );
 }
 
-/** One DM row: call button, name (opens the conversation), unread + presence. */
+/** One conversation row. DM rows get call + presence affordances. */
 function ConversationRow(props: { row: ConversationRow }) {
   const { t } = useI18n();
   const label = () => props.row.label ?? t('shared.unknown');
 
   const onOpenConversation = () => {
-    if (!props.row.id) return;
-    // The opaque DM conversation id is resolved from the contact id inside the
-    // store (resolve-or-create) — see openDirectConversation.
-    void openDirectConversation(props.row.id, {
+    openConversation({
+      conversationId: props.row.conversationId,
+      kind: props.row.kind,
+      remoteParticipantIds: props.row.remoteParticipantIds,
       displayUI: true,
       nickname: label(),
     });
@@ -111,15 +132,19 @@ function ConversationRow(props: { row: ConversationRow }) {
 
   return (
     <div class="conversation-entry">
-      <StartCallButton
-        calleeId={props.row.id}
-        calleeName={label()}
-        audioOnly={false}
-      />
+      <Show when={props.row.peerUserId}>
+        {(peerUserId) => (
+          <StartCallButton
+            calleeId={peerUserId()}
+            calleeName={label()}
+            audioOnly={false}
+          />
+        )}
+      </Show>
       <button
         type="button"
         class="contact-name"
-        data-contact-id={props.row.id}
+        data-conversation-id={props.row.conversationId}
         onClick={onOpenConversation}
         aria-label={label()}
       >
@@ -136,7 +161,9 @@ function ConversationRow(props: { row: ConversationRow }) {
           <span aria-hidden="true">•</span>
         </span>
       </Show>
-      <PresenceIndicator userId={props.row.id} />
+      <Show when={props.row.peerUserId}>
+        {(peerUserId) => <PresenceIndicator userId={peerUserId()} />}
+      </Show>
     </div>
   );
 }

--- a/src/app/ConversationsList.tsx
+++ b/src/app/ConversationsList.tsx
@@ -29,8 +29,12 @@ function shortName(name: string): string {
     : name;
 }
 
-function memberNameJoin(members: { display_name: string | null }[]): string {
+function memberNameJoin(
+  members: { user_id: string; display_name: string | null }[],
+  me: string | null,
+): string {
   return members
+    .filter((member) => member.user_id !== me)
     .map((member) => member.display_name)
     .filter((name): name is string => Boolean(name))
     .map(shortName)
@@ -59,7 +63,7 @@ function createConversationRows() {
             ? (contact ? getContactLabel(contact) : null) ||
               peer?.display_name ||
               null
-            : summary.title || memberNameJoin(summary.members) || null;
+            : summary.title || memberNameJoin(summary.members, me) || null;
         const lastReadAt = getLastReadAt(summary.conversationId);
         const hasUnread =
           Boolean(me) &&

--- a/src/app/MainContent.tsx
+++ b/src/app/MainContent.tsx
@@ -4,6 +4,7 @@ import { createAutoHide } from '../shared/createAutoHide';
 import { User, PhoneCall, Mail, ChevronLeft } from 'lucide-solid';
 import { useP2PContext } from '../shared/p2p-context.js';
 import { useAuth } from '../auth/solid-auth';
+import { getLoggedInUserId } from '../auth/index.js';
 import { useI18n } from '../shared/i18n';
 
 import AppLogo from '../components/app/AppLogo';
@@ -28,20 +29,23 @@ import { StartCallButton } from '../features/call/components/CallControls';
 import { LoadBoundary } from '../components/app/LoadBoundary';
 import { Spinner } from '../components/app/Spinner';
 import IdentityBadge from '../components/app/IdentityBadge';
-import { conversationListState } from '../stores/conversation-list-state';
+import {
+  conversationListSeeded,
+  conversationListState,
+  type ConversationSummary,
+} from '../stores/conversation-list-state';
 import {
   getContactById,
   getContactLabel,
   getContactsStore,
-  type Contact,
 } from '../stores/contactsStore.js';
 
 import mainStyles from './MainContent.module.css';
 import topbarStyles from './TopBar.module.css';
 
 import {
-  loadSelectedContactId,
-  openDirectConversation,
+  loadSelectedConversationId,
+  openConversation,
   selection as selectedConversation,
   type ConversationSelection,
 } from '../stores/conversationStore';
@@ -84,24 +88,46 @@ export default function MainContent() {
     ),
   );
 
-  function getDefaultContact(): Contact | null {
-    const listState = conversationListState();
+  function getConversationLabel(summary: ConversationSummary): string | null {
+    const me = getLoggedInUserId();
+    if (summary.kind === 'direct') {
+      const peer = summary.members.find((member) => member.user_id !== me);
+      const contact = peer ? contactsState.byId[peer.user_id] : null;
+      return (
+        (contact ? getContactLabel(contact) : null) ||
+        peer?.display_name ||
+        null
+      );
+    }
     return (
-      Object.values(contactsState.byId)
-        .filter((contact): contact is Contact =>
-          Boolean(contact?.contactId && contact.conversationId),
-        )
-        .sort((a, b) => {
-          const aSortKey =
-            listState.get(a.contactId)?.latestSentAt || a.savedAt || 0;
-          const bSortKey =
-            listState.get(b.contactId)?.latestSentAt || b.savedAt || 0;
-          if (aSortKey !== bSortKey) return bSortKey - aSortKey;
+      summary.title ||
+      summary.members
+        .map((member) => member.display_name)
+        .filter((name): name is string => Boolean(name))
+        .join(', ') ||
+      null
+    );
+  }
 
-          return (
-            getContactLabel(a)?.localeCompare(getContactLabel(b) || '') ?? 0
-          );
-        })
+  function openSummary(summary: ConversationSummary): void {
+    if (!summary.kind) return;
+    const me = getLoggedInUserId();
+    openConversation({
+      conversationId: summary.conversationId,
+      kind: summary.kind,
+      remoteParticipantIds: summary.members
+        .map((member) => member.user_id)
+        .filter((id) => id !== me),
+      nickname: getConversationLabel(summary),
+      displayUI: false,
+    });
+  }
+
+  function getDefaultConversation(): ConversationSummary | null {
+    return (
+      [...conversationListState().values()]
+        .filter((summary) => Boolean(summary.kind))
+        .sort((a, b) => b.latestSentAt - a.latestSentAt)
         .at(0) ?? null
     );
   }
@@ -133,27 +159,21 @@ export default function MainContent() {
   createEffect(() => {
     if (!showAuthenticatedUi()) return;
     if (selectedConversation()) return;
-    if (contactsState.status !== 'ready') return;
+    if (!conversationListSeeded()) return;
 
-    const storedContactId = loadSelectedContactId();
-    const storedContact = storedContactId
-      ? contactsState.byId[storedContactId]
+    const storedConversationId = loadSelectedConversationId();
+    const storedSummary = storedConversationId
+      ? conversationListState().get(storedConversationId)
       : null;
-    if (storedContact) {
-      void openDirectConversation(storedContact.contactId, {
-        displayUI: false,
-        nickname: getContactLabel(storedContact),
-      });
+    if (storedSummary) {
+      openSummary(storedSummary);
       return;
     }
 
-    const contact = getDefaultContact();
-    if (!contact) return;
+    const summary = getDefaultConversation();
+    if (!summary) return;
 
-    void openDirectConversation(contact.contactId, {
-      displayUI: false,
-      nickname: getContactLabel(contact),
-    });
+    openSummary(summary);
   });
 
   return (
@@ -247,7 +267,8 @@ function TopBar(props: TopBarProps) {
   const { t } = useI18n();
 
   const calleeId = createMemo(() => {
-    return props.selectedConversation?.remoteParticipantIds?.[0] ?? null;
+    if (props.selectedConversation?.kind !== 'direct') return null;
+    return props.selectedConversation.remoteParticipantIds?.[0] ?? null;
   });
 
   // Whose identity the top bar shows: the selected conversation's contact

--- a/src/app/MainContent.tsx
+++ b/src/app/MainContent.tsx
@@ -102,6 +102,7 @@ export default function MainContent() {
     return (
       summary.title ||
       summary.members
+        .filter((member) => member.user_id !== me)
         .map((member) => member.display_name)
         .filter((name): name is string => Boolean(name))
         .join(', ') ||

--- a/src/features/push-notifications/SWNavigation.tsx
+++ b/src/features/push-notifications/SWNavigation.tsx
@@ -4,7 +4,7 @@ import {
   getContactsIsHydrated,
 } from '../../stores/contactsStore';
 import {
-  open as openSelectedConversation,
+  openConversation as openSelectedConversation,
   openDirectConversation,
 } from '../../stores/conversationStore';
 

--- a/src/features/push-notifications/SWNavigation.tsx
+++ b/src/features/push-notifications/SWNavigation.tsx
@@ -26,13 +26,15 @@ function dispatchPath(path: string) {
   const url = new URL(path, window.location.origin);
   const conversationId = trimmedParam(url.searchParams, 'conversationId');
   const contactId = trimmedParam(url.searchParams, 'contact');
+  const kind =
+    trimmedParam(url.searchParams, 'kind') === 'group' ? 'group' : 'direct';
 
   // Links may carry an opaque conversationId directly; open it as-is.
   if (conversationId) {
     const contact = contactId ? getContactById(contactId) : null;
     openSelectedConversation({
       conversationId,
-      kind: 'direct',
+      kind,
       remoteParticipantIds: contactId ? [contactId] : [],
       displayUI: true,
       nickname: contact?.nickname ?? undefined,

--- a/src/features/push-notifications/SWNavigation.tsx
+++ b/src/features/push-notifications/SWNavigation.tsx
@@ -32,6 +32,7 @@ function dispatchPath(path: string) {
     const contact = contactId ? getContactById(contactId) : null;
     openSelectedConversation({
       conversationId,
+      kind: 'direct',
       remoteParticipantIds: contactId ? [contactId] : [],
       displayUI: true,
       nickname: contact?.nickname ?? undefined,

--- a/src/features/push-notifications/__tests__/SWNavigation.test.jsx
+++ b/src/features/push-notifications/__tests__/SWNavigation.test.jsx
@@ -112,4 +112,29 @@ describe('SWNavigation', () => {
       expect.any(Function),
     );
   });
+
+  it('preserves group kind on conversation deep links', async () => {
+    const { unmount } = render(() => <SWNavigation />);
+
+    messageListener?.({
+      data: {
+        type: 'NAVIGATE',
+        path: '/?conversationId=group-1&kind=group',
+      },
+    });
+
+    setHydrated(true);
+
+    await waitFor(() => {
+      expect(mocks.openSelectedConversation).toHaveBeenCalledWith({
+        conversationId: 'group-1',
+        kind: 'group',
+        remoteParticipantIds: [],
+        displayUI: true,
+        nickname: undefined,
+      });
+    });
+
+    unmount();
+  });
 });

--- a/src/features/push-notifications/__tests__/SWNavigation.test.jsx
+++ b/src/features/push-notifications/__tests__/SWNavigation.test.jsx
@@ -24,7 +24,7 @@ vi.mock('../../../stores/contactsStore', () => ({
 }));
 
 vi.mock('../../../stores/conversationStore', () => ({
-  open: mocks.openSelectedConversation,
+  openConversation: mocks.openSelectedConversation,
   openDirectConversation: mocks.openDirectConversation,
   selection: () => null,
 }));

--- a/src/features/push-notifications/push-notifications.js
+++ b/src/features/push-notifications/push-notifications.js
@@ -448,6 +448,7 @@ export class PushNotifications {
       return await callCloudFunction('sendMessageNotification', {
         recipientIds,
         conversationId,
+        conversationKind: rest.conversationKind,
         senderId: rest.senderId,
         senderName: formatted.senderName,
         messagePreview: formatted.messageText,

--- a/src/features/push-notifications/sw/__tests__/notification-click-handler.test.js
+++ b/src/features/push-notifications/sw/__tests__/notification-click-handler.test.js
@@ -52,7 +52,7 @@ describe('notification click routing', () => {
     ).toBe('/?contact=caller-2');
   });
 
-  it('routes message notifications to the sender conversation context', () => {
+  it('routes direct message notifications to the sender conversation context', () => {
     expect(
       getNotificationNavigationPath(
         {
@@ -63,6 +63,20 @@ describe('notification click routing', () => {
         'view',
       ),
     ).toBe('/?contact=sender-1&conversationId=conversation-1');
+  });
+
+  it('routes group message notifications by conversation id', () => {
+    expect(
+      getNotificationNavigationPath(
+        {
+          type: 'message',
+          senderId: 'sender-1',
+          conversationId: 'conversation-1',
+          conversationKind: 'group',
+        },
+        'view',
+      ),
+    ).toBe('/?conversationId=conversation-1&kind=group');
   });
 
   it('falls back to the app root when notification data is incomplete', () => {

--- a/src/features/push-notifications/sw/notification-click-handler.js
+++ b/src/features/push-notifications/sw/notification-click-handler.js
@@ -4,7 +4,8 @@ import { isIncomingCallType } from './notification-presentation.js';
  * Maps normalized notification payload data to the app navigation path.
  */
 export function getNotificationNavigationPath(data, action) {
-  const { type, roomId, senderId, callerId, conversationId } = data || {};
+  const { type, roomId, senderId, callerId, conversationId, conversationKind } =
+    data || {};
 
   if (isIncomingCallType(type)) {
     if (!roomId) return '/';
@@ -27,6 +28,14 @@ export function getNotificationNavigationPath(data, action) {
   }
 
   if (type === 'message') {
+    if (conversationKind === 'group' && conversationId) {
+      const params = new URLSearchParams({
+        conversationId,
+        kind: conversationKind,
+      });
+      return `/?${params.toString()}`;
+    }
+
     if (senderId) {
       const params = new URLSearchParams({
         contact: senderId,
@@ -34,6 +43,9 @@ export function getNotificationNavigationPath(data, action) {
 
       if (conversationId) {
         params.set('conversationId', conversationId);
+      }
+      if (conversationKind) {
+        params.set('kind', conversationKind);
       }
 
       return `/?${params.toString()}`;

--- a/src/stores/conversation-list-state.test.js
+++ b/src/stores/conversation-list-state.test.js
@@ -64,10 +64,41 @@ describe('markConversationRead', () => {
       ]),
     });
 
-    recordConversationListMessage('peer', 'conversation-1', 2000, 'me');
+    recordConversationListMessage('conversation-1', 2000, 'me');
     await refreshConversationListState();
 
-    expect(conversationListState().get('peer')?.latestSentAt).toBe(2000);
+    expect(conversationListState().get('conversation-1')?.latestSentAt).toBe(
+      2000,
+    );
+  });
+
+  it('keeps group conversations from the seed', async () => {
+    vi.mocked(getLoggedInUserId).mockReturnValue('me');
+    vi.mocked(getConversationsClient).mockReturnValue({
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 'group-1',
+          kind: 'group',
+          title: 'Project Room',
+          updated_at: 1000,
+          members: [
+            { user_id: 'me', display_name: 'Me' },
+            { user_id: 'peer', display_name: 'Peer' },
+          ],
+          latest_sent_at: 1000,
+          latest_sender_id: 'peer',
+        },
+      ]),
+    });
+
+    await refreshConversationListState();
+
+    expect(conversationListState().get('group-1')).toMatchObject({
+      conversationId: 'group-1',
+      kind: 'group',
+      title: 'Project Room',
+      latestSenderId: 'peer',
+    });
   });
 
   it('can subscribe again after being stopped', () => {

--- a/src/stores/conversation-list-state.ts
+++ b/src/stores/conversation-list-state.ts
@@ -1,13 +1,10 @@
 // Conversation-list state: drives MRU reorder + the unread badge.
 //
-// Two inputs, one reactive map keyed by the row id. Current rows are DMs, so the
-// row id is the OTHER participant's uid:
+// Two inputs, one reactive map keyed by conversationId:
 //   - seed: GET /conversations once on start (and on demand), carrying each
 //     conversation's latest message time + sender.
 //   - live: the per-user mailbox pushes an `activity` envelope on every message
-//     to a conversation you're in (see shared/user-mailbox/protocol). For a DM
-//     the envelope only reaches the *other* member, so senderId is exactly the
-//     current row id.
+//     to a conversation you're in (see shared/user-mailbox/protocol).
 //
 // Read state (lastReadAt) is per-device localStorage for now; markConversationRead
 // bumps a version signal so the unread derivation re-runs without a refetch.
@@ -23,16 +20,21 @@ import {
   subscribeToUserMailbox,
 } from '../realtime/user-mailbox';
 import { getHangViduApiBaseUrl } from '../infra/hangvidu-api-url';
+import type { ConversationMember } from '../storage/conversations/data-client';
 
-interface ConversationListEntryState {
+export type ConversationSummary = {
   conversationId: string;
+  kind: 'direct' | 'group' | null;
+  title: string | null;
+  members: ConversationMember[];
   latestSentAt: number;
   latestSenderId: string | null;
-}
+};
 
 const [listState, setListState] = createSignal<
-  Map<string, ConversationListEntryState>
+  Map<string, ConversationSummary>
 >(new Map());
+const [seeded, setSeeded] = createSignal(false);
 const [readVersion, setReadVersion] = createSignal(0);
 // Server-owned read markers (conversationId -> lastReadAt), seeded from
 // GET /conversations. Makes the unread badge cross-device: a read on another
@@ -42,8 +44,9 @@ const [serverLastRead, setServerLastRead] = createSignal<Map<string, number>>(
   new Map(),
 );
 
-/** Reactive: row id -> latest list state. Read by app/ConversationsList. */
+/** Reactive: conversationId -> latest list state. Read by app/ConversationsList. */
 export const conversationListState = listState;
+export const conversationListSeeded = seeded;
 // ── per-device read state ────────────────────────────────────────────────────
 const readKey = (conversationId: string) =>
   `hangvidu:lastRead:${conversationId}`;
@@ -81,27 +84,39 @@ export function markConversationRead(
 }
 
 // ── seed + live wiring ───────────────────────────────────────────────────────
-function upsert(rowKey: string, next: ConversationListEntryState): void {
+function upsert(
+  conversationId: string,
+  next: Partial<ConversationSummary>,
+): void {
   setListState((prev) => {
-    const cur = prev.get(rowKey);
-    if (cur && cur.latestSentAt >= next.latestSentAt) return prev; // older: ignore
-    return new Map(prev).set(rowKey, next);
+    const cur = prev.get(conversationId);
+    const latestSentAt = next.latestSentAt ?? cur?.latestSentAt ?? 0;
+    if (cur && cur.latestSentAt > latestSentAt) return prev; // older: ignore
+    return new Map(prev).set(conversationId, {
+      conversationId,
+      kind: 'kind' in next ? (next.kind ?? null) : (cur?.kind ?? null),
+      title: 'title' in next ? (next.title ?? null) : (cur?.title ?? null),
+      members: 'members' in next ? (next.members ?? []) : (cur?.members ?? []),
+      latestSentAt,
+      latestSenderId:
+        'latestSenderId' in next
+          ? (next.latestSenderId ?? null)
+          : (cur?.latestSenderId ?? null),
+    });
   });
 }
 
 /**
- * Record activity for a DM from the open conversation's message stream. Covers
+ * Record activity for the open conversation's message stream. Covers
  * the sender's OWN send, which never comes back over the mailbox (the server
- * fans `activity` to other members only). For current DM rows, `rowKey` is the
- * peer's uid.
+ * fans `activity` to other members only).
  */
 export function recordConversationListMessage(
-  rowKey: string,
   conversationId: string,
   latestSentAt: number,
   latestSenderId: string | null,
 ): void {
-  upsert(rowKey, { conversationId, latestSentAt, latestSenderId });
+  upsert(conversationId, { latestSentAt, latestSenderId });
 }
 
 /** Refetch the current conversation-list state snapshot (seed). */
@@ -110,20 +125,21 @@ export async function refreshConversationListState(): Promise<void> {
   if (!me) {
     setListState(new Map());
     setServerLastRead(new Map());
+    setSeeded(false);
     return;
   }
   try {
     const conversations = await getConversationsClient().list();
     if (getLoggedInUserId() !== me) return;
 
-    const map = new Map<string, ConversationListEntryState>();
+    const map = new Map<string, ConversationSummary>();
     const reads = new Map<string, number>();
     for (const c of conversations) {
-      if (c.kind !== 'direct') continue; // contacts list is DMs only for now
-      const other = c.members.find((m) => m.user_id !== me);
-      if (!other) continue;
-      map.set(other.user_id, {
+      map.set(c.id, {
         conversationId: c.id,
+        kind: c.kind,
+        title: c.title ?? null,
+        members: c.members,
         latestSentAt: c.latest_sent_at ?? c.updated_at,
         latestSenderId: c.latest_sender_id ?? null,
       });
@@ -139,6 +155,7 @@ export async function refreshConversationListState(): Promise<void> {
       }
       return map;
     });
+    setSeeded(true);
   } catch (error) {
     console.warn('[conversation-list-state] seed failed', error);
   }
@@ -164,6 +181,7 @@ export function stopConversationListSync(): void {
   started = false;
   setListState(new Map());
   setServerLastRead(new Map());
+  setSeeded(false);
 }
 
 /** Idempotent: seed once + open the live mailbox subscription. */
@@ -181,10 +199,7 @@ export function startConversationListSync(): void {
     },
     (envelope) => {
       if (envelope.t !== 'activity') return; // ignore call invites/responses
-      // DM: the envelope reaches only the other member, so senderId IS the
-      // row id.
-      upsert(envelope.senderId, {
-        conversationId: envelope.conversationId,
+      upsert(envelope.conversationId, {
         latestSentAt: envelope.sentAt,
         latestSenderId: envelope.senderId,
       });

--- a/src/stores/conversation-list-state.ts
+++ b/src/stores/conversation-list-state.ts
@@ -199,10 +199,15 @@ export function startConversationListSync(): void {
     },
     (envelope) => {
       if (envelope.t !== 'activity') return; // ignore call invites/responses
+      const known = listState().has(envelope.conversationId);
       upsert(envelope.conversationId, {
         latestSentAt: envelope.sentAt,
         latestSenderId: envelope.senderId,
       });
+      // A conversation created after the seed (new group, newly accepted
+      // contact) arrives here without kind/title/members, and the list hides
+      // kind-less entries — reseed once to fill them in.
+      if (!known) void refreshConversationListState();
     },
   );
 

--- a/src/stores/conversationStore.test.js
+++ b/src/stores/conversationStore.test.js
@@ -210,6 +210,7 @@ describe('conversationStore', () => {
       expect.objectContaining({
         recipientIds: ['contact-1'],
         conversationId: 'conversation-1',
+        conversationKind: 'direct',
         messageText: 'hello',
       }),
     );

--- a/src/stores/conversationStore.test.js
+++ b/src/stores/conversationStore.test.js
@@ -102,12 +102,12 @@ describe('conversationStore', () => {
     });
   });
 
-  it('persists the selected contact id for direct opens', async () => {
+  it('persists the selected conversation id for direct opens', async () => {
     const store = await import('./conversationStore.ts');
 
     await store.openDirectConversation('contact-1', { displayUI: false });
 
-    expect(store.loadSelectedContactId()).toBe('contact-1');
+    expect(store.loadSelectedConversationId()).toBe('conversation-1');
     expect(repo.watchRecentMessages).toHaveBeenCalledWith(
       'conversation-1',
       expect.any(Function),
@@ -115,16 +115,17 @@ describe('conversationStore', () => {
     );
   });
 
-  it('persists direct selections opened from raw selection state', async () => {
+  it('persists selections opened from raw selection state', async () => {
     const store = await import('./conversationStore.ts');
 
-    store.open({
-      conversationId: 'conversation-1',
-      remoteParticipantIds: ['contact-2'],
+    store.openConversation({
+      conversationId: 'group-1',
+      kind: 'group',
+      remoteParticipantIds: ['contact-2', 'contact-3'],
       displayUI: true,
     });
 
-    expect(store.loadSelectedContactId()).toBe('contact-2');
+    expect(store.loadSelectedConversationId()).toBe('group-1');
   });
 
   it('merges watcher snapshots in chronological order and maps file envelopes', async () => {
@@ -177,7 +178,6 @@ describe('conversationStore', () => {
     watch.emit([envelope({ messageId: 'msg-1', sentAt: 5 })]);
 
     expect(mocks.recordConversationListMessage).toHaveBeenCalledWith(
-      'contact-1',
       'conversation-1',
       5,
       'user-a',

--- a/src/stores/conversationStore.ts
+++ b/src/stores/conversationStore.ts
@@ -49,6 +49,7 @@ import type { ReactionChange } from '../features/conversations/reactions/solid/s
 
 export type ConversationSelection = {
   conversationId: ConversationId;
+  kind: 'direct' | 'group';
   remoteParticipantIds?: UserId[];
   nickname?: string | null;
   displayUI?: boolean;
@@ -102,9 +103,9 @@ export function getConversationState() {
   return state;
 }
 
-// ---------- selected-contact persistence ----------
+// ---------- selected-conversation persistence ----------
 
-const STORAGE_PREFIX = 'hangvidu:conversations:selected-contact';
+const STORAGE_PREFIX = 'hangvidu:conversations:selected';
 
 function getLocalStorage(): Storage | null {
   return typeof globalThis.localStorage === 'undefined'
@@ -116,21 +117,21 @@ function storageKey(userId: string) {
   return `${STORAGE_PREFIX}:${encodeURIComponent(userId)}`;
 }
 
-function saveSelectedContactId(contactId: string | null): void {
+function saveSelectedConversationId(conversationId: string | null): void {
   try {
     const userId = getLoggedInUserId();
     const storage = getLocalStorage();
     if (!userId || !storage) return;
 
     const key = storageKey(userId);
-    if (contactId) storage.setItem(key, contactId);
+    if (conversationId) storage.setItem(key, conversationId);
     else storage.removeItem(key);
   } catch {
     // Selection persistence is best-effort; in-memory state remains canonical.
   }
 }
 
-export function loadSelectedContactId(): string | null {
+export function loadSelectedConversationId(): string | null {
   try {
     const userId = getLoggedInUserId();
     const storage = getLocalStorage();
@@ -302,18 +303,13 @@ function startWatch(
           myUserId,
           sentAt: latest.sentAt,
         });
-        // Keep the contact-list row ordered for the open conversation —
-        // covers the user's own send (never echoed over the mailbox). DM
-        // only: peer uid is the activity map key.
-        const peers = sel.remoteParticipantIds;
-        if (peers?.length === 1) {
-          recordConversationListMessage(
-            peers[0],
-            conversationId,
-            latest.sentAt,
-            latest.senderId,
-          );
-        }
+        // Keep the list row ordered for the open conversation; covers the
+        // user's own send, which is never echoed over the mailbox.
+        recordConversationListMessage(
+          conversationId,
+          latest.sentAt,
+          latest.senderId,
+        );
       }
     },
     (error) => {
@@ -324,7 +320,7 @@ function startWatch(
       const contactId = sel.remoteParticipantIds?.[0];
       if (
         (error as { status?: number })?.status === 404 &&
-        sel.remoteParticipantIds?.length === 1 &&
+        sel.kind === 'direct' &&
         contactId
       ) {
         void cacheContactConversationId(contactId, null).then(() =>
@@ -387,18 +383,16 @@ function activate(next: ConversationSelection | null) {
 
 // ---------- selection actions ----------
 
-export function open(next: ConversationSelection): void {
-  saveSelectedContactId(
-    next.remoteParticipantIds?.length === 1
-      ? next.remoteParticipantIds[0]
-      : null,
-  );
+export function openConversation(next: ConversationSelection): void {
+  saveSelectedConversationId(next.conversationId);
   activate(next);
 }
 
+export const open = openConversation;
+
 type OpenDirectMeta = Omit<
   ConversationSelection,
-  'conversationId' | 'remoteParticipantIds'
+  'conversationId' | 'kind' | 'remoteParticipantIds'
 >;
 
 /**
@@ -439,8 +433,12 @@ export async function openDirectConversation(
     return;
   }
 
-  saveSelectedContactId(contactId);
-  activate({ ...meta, conversationId, remoteParticipantIds: [contactId] });
+  openConversation({
+    ...meta,
+    conversationId,
+    kind: 'direct',
+    remoteParticipantIds: [contactId],
+  });
 }
 
 /** Release the active conversation and all its state. Called on logout. */

--- a/src/stores/conversationStore.ts
+++ b/src/stores/conversationStore.ts
@@ -388,8 +388,6 @@ export function openConversation(next: ConversationSelection): void {
   activate(next);
 }
 
-export const open = openConversation;
-
 type OpenDirectMeta = Omit<
   ConversationSelection,
   'conversationId' | 'kind' | 'remoteParticipantIds'

--- a/src/stores/conversationStore.ts
+++ b/src/stores/conversationStore.ts
@@ -508,6 +508,7 @@ export async function sendMessage(
   setState({ draft: '', sending: true });
 
   const recipientIds = selection()?.remoteParticipantIds ?? [];
+  const conversationKind = selection()?.kind;
 
   let sent = false;
   try {
@@ -536,6 +537,7 @@ export async function sendMessage(
       void getPushNotifications()?.sendMessageNotification({
         recipientIds,
         conversationId,
+        conversationKind,
         senderId: myUserId,
         senderName,
         messageText,


### PR DESCRIPTION
## Summary
- key conversation list state and selection by conversationId
- render list rows from the conversations feed, including groups without call/presence controls
- restore selected conversations from the feed and persist selected conversation ids

## Tests
- vp check
- vp test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now restore the last selected conversation by conversation ID, including group chats, when you return to the app.
  * Conversation lists now use conversation details (direct and group) for titles, unread badges, and active ordering.
  * Push and notification navigation now preserves conversation type (direct vs group).

* **Bug Fixes**
  * Unread badges, active ordering, and read-state updates stay consistent during loading and live updates.
  * Opening conversations from the list or notifications now targets the correct conversation type and participant set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->