### PR TITLE
Simplify push setup lifecycle

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,7 @@ import { render } from 'solid-js/web';
 
 import App from './App';
 import { initializeAppCheckDeferred } from './infra/firebase.js';
-import {
-  setup as setupPushNotifications,
-  initPushNotifications,
-} from '@push/index.js';
+import { setup as setupPushNotifications } from '@push/index.js';
 import { setup as setupAuth } from './auth/setup.js';
 import { setup as setupContacts } from './features/contacts';
 import { setup as setupConversations } from './features/conversations';
@@ -43,9 +40,6 @@ function AppSideEffects(props: { children: JSX.Element }) {
       // lifecycle events only once every subscriber above is registered.
       cleanups.push(await setupAuth());
       cleanups.push(await setupPWA());
-      initPushNotifications().catch((error) => {
-        console.error('[main] Push notifications init:', error);
-      });
     } catch (error) {
       console.error('[main] Side-effect setup failed:', error);
       runCleanups(cleanups);

--- a/src/push/__tests__/setup.test.js
+++ b/src/push/__tests__/setup.test.js
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => {
   const handlers = new Map();
   return {
     handlers,
+    serviceWorkerMessageHandler: undefined,
     handleCommand: vi.fn((eventName, handler) => {
       handlers.set(eventName, handler);
       return () => handlers.delete(eventName);
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => {
       return () => handlers.delete(eventName);
     }),
     disable: vi.fn(() => Promise.resolve()),
+    enable: vi.fn(() => Promise.resolve()),
     ensureEnabledIfGranted: vi.fn(),
     getPushNotifications: vi.fn(),
     initPushNotifications: vi.fn(),
@@ -37,8 +39,22 @@ describe('push-notifications setup', () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.handlers.clear();
+    mocks.serviceWorkerMessageHandler = undefined;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {
+        serviceWorker: {
+          addEventListener: vi.fn((eventName, handler) => {
+            if (eventName === 'message') {
+              mocks.serviceWorkerMessageHandler = handler;
+            }
+          }),
+        },
+      },
+      configurable: true,
+    });
     mocks.getPushNotifications.mockReturnValue({
       disable: mocks.disable,
+      enable: mocks.enable,
       ensureEnabledIfGranted: mocks.ensureEnabledIfGranted,
     });
     mocks.initPushNotifications.mockResolvedValue(mocks.getPushNotifications());
@@ -99,5 +115,16 @@ describe('push-notifications setup', () => {
       callerName: 'Caller',
       roomId: 'room-1',
     });
+  });
+
+  it('re-enables push when the service worker reports subscription changes', async () => {
+    const push = await import('../index.js');
+
+    await push.setup();
+    mocks.serviceWorkerMessageHandler?.({
+      data: { type: 'PUSH_SUBSCRIPTION_CHANGED' },
+    });
+
+    expect(mocks.enable).toHaveBeenCalledOnce();
   });
 });

--- a/src/push/__tests__/setup.test.js
+++ b/src/push/__tests__/setup.test.js
@@ -8,16 +8,20 @@ const mocks = vi.hoisted(() => {
       handlers.set(eventName, handler);
       return () => handlers.delete(eventName);
     }),
+    dispatchCommand: vi.fn(),
     subscribe: vi.fn((eventName, handler) => {
       handlers.set(eventName, handler);
       return () => handlers.delete(eventName);
     }),
     disable: vi.fn(() => Promise.resolve()),
+    ensureEnabledIfGranted: vi.fn(),
     getPushNotifications: vi.fn(),
+    initPushNotifications: vi.fn(),
   };
 });
 
 vi.mock('../../shared/events/index.js', () => ({
+  dispatchCommand: mocks.dispatchCommand,
   handleCommand: mocks.handleCommand,
   subscribe: mocks.subscribe,
 }));
@@ -25,6 +29,7 @@ vi.mock('../../shared/events/index.js', () => ({
 vi.mock('../push-notifications.js', () => ({
   PushNotifications: class {},
   getPushNotifications: mocks.getPushNotifications,
+  initPushNotifications: mocks.initPushNotifications,
 }));
 
 describe('push-notifications setup', () => {
@@ -32,7 +37,12 @@ describe('push-notifications setup', () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.handlers.clear();
-    mocks.getPushNotifications.mockReturnValue({ disable: mocks.disable });
+    mocks.getPushNotifications.mockReturnValue({
+      disable: mocks.disable,
+      ensureEnabledIfGranted: mocks.ensureEnabledIfGranted,
+    });
+    mocks.initPushNotifications.mockResolvedValue(mocks.getPushNotifications());
+    mocks.ensureEnabledIfGranted.mockResolvedValue({ state: 'enabled' });
   });
 
   it('registers cmd:push:subscription:disable and delegates to PushNotifications.disable', async () => {
@@ -44,5 +54,50 @@ describe('push-notifications setup', () => {
     await handler?.();
 
     expect(mocks.disable).toHaveBeenCalled();
+  });
+
+  it('initializes push during setup before auth events can fire', async () => {
+    const push = await import('../index.js');
+
+    await push.setup();
+
+    expect(mocks.initPushNotifications).toHaveBeenCalledOnce();
+  });
+
+  it('prompts for push when login finds permission is not decided', async () => {
+    const push = await import('../index.js');
+    mocks.ensureEnabledIfGranted.mockResolvedValue({ state: 'prompt-needed' });
+
+    await push.setup();
+    await mocks.handlers.get('evt:auth:session:logged-in')?.();
+
+    expect(mocks.dispatchCommand).toHaveBeenCalledWith(
+      'cmd:app-notifications:show:enable-push',
+    );
+  });
+
+  it('sends incoming call push from call invite events', async () => {
+    const sendIncomingCall = vi.fn(() => Promise.resolve());
+    mocks.getPushNotifications.mockReturnValue({
+      disable: mocks.disable,
+      ensureEnabledIfGranted: mocks.ensureEnabledIfGranted,
+      sendIncomingCall,
+    });
+    const push = await import('../index.js');
+
+    await push.setup();
+    mocks.handlers.get('evt:call:invite:sent')?.({
+      calleeId: 'callee',
+      callerId: 'caller',
+      callerName: 'Caller',
+      roomId: 'room-1',
+    });
+
+    expect(sendIncomingCall).toHaveBeenCalledWith({
+      targetUserId: 'callee',
+      callerId: 'caller',
+      callerName: 'Caller',
+      roomId: 'room-1',
+    });
   });
 });

--- a/src/push/index.js
+++ b/src/push/index.js
@@ -46,7 +46,14 @@ export const setup = createSingleFlightSetup({
             return { state: 'error' };
           });
         if (result?.state === 'prompt-needed') {
-          dispatchCommand('cmd:app-notifications:show:enable-push');
+          try {
+            dispatchCommand('cmd:app-notifications:show:enable-push');
+          } catch (e) {
+            console.warn(
+              '[Push Notifications] enable-push prompt dispatch failed:',
+              e,
+            );
+          }
         }
       },
       { signal },

--- a/src/push/index.js
+++ b/src/push/index.js
@@ -1,6 +1,13 @@
-import { handleCommand, subscribe } from '@shared/events/index.js';
+import {
+  dispatchCommand,
+  handleCommand,
+  subscribe,
+} from '@shared/events/index.js';
 import { createSingleFlightSetup } from '@shared/utils/create-single-flight-setup.js';
-import { getPushNotifications } from './push-notifications.js';
+import {
+  getPushNotifications,
+  initPushNotifications,
+} from './push-notifications.js';
 
 export {
   PushNotifications,
@@ -28,6 +35,40 @@ export const setup = createSingleFlightSetup({
       },
       { signal },
     );
+
+    subscribe(
+      'evt:auth:session:logged-in',
+      async () => {
+        const result = await getPushNotifications()
+          ?.ensureEnabledIfGranted()
+          ?.catch((e) => {
+            console.warn('[Push Notifications] setup failed:', e);
+            return { state: 'error' };
+          });
+        if (result?.state === 'prompt-needed') {
+          dispatchCommand('cmd:app-notifications:show:enable-push');
+        }
+      },
+      { signal },
+    );
+
+    // The SW re-subscribes on pushsubscriptionchange but can't authenticate to the
+    // backend itself; it pings us to re-register the new endpoint via enable().
+    if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener(
+        'message',
+        (event) => {
+          if (event.data?.type === 'PUSH_SUBSCRIPTION_CHANGED') {
+            getPushNotifications()
+              ?.enable()
+              ?.catch((e) => {
+                console.warn('[Push Notifications] re-register failed:', e);
+              });
+          }
+        },
+        { signal },
+      );
+    }
 
     // Push reacts to call facts — the call feature doesn't know push exists.
     // Payload is the call's { calleeId, roomId, callerId, callerName }.
@@ -74,4 +115,5 @@ export const setup = createSingleFlightSetup({
       { signal },
     );
   },
+  start: () => initPushNotifications(),
 });

--- a/src/push/push-notifications.js
+++ b/src/push/push-notifications.js
@@ -1,6 +1,5 @@
 // Public app-facing push notifications facade.
 
-import { dispatchCommand, subscribe } from '@shared/events/index.js';
 import { callCloudFunction } from './cloud-functions.js';
 
 const PERMISSION_REQUEST_TIMEOUT_MS = 8000;
@@ -732,27 +731,6 @@ export const initPushNotifications = async (options = {}) => {
       // }
     } catch (error) {
       console.error('[Push Notifications] init failed:', error);
-    }
-    subscribe('evt:auth:session:logged-in', async () => {
-      const result = await instance.ensureEnabledIfGranted().catch((e) => {
-        console.warn('[Push Notifications] setup failed:', e);
-        return { state: 'error' };
-      });
-      if (result.state === 'prompt-needed') {
-        dispatchCommand('cmd:app-notifications:show:enable-push');
-      }
-    });
-
-    // The SW re-subscribes on pushsubscriptionchange but can't authenticate to the
-    // backend itself; it pings us to re-register the new endpoint via enable().
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.addEventListener('message', (event) => {
-        if (event.data?.type === 'PUSH_SUBSCRIPTION_CHANGED') {
-          instance.enable().catch((e) => {
-            console.warn('[Push Notifications] re-register failed:', e);
-          });
-        }
-      });
     }
   }
 


### PR DESCRIPTION
## Summary
- make `setupPushNotifications()` initialize the push singleton and own push lifecycle listeners
- move auth auto-enable and service-worker re-register listeners out of the singleton initializer
- remove the separate `initPushNotifications()` bootstrap call from `main.tsx`
- add focused setup tests for initialization order, auth prompt behavior, and call invite push delivery

## Why
Push setup was split across `setupPushNotifications()` and a later `initPushNotifications()` call. Because auth setup fires initial session events during bootstrap, the later init could miss the first logged-in event. Centralizing push lifecycle wiring keeps the auth subscriber registered before `setupAuth()` runs and gives the listeners the same cleanup path as the rest of push setup.

## Validation
- `pnpm vitest --run src/push/__tests__/setup.test.js src/push/__tests__/push-notifications.browser.test.js src/features/call/call-handshake-controller.test.js`
- `vp test`
- `vp check`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push notifications now integrate more closely with login state, enabling notifications when permission is already granted and showing an enable-push prompt when it isn’t decided.
  * Incoming call events more consistently trigger the expected push notification flow.

* **Bug Fixes**
  * Improved push notification startup sequencing for more reliable initialization.
  * Push subscriptions now refresh when updates are detected from the browser/service worker to help keep notifications working.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->