### PR TITLE
Fix notification-opened call hangup

### DIFF
--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -181,10 +181,13 @@ describe('CallHandshakeController', () => {
     });
   });
 
-  it('does not close an accepted incoming room while waiting for the caller to join', async () => {
+  it('closes a notification-opened call when the remote caller leaves while the accept response is pending', async () => {
+    let onAlone;
+    const acceptResponse = deferred();
+    mocks.respondToIncomingCallInvite.mockReturnValue(acceptResponse.promise);
     const p2p = {
       join: vi.fn(async (options) => {
-        options.onAlone?.({ roomId: 'room-1', members: ['callee-id'] });
+        onAlone = options.onAlone;
         return { roomId: 'room-1', members: ['callee-id'] };
       }),
       close: vi.fn(),
@@ -199,16 +202,12 @@ describe('CallHandshakeController', () => {
       onCalleeBusy: vi.fn(),
     });
 
-    controller.init();
-    mocks.incomingCallback?.({
-      type: 'invite',
-      invite: {
-        roomId: 'room-1',
-        callerId: 'caller-id',
-        callerName: 'Caller',
-        audioOnly: false,
-        expiresAt: Date.now() + 60_000,
-      },
+    controller.showIncomingCallFromNotification({
+      roomId: 'room-1',
+      callerId: 'caller-id',
+      callerName: 'Caller',
+      audioOnly: false,
+      startedAt: Date.now(),
     });
 
     controller.acceptIncoming();
@@ -219,7 +218,10 @@ describe('CallHandshakeController', () => {
       callerId: 'caller-id',
       responseType: 'accepted',
     });
-    expect(p2p.close).not.toHaveBeenCalled();
+
+    onAlone?.({ members: ['callee-id'], memberCount: 1 });
+
+    expect(p2p.close).toHaveBeenCalledTimes(1);
   });
 
   it('does not notify accepted when joining the room fails', async () => {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -51,7 +51,6 @@ export type IncomingCallNotificationDetails = {
 type EnterRoomOptions = {
   memberCapacity?: number;
   autoExitOnEmpty?: boolean;
-  ignoreInitialAlone?: boolean;
 };
 
 export class CallHandshakeController {
@@ -374,13 +373,8 @@ export class CallHandshakeController {
     localUserId: string,
     audioOnly = false,
     getLocalStream?: () => Promise<MediaStream>,
-    {
-      memberCapacity = 2,
-      autoExitOnEmpty = true,
-      ignoreInitialAlone = false,
-    }: EnterRoomOptions = {},
+    { memberCapacity = 2, autoExitOnEmpty = true }: EnterRoomOptions = {},
   ) {
-    let ignoredInitialAlone = false;
     const room = await this.p2p.join({
       roomId,
       peerId: localUserId,
@@ -391,10 +385,6 @@ export class CallHandshakeController {
       dataChannel: true,
       onAlone: (detail) => {
         if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
-        if (ignoreInitialAlone && !ignoredInitialAlone) {
-          ignoredInitialAlone = true;
-          return;
-        }
         if (autoExitOnEmpty) this.exitActiveRoom();
       },
     });
@@ -486,13 +476,7 @@ export class CallHandshakeController {
     if (!svc || !localUID) return;
     this.clearOutgoingCallTracking();
     this.setHandshakeState(null);
-    this.enterRoom(
-      state.call.roomId,
-      localUID,
-      state.call.audioOnly ?? false,
-      undefined,
-      { ignoreInitialAlone: true },
-    )
+    this.enterRoom(state.call.roomId, localUID, state.call.audioOnly ?? false)
       .then(() =>
         svc.respondToIncomingCallInvite({
           roomId: state.call.roomId,


### PR DESCRIPTION
## What changed

- remove the `ignoreInitialAlone` behavior from accepted incoming calls
- close the local P2P room whenever `onAlone` reports that the remote participant left
- replace the invalid initial-alone test with a notification-opened call regression test

## Root cause

The push-notification handoff added `ignoreInitialAlone` under the assumption that the first `onAlone` event could occur while waiting for the caller to join. The P2P room contract does not emit `onAlone` for an initially empty room; it emits only after a remote member was present and the remote member count transitions to zero.

Consequently, the ignored first event was the real caller hang-up. The callee never called `p2p.close()`, leaving P2P state active and the UI stuck on the black call view.

## User impact

Incoming DM calls restored by opening a push notification now exit locally when the remote caller hangs up, including when the accept-response request is still pending.

## Validation

- `vp check --fix`
- `vp test` — 338 passed, 1 skipped
- focused notification-opened hang-up regression test
- standards and spec review completed with no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of incoming calls opened from notifications when the caller leaves before the call is fully connected.
  - Ensured call rooms close promptly when no remote participant remains.
  - Updated incoming-call connection behavior to handle the initial room state more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->