### PR TITLE
Remove unused deps and inert pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@tailwindcss/vite": "^4.3.2",
     "@vitest/browser-playwright": "4.1.9",
     "@vitest/coverage-v8": "^4.1.9",
-    "baseline-browser-mapping": "^2.10.40",
     "concurrently": "^10.0.3",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-boundaries": "^6.0.2",
@@ -105,7 +104,6 @@
     "vite-plugin-solid": "^2.11.12",
     "vite-plus": "catalog:",
     "vitest": "catalog:",
-    "workbox-build": "^7.4.1",
     "workbox-precaching": "^7.4.1",
     "workbox-routing": "^7.4.1",
     "workbox-strategies": "^7.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,11 +213,9 @@ overrides:
   ajv@>=8: 8.18.0
   eslint>ajv: 6.12.6
   fast-xml-parser: 5.5.7
-  lodash: 4.18.1
   minimatch@>=5 <5.1.7: 5.1.9
   minimatch@>=9 <9.0.6: 9.0.9
   minimatch@>=10 <10.2.1: 10.2.5
-  node-forge: 1.4.0
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4 <4.0.4: 4.0.4
   serialize-javascript: 7.0.5
@@ -274,9 +272,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
-      baseline-browser-mapping:
-        specifier: ^2.10.40
-        version: 2.10.40
       concurrently:
         specifier: ^10.0.3
         version: 10.0.3
@@ -315,7 +310,7 @@ importers:
         version: 2.1.0(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))(supports-color@10.2.2)(workbox-build@7.4.1(@types/babel__core@7.20.5)(supports-color@10.2.2))(workbox-window@7.4.1)
+        version: 1.3.0(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))(supports-color@10.2.2)(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1)
       vite-plugin-solid:
         specifier: ^2.11.12
         version: 2.11.12(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))(solid-js@1.9.13)
@@ -325,9 +320,6 @@ importers:
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))(jsdom@29.1.1)
-      workbox-build:
-        specifier: ^7.4.1
-        version: 7.4.1(@types/babel__core@7.20.5)(supports-color@10.2.2)
       workbox-precaching:
         specifier: ^7.4.1
         version: 7.4.1
@@ -5462,7 +5454,7 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)(supports-color@10.2.2)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
@@ -5949,7 +5941,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)(supports-color@10.2.2)':
+  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
@@ -6017,7 +6009,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)(supports-color@10.2.2)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
@@ -7814,11 +7806,11 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0)(supports-color@10.2.2):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -7826,7 +7818,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -7834,7 +7826,7 @@ snapshots:
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10264,13 +10256,13 @@ snapshots:
       undici: 8.3.0
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3)'
 
-  vite-plugin-pwa@1.3.0(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))(supports-color@10.2.2)(workbox-build@7.4.1(@types/babel__core@7.20.5)(supports-color@10.2.2))(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3))(supports-color@10.2.2)(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(typescript@6.0.3)'
-      workbox-build: 7.4.1(@types/babel__core@7.20.5)(supports-color@10.2.2)
+      workbox-build: 7.4.1(@types/babel__core@7.20.5)
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
@@ -10493,11 +10485,11 @@ snapshots:
     dependencies:
       workbox-core: 7.4.1
 
-  workbox-build@7.4.1(@types/babel__core@7.20.5)(supports-color@10.2.2):
+  workbox-build@7.4.1(@types/babel__core@7.20.5):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.7(ajv@8.18.0)
       '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)(supports-color@10.2.2)
+      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.62.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,11 +21,9 @@ overrides:
   'ajv@>=8': 8.18.0
   'eslint>ajv': 6.12.6
   fast-xml-parser: 5.5.7
-  lodash: 4.18.1
   'minimatch@>=5 <5.1.7': 5.1.9
   'minimatch@>=9 <9.0.6': 9.0.9
   'minimatch@>=10 <10.2.1': 10.2.5
-  node-forge: 1.4.0
   'picomatch@<2.3.2': 2.3.2
   'picomatch@>=4 <4.0.4': 4.0.4
   serialize-javascript: 7.0.5


### PR DESCRIPTION
Cleanup from the over-engineering audit (items: unused deps, stale dependency overrides).

**Removed devDependencies**
- `baseline-browser-mapping` — no references anywhere in the repo.
- `workbox-build` — no references; the PWA build goes through `vite-plugin-pwa`, which vendors its own.

**Removed pnpm overrides**
- `lodash` and `node-forge` — neither package appears in `pnpm-lock.yaml`, so the pins were inert.
- Kept the active pins (`ajv`, `fast-xml-parser`, `minimatch`, `picomatch`, `serialize-javascript`) — their targets still resolve in the lockfile.

**Kept after verification**
- `workbox-window` — removing it breaks the build: `virtual:pwa-register` imports it and rolldown resolves it from the root package.

**Verification**
- `pnpm build` passes (tsc + vite build + PWA injectManifest).
- `pnpm test` passes: 330 passed, 1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to use patched versions, helping keep the app’s build and runtime environment more stable.
  * Removed unused development tooling entries to streamline project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->