### PR TITLE
Fix incoming call notification handoff

### DIFF
--- a/src/app/SWNavigation.test.jsx
+++ b/src/app/SWNavigation.test.jsx
@@ -155,6 +155,7 @@ describe('SWNavigation', () => {
         callerId: 'caller-1',
         callerName: 'Caller',
         accept: true,
+        startedAt: undefined,
       }),
     );
     expect(mocks.openDirectConversation).not.toHaveBeenCalled();

--- a/src/app/SWNavigation.test.jsx
+++ b/src/app/SWNavigation.test.jsx
@@ -145,7 +145,7 @@ describe('SWNavigation', () => {
     messageListener?.({
       data: {
         type: 'NAVIGATE',
-        path: '/?callRoom=room-1&callerId=caller-1&callerName=Caller&accept=1',
+        path: '/?conversationRoom=room-1&callerId=caller-1&callerName=Caller&accept=1',
       },
     });
 

--- a/src/app/SWNavigation.test.jsx
+++ b/src/app/SWNavigation.test.jsx
@@ -132,4 +132,40 @@ describe('SWNavigation', () => {
 
     unmount();
   });
+
+  it('dispatches incoming-call notification navigation immediately', async () => {
+    const onIncomingCallNotification = vi.fn();
+    window.addEventListener(
+      'hangvidu:incoming-call-notification',
+      onIncomingCallNotification,
+    );
+
+    const { unmount } = render(() => <SWNavigation />);
+
+    messageListener?.({
+      data: {
+        type: 'NAVIGATE',
+        path: '/?callRoom=room-1&callerId=caller-1&callerName=Caller&accept=1',
+      },
+    });
+
+    expect(onIncomingCallNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          roomId: 'room-1',
+          callerId: 'caller-1',
+          callerName: 'Caller',
+          accept: true,
+        }),
+      }),
+    );
+    expect(mocks.openDirectConversation).not.toHaveBeenCalled();
+    expect(mocks.openSelectedConversation).not.toHaveBeenCalled();
+
+    window.removeEventListener(
+      'hangvidu:incoming-call-notification',
+      onIncomingCallNotification,
+    );
+    unmount();
+  });
 });

--- a/src/app/SWNavigation.test.jsx
+++ b/src/app/SWNavigation.test.jsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   getContactsIsHydrated: vi.fn(),
   openSelectedConversation: vi.fn(),
   openDirectConversation: vi.fn(),
+  publish: vi.fn(),
 }));
 
 vi.mock('../stores/contacts-store', () => ({
@@ -27,6 +28,10 @@ vi.mock('../stores/conversation/conversation-store', () => ({
   openConversation: mocks.openSelectedConversation,
   openDirectConversation: mocks.openDirectConversation,
   selection: () => null,
+}));
+
+vi.mock('@shared/events/index.js', () => ({
+  publish: mocks.publish,
 }));
 
 describe('SWNavigation', () => {
@@ -133,13 +138,7 @@ describe('SWNavigation', () => {
     unmount();
   });
 
-  it('dispatches incoming-call notification navigation immediately', async () => {
-    const onIncomingCallNotification = vi.fn();
-    window.addEventListener(
-      'hangvidu:incoming-call-notification',
-      onIncomingCallNotification,
-    );
-
+  it('publishes incoming-call notification navigation immediately', async () => {
     const { unmount } = render(() => <SWNavigation />);
 
     messageListener?.({
@@ -149,23 +148,18 @@ describe('SWNavigation', () => {
       },
     });
 
-    expect(onIncomingCallNotification).toHaveBeenCalledWith(
+    expect(mocks.publish).toHaveBeenCalledWith(
+      'evt:call:notification:opened',
       expect.objectContaining({
-        detail: expect.objectContaining({
-          roomId: 'room-1',
-          callerId: 'caller-1',
-          callerName: 'Caller',
-          accept: true,
-        }),
+        roomId: 'room-1',
+        callerId: 'caller-1',
+        callerName: 'Caller',
+        accept: true,
       }),
     );
     expect(mocks.openDirectConversation).not.toHaveBeenCalled();
     expect(mocks.openSelectedConversation).not.toHaveBeenCalled();
 
-    window.removeEventListener(
-      'hangvidu:incoming-call-notification',
-      onIncomingCallNotification,
-    );
     unmount();
   });
 });

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -19,18 +19,8 @@ function trimmedParam(
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
-function conversationRoomParam(searchParams: URLSearchParams): string | null {
-  return trimmedParam(searchParams, 'conversationRoom');
-}
-
-function isCallNavigationPath(path: string): boolean {
-  const url = new URL(path, window.location.origin);
-  return Boolean(conversationRoomParam(url.searchParams));
-}
-
-function dispatchPath(path: string) {
-  const url = new URL(path, window.location.origin);
-  const conversationRoomId = conversationRoomParam(url.searchParams);
+function dispatchUrl(url: URL): void {
+  const conversationRoomId = trimmedParam(url.searchParams, 'conversationRoom');
   if (conversationRoomId) {
     const timestamp = Number(url.searchParams.get('timestamp'));
     window.dispatchEvent(
@@ -64,6 +54,10 @@ function dispatchPath(path: string) {
   void openDirectConversation(contactId, { displayUI: true });
 }
 
+function dispatchPath(path: string): void {
+  dispatchUrl(new URL(path, window.location.origin));
+}
+
 /**
  * Listens for SW NAVIGATE messages (posted by the SW notification-click
  * handler when the user taps a push notification) and opens the resolved
@@ -95,9 +89,10 @@ export default function SWNavigation(props: Props = {}) {
     const handler = (event: MessageEvent) => {
       const data = event.data || {};
       if (data.type !== 'NAVIGATE' || !data.path) return;
+      const url = new URL(data.path, window.location.origin);
 
-      if (isCallNavigationPath(data.path)) {
-        dispatchPath(data.path);
+      if (trimmedParam(url.searchParams, 'conversationRoom')) {
+        dispatchUrl(url);
         return;
       }
 
@@ -107,7 +102,7 @@ export default function SWNavigation(props: Props = {}) {
         return;
       }
 
-      dispatchPath(data.path);
+      dispatchUrl(url);
     };
 
     navigator.serviceWorker.addEventListener('message', handler);

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -20,16 +20,22 @@ function trimmedParam(
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function optionalTimestamp(searchParams: URLSearchParams): number | undefined {
+  const rawTimestamp = searchParams.get('timestamp');
+  if (rawTimestamp == null) return undefined;
+  const timestamp = Number(rawTimestamp);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
 function dispatchUrl(url: URL): void {
   const conversationRoomId = trimmedParam(url.searchParams, 'conversationRoom');
   if (conversationRoomId) {
-    const timestamp = Number(url.searchParams.get('timestamp'));
     publish('evt:call:notification:opened', {
       roomId: conversationRoomId,
       callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
       callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,
       audioOnly: url.searchParams.get('audioOnly') === '1',
-      startedAt: Number.isFinite(timestamp) ? timestamp : undefined,
+      startedAt: optionalTimestamp(url.searchParams),
       accept: url.searchParams.get('accept') === '1',
     });
     return;

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -19,8 +19,35 @@ function trimmedParam(
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function callRoomParam(searchParams: URLSearchParams): string | null {
+  return trimmedParam(searchParams, 'callRoom');
+}
+
+function isCallNavigationPath(path: string): boolean {
+  const url = new URL(path, window.location.origin);
+  return Boolean(callRoomParam(url.searchParams));
+}
+
 function dispatchPath(path: string) {
   const url = new URL(path, window.location.origin);
+  const callRoomId = callRoomParam(url.searchParams);
+  if (callRoomId) {
+    const timestamp = Number(url.searchParams.get('timestamp'));
+    window.dispatchEvent(
+      new CustomEvent('hangvidu:incoming-call-notification', {
+        detail: {
+          roomId: callRoomId,
+          callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
+          callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,
+          audioOnly: url.searchParams.get('audioOnly') === '1',
+          timestamp: Number.isFinite(timestamp) ? timestamp : undefined,
+          accept: url.searchParams.get('accept') === '1',
+        },
+      }),
+    );
+    return;
+  }
+
   const conversationId = trimmedParam(url.searchParams, 'conversationId');
   const contactId = trimmedParam(url.searchParams, 'contact');
 
@@ -68,6 +95,11 @@ export default function SWNavigation(props: Props = {}) {
     const handler = (event: MessageEvent) => {
       const data = event.data || {};
       if (data.type !== 'NAVIGATE' || !data.path) return;
+
+      if (isCallNavigationPath(data.path)) {
+        dispatchPath(data.path);
+        return;
+      }
 
       if (!getContactsIsHydrated()) {
         pending.push(data.path);

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -4,6 +4,7 @@ import {
   openConversation as openSelectedConversation,
   openDirectConversation,
 } from '../stores/conversation/conversation-store';
+import { publish } from '@shared/events/index.js';
 
 type Props = {
   queueLimit?: number;
@@ -23,18 +24,14 @@ function dispatchUrl(url: URL): void {
   const conversationRoomId = trimmedParam(url.searchParams, 'conversationRoom');
   if (conversationRoomId) {
     const timestamp = Number(url.searchParams.get('timestamp'));
-    window.dispatchEvent(
-      new CustomEvent('hangvidu:incoming-call-notification', {
-        detail: {
-          roomId: conversationRoomId,
-          callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
-          callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,
-          audioOnly: url.searchParams.get('audioOnly') === '1',
-          timestamp: Number.isFinite(timestamp) ? timestamp : undefined,
-          accept: url.searchParams.get('accept') === '1',
-        },
-      }),
-    );
+    publish('evt:call:notification:opened', {
+      roomId: conversationRoomId,
+      callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
+      callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,
+      audioOnly: url.searchParams.get('audioOnly') === '1',
+      startedAt: Number.isFinite(timestamp) ? timestamp : undefined,
+      accept: url.searchParams.get('accept') === '1',
+    });
     return;
   }
 

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -19,24 +19,28 @@ function trimmedParam(
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
-function callRoomParam(searchParams: URLSearchParams): string | null {
-  return trimmedParam(searchParams, 'callRoom');
+function conversationRoomParam(searchParams: URLSearchParams): string | null {
+  return (
+    trimmedParam(searchParams, 'conversationRoom') ??
+    // Legacy name used by earlier incoming-call push notifications.
+    trimmedParam(searchParams, 'callRoom')
+  );
 }
 
 function isCallNavigationPath(path: string): boolean {
   const url = new URL(path, window.location.origin);
-  return Boolean(callRoomParam(url.searchParams));
+  return Boolean(conversationRoomParam(url.searchParams));
 }
 
 function dispatchPath(path: string) {
   const url = new URL(path, window.location.origin);
-  const callRoomId = callRoomParam(url.searchParams);
-  if (callRoomId) {
+  const conversationRoomId = conversationRoomParam(url.searchParams);
+  if (conversationRoomId) {
     const timestamp = Number(url.searchParams.get('timestamp'));
     window.dispatchEvent(
       new CustomEvent('hangvidu:incoming-call-notification', {
         detail: {
-          roomId: callRoomId,
+          roomId: conversationRoomId,
           callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
           callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,
           audioOnly: url.searchParams.get('audioOnly') === '1',

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -20,11 +20,7 @@ function trimmedParam(
 }
 
 function conversationRoomParam(searchParams: URLSearchParams): string | null {
-  return (
-    trimmedParam(searchParams, 'conversationRoom') ??
-    // Legacy name used by earlier incoming-call push notifications.
-    trimmedParam(searchParams, 'callRoom')
-  );
+  return trimmedParam(searchParams, 'conversationRoom');
 }
 
 function isCallNavigationPath(path: string): boolean {

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -181,6 +181,47 @@ describe('CallHandshakeController', () => {
     });
   });
 
+  it('does not close an accepted incoming room while waiting for the caller to join', async () => {
+    const p2p = {
+      join: vi.fn(async (options) => {
+        options.onAlone?.({ roomId: 'room-1', members: ['callee-id'] });
+        return { roomId: 'room-1', members: ['callee-id'] };
+      }),
+      close: vi.fn(),
+      state: vi.fn(() => 'idle'),
+      room: vi.fn(),
+    };
+    const controller = new CallHandshakeController({
+      p2p,
+      createSignaling: vi.fn(),
+      getCallerName: () => 'Callee',
+      onStateChange: vi.fn(),
+      onCalleeBusy: vi.fn(),
+    });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+
+    controller.acceptIncoming();
+    await flushPromises();
+
+    expect(mocks.respondToIncomingCallInvite).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      callerId: 'caller-id',
+      responseType: 'accepted',
+    });
+    expect(p2p.close).not.toHaveBeenCalled();
+  });
+
   it('does not notify accepted when joining the room fails', async () => {
     const joinError = new Error('camera blocked');
     const p2p = {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -40,6 +40,14 @@ type CallHandshakeControllerOptions = {
   onCalleeBusy: (busy: boolean) => void;
 };
 
+export type IncomingCallNotificationDetails = {
+  roomId: string;
+  callerId: string;
+  callerName?: string;
+  audioOnly?: boolean;
+  startedAt?: number;
+};
+
 export class CallHandshakeController {
   private readonly p2p: SolidP2PRoom;
   private readonly createSignaling: CreateRoomSignaling;
@@ -125,24 +133,54 @@ export class CallHandshakeController {
         }
         return;
       }
-      const { invite: call } = event;
-      if (this.isBusyForIncomingCall(call)) {
-        callService
-          .respondToIncomingCallInvite({
-            roomId: call.roomId,
-            callerId: call.callerId,
-            responseType: 'busy',
-          })
-          .catch((err) =>
-            console.error('Error responding busy to incoming call:', err),
-          );
-        return;
-      }
-      this.setHandshakeState({ direction: 'incoming', call });
-      if (import.meta.env.DEV) {
-        console.debug('Received incoming call invite:', { call });
-      }
+      this.handleIncomingCallInvite(event.invite, callService);
     });
+  }
+
+  showIncomingCallFromNotification(
+    details: IncomingCallNotificationDetails,
+  ): void {
+    const localUID = getLoggedInUserId();
+    if (!localUID || !details.roomId || !details.callerId) return;
+    const startedAt = details.startedAt ?? Date.now();
+    const call: MailboxInvite = {
+      roomId: details.roomId,
+      callerId: details.callerId,
+      calleeId: localUID,
+      callerName: details.callerName,
+      audioOnly: details.audioOnly,
+      startedAt,
+      expiresAt: startedAt + CALLING_TTL_MS,
+    };
+    if (call.expiresAt != null && call.expiresAt <= Date.now()) return;
+    const callService = initCallService({
+      localUID,
+      baseUrl: DATA_URL,
+      getToken: getLoggedInUserToken,
+    });
+    this.handleIncomingCallInvite(call, callService);
+  }
+
+  private handleIncomingCallInvite(
+    call: MailboxInvite,
+    callService: NonNullable<ReturnType<typeof getCallService>>,
+  ): void {
+    if (this.isBusyForIncomingCall(call)) {
+      callService
+        .respondToIncomingCallInvite({
+          roomId: call.roomId,
+          callerId: call.callerId,
+          responseType: 'busy',
+        })
+        .catch((err) =>
+          console.error('Error responding busy to incoming call:', err),
+        );
+      return;
+    }
+    this.setHandshakeState({ direction: 'incoming', call });
+    if (import.meta.env.DEV) {
+      console.debug('Received incoming call invite:', { call });
+    }
   }
 
   private isBusyForIncomingCall(call: MailboxInvite): boolean {
@@ -317,7 +355,9 @@ export class CallHandshakeController {
     getLocalStream?: () => Promise<MediaStream>,
     memberCapacity = 2,
     autoExitOnEmpty = true,
+    ignoreInitialAlone = false,
   ) {
+    let ignoredInitialAlone = false;
     const room = await this.p2p.join({
       roomId,
       peerId: localUserId,
@@ -328,6 +368,10 @@ export class CallHandshakeController {
       dataChannel: true,
       onAlone: (detail) => {
         if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
+        if (ignoreInitialAlone && !ignoredInitialAlone) {
+          ignoredInitialAlone = true;
+          return;
+        }
         if (autoExitOnEmpty) this.exitActiveRoom();
       },
     });
@@ -419,7 +463,15 @@ export class CallHandshakeController {
     if (!svc || !localUID) return;
     this.clearOutgoingCallTracking();
     this.setHandshakeState(null);
-    this.enterRoom(state.call.roomId, localUID, state.call.audioOnly ?? false)
+    this.enterRoom(
+      state.call.roomId,
+      localUID,
+      state.call.audioOnly ?? false,
+      undefined,
+      2,
+      true,
+      true,
+    )
       .then(() =>
         svc.respondToIncomingCallInvite({
           roomId: state.call.roomId,

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -48,6 +48,12 @@ export type IncomingCallNotificationDetails = {
   startedAt?: number;
 };
 
+type EnterRoomOptions = {
+  memberCapacity?: number;
+  autoExitOnEmpty?: boolean;
+  ignoreInitialAlone?: boolean;
+};
+
 export class CallHandshakeController {
   private readonly p2p: SolidP2PRoom;
   private readonly createSignaling: CreateRoomSignaling;
@@ -353,9 +359,11 @@ export class CallHandshakeController {
     localUserId: string,
     audioOnly = false,
     getLocalStream?: () => Promise<MediaStream>,
-    memberCapacity = 2,
-    autoExitOnEmpty = true,
-    ignoreInitialAlone = false,
+    {
+      memberCapacity = 2,
+      autoExitOnEmpty = true,
+      ignoreInitialAlone = false,
+    }: EnterRoomOptions = {},
   ) {
     let ignoredInitialAlone = false;
     const room = await this.p2p.join({
@@ -468,9 +476,7 @@ export class CallHandshakeController {
       localUID,
       state.call.audioOnly ?? false,
       undefined,
-      2,
-      true,
-      true,
+      { ignoreInitialAlone: true },
     )
       .then(() =>
         svc.respondToIncomingCallInvite({

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -5,6 +5,10 @@ import { render, cleanup } from '@solidjs/testing-library';
 const mocks = vi.hoisted(() => ({
   init: vi.fn(),
   cleanup: vi.fn(),
+  showIncomingCallFromNotification: vi.fn(),
+  acceptIncoming: vi.fn(),
+  subscribe: vi.fn(),
+  subscriptions: new Map(),
   user: () => null,
 }));
 
@@ -13,9 +17,10 @@ vi.mock('./call-handshake-controller.js', () => ({
     return {
       init: mocks.init,
       cleanup: mocks.cleanup,
+      showIncomingCallFromNotification: mocks.showIncomingCallFromNotification,
       exitActiveRoom: vi.fn(),
       cancelOutgoing: vi.fn(),
-      acceptIncoming: vi.fn(),
+      acceptIncoming: mocks.acceptIncoming,
       declineIncoming: vi.fn(),
     };
   }),
@@ -25,11 +30,19 @@ vi.mock('../../realtime/index.js', () => ({ createRoomSignaling: vi.fn() }));
 vi.mock('../../auth/solid-auth.js', () => ({
   useAuth: () => ({ user: (...args) => mocks.user(...args) }),
 }));
+vi.mock('@shared/events/index.js', () => ({
+  subscribe: mocks.subscribe,
+}));
 
 describe('CallHandshakeProvider', () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    mocks.subscriptions.clear();
+    mocks.subscribe.mockImplementation((name, handler) => {
+      mocks.subscriptions.set(name, handler);
+      return vi.fn();
+    });
     mocks.user = () => null;
   });
 
@@ -69,5 +82,29 @@ describe('CallHandshakeProvider', () => {
     setP2pState('connected');
     expect(mocks.init).toHaveBeenCalledTimes(1);
     expect(mocks.cleanup).not.toHaveBeenCalled();
+  });
+
+  it('uses the app bus incoming-call notification event after auth is ready', async () => {
+    const { CallHandshakeProvider } = await import('./call-handshake');
+    const [user] = createSignal({ uid: 'u1' });
+    mocks.user = user;
+
+    render(() => <CallHandshakeProvider>{null}</CallHandshakeProvider>);
+
+    const handler = mocks.subscriptions.get('evt:call:notification:opened');
+    handler?.({
+      roomId: 'room-1',
+      callerId: 'caller-1',
+      callerName: 'Caller',
+      accept: true,
+    });
+
+    expect(mocks.showIncomingCallFromNotification).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      callerId: 'caller-1',
+      callerName: 'Caller',
+      audioOnly: false,
+      startedAt: undefined,
+    });
   });
 });

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -44,6 +44,7 @@ describe('CallHandshakeProvider', () => {
       return vi.fn();
     });
     mocks.user = () => null;
+    window.history.replaceState(null, '', '/');
   });
 
   it('attaches the incoming-call listener when auth becomes authenticated after mount', async () => {
@@ -106,5 +107,26 @@ describe('CallHandshakeProvider', () => {
       audioOnly: false,
       startedAt: undefined,
     });
+  });
+
+  it('keeps a missing notification URL timestamp undefined', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/?conversationRoom=room-1&callerId=caller-1',
+    );
+    const { CallHandshakeProvider } = await import('./call-handshake');
+    const [user] = createSignal({ uid: 'u1' });
+    mocks.user = user;
+
+    render(() => <CallHandshakeProvider>{null}</CallHandshakeProvider>);
+
+    expect(mocks.showIncomingCallFromNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        callerId: 'caller-1',
+        startedAt: undefined,
+      }),
+    );
   });
 });

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -41,7 +41,12 @@ const CallHandshakeContext = createContext<CallHandshakeContextValue>();
 const INCOMING_CALL_NOTIFICATION_EVENT = 'hangvidu:incoming-call-notification';
 
 function incomingCallRoomParam(params: URLSearchParams): string | null {
-  return params.get('callRoom') || params.get('room');
+  return (
+    params.get('conversationRoom') ||
+    // Legacy names used before conversation/public room URLs were explicit.
+    params.get('callRoom') ||
+    (params.get('callerId') ? params.get('room') : null)
+  );
 }
 
 function incomingCallNotificationDetailsFromParams(

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -43,6 +43,13 @@ type IncomingCallNotificationOpenedPayload = IncomingCallNotificationDetails & {
   accept?: boolean;
 };
 
+function optionalTimestamp(params: URLSearchParams): number | undefined {
+  const rawTimestamp = params.get('timestamp');
+  if (rawTimestamp == null) return undefined;
+  const timestamp = Number(rawTimestamp);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
 function incomingCallNotificationDetailsFromParams(
   params: URLSearchParams,
 ): IncomingCallNotificationDetails | null {
@@ -50,13 +57,12 @@ function incomingCallNotificationDetailsFromParams(
   const callerId = params.get('callerId');
   if (!roomId || !callerId) return null;
 
-  const timestamp = Number(params.get('timestamp'));
   return {
     roomId,
     callerId,
     callerName: params.get('callerName') || undefined,
     audioOnly: params.get('audioOnly') === '1',
-    startedAt: Number.isFinite(timestamp) ? timestamp : undefined,
+    startedAt: optionalTimestamp(params),
   };
 }
 

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../auth/solid-auth.js';
 import { getAuthProviderProfileSeed } from '../../auth/index.js';
 import { useP2PContext } from '@shared/p2p-context.js';
 import { createRoomSignaling } from '../../realtime/index.js';
+import { subscribe } from '@shared/events/index.js';
 import { getLoggedInUserProfile } from '../../stores/user-profile-store.js';
 import type { MailboxInvite } from '../../../shared/user-mailbox/protocol';
 import {
@@ -38,7 +39,9 @@ type CallHandshakeContextValue = {
 };
 
 const CallHandshakeContext = createContext<CallHandshakeContextValue>();
-const INCOMING_CALL_NOTIFICATION_EVENT = 'hangvidu:incoming-call-notification';
+type IncomingCallNotificationOpenedPayload = IncomingCallNotificationDetails & {
+  accept?: boolean;
+};
 
 function incomingCallNotificationDetailsFromParams(
   params: URLSearchParams,
@@ -57,20 +60,22 @@ function incomingCallNotificationDetailsFromParams(
   };
 }
 
-function incomingCallNotificationDetailsFromEvent(
-  event: Event,
+function incomingCallNotificationDetailsFromPayload(
+  payload: IncomingCallNotificationOpenedPayload,
 ): IncomingCallNotificationDetails | null {
-  const detail = (event as CustomEvent).detail || {};
-  if (typeof detail.roomId !== 'string' || typeof detail.callerId !== 'string')
+  if (
+    typeof payload.roomId !== 'string' ||
+    typeof payload.callerId !== 'string'
+  )
     return null;
   return {
-    roomId: detail.roomId,
-    callerId: detail.callerId,
+    roomId: payload.roomId,
+    callerId: payload.callerId,
     callerName:
-      typeof detail.callerName === 'string' ? detail.callerName : undefined,
-    audioOnly: detail.audioOnly === true,
+      typeof payload.callerName === 'string' ? payload.callerName : undefined,
+    audioOnly: payload.audioOnly === true,
     startedAt:
-      typeof detail.timestamp === 'number' ? detail.timestamp : undefined,
+      typeof payload.startedAt === 'number' ? payload.startedAt : undefined,
   };
 }
 
@@ -153,27 +158,20 @@ export function CallHandshakeProvider(props: ParentProps) {
       );
     }
 
-    const handleIncomingCallNotification = (event: Event) => {
-      const detail = (event as CustomEvent).detail || {};
-      const notificationDetails =
-        incomingCallNotificationDetailsFromEvent(event);
-      if (notificationDetails) {
-        setQueuedNotificationDetails(notificationDetails);
-      }
-      if (detail.accept && typeof detail.roomId === 'string') {
-        setWantAcceptRoomId(detail.roomId);
-      }
-    };
-    window.addEventListener(
-      INCOMING_CALL_NOTIFICATION_EVENT,
-      handleIncomingCallNotification,
+    const unsubscribeIncomingCallNotification = subscribe(
+      'evt:call:notification:opened',
+      (payload: IncomingCallNotificationOpenedPayload) => {
+        const notificationDetails =
+          incomingCallNotificationDetailsFromPayload(payload);
+        if (notificationDetails) {
+          setQueuedNotificationDetails(notificationDetails);
+        }
+        if (payload.accept && typeof payload.roomId === 'string') {
+          setWantAcceptRoomId(payload.roomId);
+        }
+      },
     );
-    onCleanup(() => {
-      window.removeEventListener(
-        INCOMING_CALL_NOTIFICATION_EVENT,
-        handleIncomingCallNotification,
-      );
-    });
+    onCleanup(() => unsubscribeIncomingCallNotification());
 
     createEffect(() => {
       if (!auth.user()?.uid) return;

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -14,7 +14,10 @@ import { useP2PContext } from '@shared/p2p-context.js';
 import { createRoomSignaling } from '../../realtime/index.js';
 import { getLoggedInUserProfile } from '../../stores/user-profile-store.js';
 import type { MailboxInvite } from '../../../shared/user-mailbox/protocol';
-import { CallHandshakeController } from './call-handshake-controller.js';
+import {
+  CallHandshakeController,
+  type IncomingCallNotificationDetails,
+} from './call-handshake-controller.js';
 import type {
   CallHandshakeState,
   PendingOutgoingCall,
@@ -35,6 +38,45 @@ type CallHandshakeContextValue = {
 };
 
 const CallHandshakeContext = createContext<CallHandshakeContextValue>();
+const INCOMING_CALL_NOTIFICATION_EVENT = 'hangvidu:incoming-call-notification';
+
+function incomingCallRoomParam(params: URLSearchParams): string | null {
+  return params.get('callRoom') || params.get('room');
+}
+
+function incomingCallNotificationDetailsFromParams(
+  params: URLSearchParams,
+): IncomingCallNotificationDetails | null {
+  const roomId = incomingCallRoomParam(params);
+  const callerId = params.get('callerId');
+  if (!roomId || !callerId) return null;
+
+  const timestamp = Number(params.get('timestamp'));
+  return {
+    roomId,
+    callerId,
+    callerName: params.get('callerName') || undefined,
+    audioOnly: params.get('audioOnly') === '1',
+    startedAt: Number.isFinite(timestamp) ? timestamp : undefined,
+  };
+}
+
+function incomingCallNotificationDetailsFromEvent(
+  event: Event,
+): IncomingCallNotificationDetails | null {
+  const detail = (event as CustomEvent).detail || {};
+  if (typeof detail.roomId !== 'string' || typeof detail.callerId !== 'string')
+    return null;
+  return {
+    roomId: detail.roomId,
+    callerId: detail.callerId,
+    callerName:
+      typeof detail.callerName === 'string' ? detail.callerName : undefined,
+    audioOnly: detail.audioOnly === true,
+    startedAt:
+      typeof detail.timestamp === 'number' ? detail.timestamp : undefined,
+  };
+}
 
 export function CallHandshakeProvider(props: ParentProps) {
   const p2p = useP2PContext();
@@ -95,7 +137,13 @@ export function CallHandshakeProvider(props: ParentProps) {
   if (typeof window !== 'undefined') {
     const params = new URLSearchParams(window.location.search);
     const hasAcceptMarker = params.get('accept') === '1';
-    let wantAcceptRoomId = hasAcceptMarker ? params.get('room') : null;
+    const [queuedNotificationDetails, setQueuedNotificationDetails] =
+      createSignal<IncomingCallNotificationDetails | null>(
+        incomingCallNotificationDetailsFromParams(params),
+      );
+    const [wantAcceptRoomId, setWantAcceptRoomId] = createSignal<string | null>(
+      hasAcceptMarker ? incomingCallRoomParam(params) : null,
+    );
     if (hasAcceptMarker) {
       // Strip the marker so a reload/back doesn't re-trigger the accept.
       params.delete('accept');
@@ -108,10 +156,42 @@ export function CallHandshakeProvider(props: ParentProps) {
           : window.location.pathname,
       );
     }
+
+    const handleIncomingCallNotification = (event: Event) => {
+      const detail = (event as CustomEvent).detail || {};
+      const notificationDetails =
+        incomingCallNotificationDetailsFromEvent(event);
+      if (notificationDetails) {
+        setQueuedNotificationDetails(notificationDetails);
+      }
+      if (detail.accept && typeof detail.roomId === 'string') {
+        setWantAcceptRoomId(detail.roomId);
+      }
+    };
+    window.addEventListener(
+      INCOMING_CALL_NOTIFICATION_EVENT,
+      handleIncomingCallNotification,
+    );
+    onCleanup(() => {
+      window.removeEventListener(
+        INCOMING_CALL_NOTIFICATION_EVENT,
+        handleIncomingCallNotification,
+      );
+    });
+
+    createEffect(() => {
+      if (!auth.user()?.uid) return;
+      const notificationDetails = queuedNotificationDetails();
+      if (!notificationDetails) return;
+      setQueuedNotificationDetails(null);
+      controller.showIncomingCallFromNotification(notificationDetails);
+    });
+
     createEffect(() => {
       const call = incomingCall();
-      if (wantAcceptRoomId && call?.roomId === wantAcceptRoomId) {
-        wantAcceptRoomId = null;
+      const roomId = wantAcceptRoomId();
+      if (roomId && call?.roomId === roomId) {
+        setWantAcceptRoomId(null);
         controller.acceptIncoming();
       }
     });

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -41,12 +41,7 @@ const CallHandshakeContext = createContext<CallHandshakeContextValue>();
 const INCOMING_CALL_NOTIFICATION_EVENT = 'hangvidu:incoming-call-notification';
 
 function incomingCallRoomParam(params: URLSearchParams): string | null {
-  return (
-    params.get('conversationRoom') ||
-    // Legacy names used before conversation/public room URLs were explicit.
-    params.get('callRoom') ||
-    (params.get('callerId') ? params.get('room') : null)
-  );
+  return params.get('conversationRoom');
 }
 
 function incomingCallNotificationDetailsFromParams(

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -40,14 +40,10 @@ type CallHandshakeContextValue = {
 const CallHandshakeContext = createContext<CallHandshakeContextValue>();
 const INCOMING_CALL_NOTIFICATION_EVENT = 'hangvidu:incoming-call-notification';
 
-function incomingCallRoomParam(params: URLSearchParams): string | null {
-  return params.get('conversationRoom');
-}
-
 function incomingCallNotificationDetailsFromParams(
   params: URLSearchParams,
 ): IncomingCallNotificationDetails | null {
-  const roomId = incomingCallRoomParam(params);
+  const roomId = params.get('conversationRoom');
   const callerId = params.get('callerId');
   if (!roomId || !callerId) return null;
 
@@ -142,7 +138,7 @@ export function CallHandshakeProvider(props: ParentProps) {
         incomingCallNotificationDetailsFromParams(params),
       );
     const [wantAcceptRoomId, setWantAcceptRoomId] = createSignal<string | null>(
-      hasAcceptMarker ? incomingCallRoomParam(params) : null,
+      hasAcceptMarker ? params.get('conversationRoom') : null,
     );
     if (hasAcceptMarker) {
       // Strip the marker so a reload/back doesn't re-trigger the accept.

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -9,11 +9,13 @@ import styles from './ActiveCallRoom.module.css';
 export default function ActiveCallRoom() {
   const p2p = useP2PContext();
 
-  // Room-link (guest) calls carry ?room= in the URL; contact calls don't.
+  // Room-link (guest) calls carry ?publicRoom= in the URL; contact calls don't.
   // Only those can re-share the page URL as an invite.
-  const isRoomLinkCall = new URLSearchParams(window.location.search).has(
-    'room',
-  );
+  const params = new URLSearchParams(window.location.search);
+  const isRoomLinkCall =
+    params.has('publicRoom') ||
+    // Back-compat for existing guest links generated before publicRoom.
+    params.has('room');
   const [copied, setCopied] = createSignal(false);
 
   async function copyLink() {

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -11,11 +11,9 @@ export default function ActiveCallRoom() {
 
   // Room-link (guest) calls carry ?publicRoom= in the URL; contact calls don't.
   // Only those can re-share the page URL as an invite.
-  const params = new URLSearchParams(window.location.search);
-  const isRoomLinkCall =
-    params.has('publicRoom') ||
-    // Back-compat for existing guest links generated before publicRoom.
-    params.has('room');
+  const isRoomLinkCall = new URLSearchParams(window.location.search).has(
+    'publicRoom',
+  );
   const [copied, setCopied] = createSignal(false);
 
   async function copyLink() {

--- a/src/features/call/components/CallLobby.tsx
+++ b/src/features/call/components/CallLobby.tsx
@@ -28,9 +28,8 @@ function joinErrorMessage(err: unknown, kind: string | undefined): string {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function roomIdFromUrl(): string | null {
-  const params = new URLSearchParams(window.location.search);
-  const raw = params.get('publicRoom') || params.get('room');
+function publicRoomIdFromUrl(): string | null {
+  const raw = new URLSearchParams(window.location.search).get('publicRoom');
   return raw && UUID_RE.test(raw) ? raw : null;
 }
 
@@ -40,7 +39,7 @@ export default function CallLobby() {
   // Set when the visitor arrived via an invite link; cleared once that
   // call ends (the room link is single-use).
   const [invitedRoomId, setInvitedRoomId] = createSignal<string | null>(
-    roomIdFromUrl(),
+    publicRoomIdFromUrl(),
   );
 
   const [roomId, setRoomId] = createSignal<string | null>(invitedRoomId());
@@ -61,7 +60,6 @@ export default function CallLobby() {
         if (prev === 'joined') {
           const url = new URL(window.location.href);
           url.searchParams.delete('publicRoom');
-          url.searchParams.delete('room');
           window.history.replaceState(null, '', url);
           setRoomId(null);
           setInvitedRoomId(null);
@@ -75,7 +73,6 @@ export default function CallLobby() {
     const id = crypto.randomUUID();
     const url = new URL(window.location.href);
     url.searchParams.set('publicRoom', id);
-    url.searchParams.delete('room');
     window.history.replaceState(null, '', url);
     setRoomId(id);
     setCallEnded(false);

--- a/src/features/call/components/CallLobby.tsx
+++ b/src/features/call/components/CallLobby.tsx
@@ -1,4 +1,4 @@
-// Guest call lobby: create a room-link call or join one via ?room=<id>.
+// Guest call lobby: create a room-link call or join one via ?publicRoom=<id>.
 // No account needed — signs in anonymously for the signaling token.
 // TODO: design pass deferred until the Tailwind migration.
 import { createSignal, createEffect, on, Show } from 'solid-js';
@@ -23,13 +23,14 @@ function joinErrorMessage(err: unknown, kind: string | undefined): string {
   return t('call.lobby.error.generic');
 }
 
-// Room ids are crypto.randomUUID(); anything else in ?room= is a mangled
+// Room ids are crypto.randomUUID(); anything else in ?publicRoom= is a mangled
 // or forged link — drop it instead of attempting a join that can't work.
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function roomIdFromUrl(): string | null {
-  const raw = new URLSearchParams(window.location.search).get('room');
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get('publicRoom') || params.get('room');
   return raw && UUID_RE.test(raw) ? raw : null;
 }
 
@@ -59,6 +60,7 @@ export default function CallLobby() {
         setJoining(false);
         if (prev === 'joined') {
           const url = new URL(window.location.href);
+          url.searchParams.delete('publicRoom');
           url.searchParams.delete('room');
           window.history.replaceState(null, '', url);
           setRoomId(null);
@@ -72,7 +74,8 @@ export default function CallLobby() {
   function createRoom() {
     const id = crypto.randomUUID();
     const url = new URL(window.location.href);
-    url.searchParams.set('room', id);
+    url.searchParams.set('publicRoom', id);
+    url.searchParams.delete('room');
     window.history.replaceState(null, '', url);
     setRoomId(id);
     setCallEnded(false);

--- a/src/push/__tests__/shared-contracts.test.js
+++ b/src/push/__tests__/shared-contracts.test.js
@@ -94,7 +94,7 @@ describe('shared push notification contracts', () => {
   it('parses service worker NAVIGATE messages', () => {
     const message = parseServiceWorkerNavigateMessage({
       type: 'NAVIGATE',
-      path: '/?callRoom=room-123',
+      path: '/?conversationRoom=room-123',
     });
 
     expect(message.type).toBe('NAVIGATE');

--- a/src/push/__tests__/shared-contracts.test.js
+++ b/src/push/__tests__/shared-contracts.test.js
@@ -94,7 +94,7 @@ describe('shared push notification contracts', () => {
   it('parses service worker NAVIGATE messages', () => {
     const message = parseServiceWorkerNavigateMessage({
       type: 'NAVIGATE',
-      path: '/?room=room-123',
+      path: '/?callRoom=room-123',
     });
 
     expect(message.type).toBe('NAVIGATE');

--- a/src/push/sw/__tests__/notification-click-handler.test.js
+++ b/src/push/sw/__tests__/notification-click-handler.test.js
@@ -7,7 +7,7 @@ import {
 } from '../notification-click-handler.js';
 
 describe('notification click routing', () => {
-  it('routes incoming call notifications to the room path', () => {
+  it('routes incoming call notifications to a call-specific path', () => {
     expect(
       getNotificationNavigationPath(
         {
@@ -16,7 +16,7 @@ describe('notification click routing', () => {
         },
         undefined,
       ),
-    ).toBe('/?room=room-123');
+    ).toBe('/?callRoom=room-123');
   });
 
   it('marks the incoming-call path for auto-accept on the explicit accept action', () => {
@@ -25,7 +25,24 @@ describe('notification click routing', () => {
         { type: 'incoming_call', roomId: 'room-123' },
         'accept',
       ),
-    ).toBe('/?room=room-123&accept=1');
+    ).toBe('/?callRoom=room-123&accept=1');
+  });
+
+  it('carries caller metadata for incoming call notification clicks', () => {
+    expect(
+      getNotificationNavigationPath(
+        {
+          type: 'incoming_call',
+          roomId: 'room-123',
+          callerId: 'caller-1',
+          callerName: 'Caller Name',
+          timestamp: '1774025000000',
+        },
+        undefined,
+      ),
+    ).toBe(
+      '/?callRoom=room-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
+    );
   });
 
   it('routes missed calls explicitly to caller contact first, then room fallback', () => {

--- a/src/push/sw/__tests__/notification-click-handler.test.js
+++ b/src/push/sw/__tests__/notification-click-handler.test.js
@@ -59,7 +59,7 @@ describe('notification click routing', () => {
         type: 'missed_call',
         roomId: 'room-fallback',
       }),
-    ).toBe('/?conversationRoom=room-fallback');
+    ).toBe('/?conversationId=room-fallback');
 
     expect(
       getNotificationNavigationPath({

--- a/src/push/sw/__tests__/notification-click-handler.test.js
+++ b/src/push/sw/__tests__/notification-click-handler.test.js
@@ -7,7 +7,7 @@ import {
 } from '../notification-click-handler.js';
 
 describe('notification click routing', () => {
-  it('routes incoming call notifications to a call-specific path', () => {
+  it('routes incoming call notifications to a conversation room path', () => {
     expect(
       getNotificationNavigationPath(
         {
@@ -16,7 +16,7 @@ describe('notification click routing', () => {
         },
         undefined,
       ),
-    ).toBe('/?callRoom=room-123');
+    ).toBe('/?conversationRoom=room-123');
   });
 
   it('marks the incoming-call path for auto-accept on the explicit accept action', () => {
@@ -25,7 +25,7 @@ describe('notification click routing', () => {
         { type: 'incoming_call', roomId: 'room-123' },
         'accept',
       ),
-    ).toBe('/?callRoom=room-123&accept=1');
+    ).toBe('/?conversationRoom=room-123&accept=1');
   });
 
   it('carries caller metadata for incoming call notification clicks', () => {
@@ -41,7 +41,7 @@ describe('notification click routing', () => {
         undefined,
       ),
     ).toBe(
-      '/?callRoom=room-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
+      '/?conversationRoom=room-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
     );
   });
 
@@ -59,7 +59,7 @@ describe('notification click routing', () => {
         type: 'missed_call',
         roomId: 'room-fallback',
       }),
-    ).toBe('/?room=room-fallback');
+    ).toBe('/?conversationRoom=room-fallback');
 
     expect(
       getNotificationNavigationPath({

--- a/src/push/sw/notification-click-handler.js
+++ b/src/push/sw/notification-click-handler.js
@@ -4,15 +4,30 @@ import { isIncomingCallType } from './notification-presentation.js';
  * Maps normalized notification payload data to the app navigation path.
  */
 export function getNotificationNavigationPath(data, action) {
-  const { type, roomId, senderId, callerId, conversationId, conversationKind } =
-    data || {};
+  const {
+    type,
+    roomId,
+    senderId,
+    callerId,
+    callerName,
+    audioOnly,
+    timestamp,
+    conversationId,
+    conversationKind,
+  } = data || {};
 
   if (isIncomingCallType(type)) {
     if (!roomId) return '/';
-    const path = `/?room=${encodeURIComponent(roomId)}`;
+    const params = new URLSearchParams({ callRoom: roomId });
+    if (callerId) params.set('callerId', callerId);
+    if (callerName) params.set('callerName', callerName);
+    if (audioOnly === true || audioOnly === 'true')
+      params.set('audioOnly', '1');
+    if (timestamp) params.set('timestamp', String(timestamp));
     // The explicit "Accept" notification action (where supported) auto-answers;
     // a plain body click just opens the in-app incoming-call dialog.
-    return action === 'accept' ? `${path}&accept=1` : path;
+    if (action === 'accept') params.set('accept', '1');
+    return `/?${params.toString()}`;
   }
 
   if (type === 'missed_call') {

--- a/src/push/sw/notification-click-handler.js
+++ b/src/push/sw/notification-click-handler.js
@@ -36,7 +36,7 @@ export function getNotificationNavigationPath(data, action) {
     }
 
     if (roomId) {
-      return `/?conversationRoom=${encodeURIComponent(roomId)}`;
+      return `/?conversationId=${encodeURIComponent(roomId)}`;
     }
 
     return '/';

--- a/src/push/sw/notification-click-handler.js
+++ b/src/push/sw/notification-click-handler.js
@@ -18,7 +18,7 @@ export function getNotificationNavigationPath(data, action) {
 
   if (isIncomingCallType(type)) {
     if (!roomId) return '/';
-    const params = new URLSearchParams({ callRoom: roomId });
+    const params = new URLSearchParams({ conversationRoom: roomId });
     if (callerId) params.set('callerId', callerId);
     if (callerName) params.set('callerName', callerName);
     if (audioOnly === true || audioOnly === 'true')
@@ -36,7 +36,7 @@ export function getNotificationNavigationPath(data, action) {
     }
 
     if (roomId) {
-      return `/?room=${encodeURIComponent(roomId)}`;
+      return `/?conversationRoom=${encodeURIComponent(roomId)}`;
     }
 
     return '/';


### PR DESCRIPTION
## Summary

- Fix incoming-call notification clicks so they no longer collide with public guest room links.
- Route saved-conversation call rooms through `conversationRoom` and guest/share-link rooms through `publicRoom`.
- Surface an incoming-call dialog from notification metadata if the mailbox replay is late.
- Keep the callee room alive through the first expected `onAlone` event while the caller is being notified of acceptance.
- Remove legacy notification URL fallbacks and trim duplicate URL parsing.

## Root Cause

Incoming-call push URLs reused the public `room` query parameter, so mobile notification entry could be interpreted as a guest room link. The callee could also auto-close the accepted room when initially alone before the caller received the accepted response and joined.

## Validation

- `vp check`
- `vp test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming-call notifications now route via `conversationRoom`, including caller metadata, optional `audioOnly`, optional `timestamp`, and `accept=1` for immediate handling.
  * Added external-notification support to start/show the incoming call UI.
  * Guest call links now use the `publicRoom` query format.

* **Bug Fixes**
  * Prevented accepted incoming calls from closing while the caller is still joining.
  * Improved service worker navigation for call and missed-call redirects, and URL cleanup to avoid stale invite links.

* **Tests**
  * Updated and added coverage for notification routing, navigation URL contracts, and incoming-call handshake behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->