### PR TITLE
Clear push notifications on foreground

### DIFF
--- a/src/push/__tests__/push-notifications.browser.test.js
+++ b/src/push/__tests__/push-notifications.browser.test.js
@@ -426,6 +426,17 @@ describe('PushNotifications', () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it('dismisses every delivered notification', async () => {
+    const notifications = [{ close: vi.fn() }, { close: vi.fn() }];
+    registration.getNotifications.mockResolvedValue(notifications);
+
+    await controller.dismissAllNotifications();
+
+    expect(registration.getNotifications).toHaveBeenCalledWith();
+    expect(notifications[0].close).toHaveBeenCalledOnce();
+    expect(notifications[1].close).toHaveBeenCalledOnce();
+  });
+
   it('fails fast when no active service worker registration exists', async () => {
     navigator.serviceWorker.getRegistration.mockResolvedValue(null);
 

--- a/src/push/__tests__/setup.test.js
+++ b/src/push/__tests__/setup.test.js
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => {
   return {
     handlers,
     serviceWorkerMessageHandler: undefined,
+    visibilityChangeHandler: undefined,
     handleCommand: vi.fn((eventName, handler) => {
       handlers.set(eventName, handler);
       return () => handlers.delete(eventName);
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => {
     disable: vi.fn(() => Promise.resolve()),
     enable: vi.fn(() => Promise.resolve()),
     ensureEnabledIfGranted: vi.fn(),
+    dismissAllNotifications: vi.fn(() => Promise.resolve()),
     getPushNotifications: vi.fn(),
     initPushNotifications: vi.fn(),
   };
@@ -40,6 +42,18 @@ describe('push-notifications setup', () => {
     vi.clearAllMocks();
     mocks.handlers.clear();
     mocks.serviceWorkerMessageHandler = undefined;
+    mocks.visibilityChangeHandler = undefined;
+    Object.defineProperty(globalThis, 'document', {
+      value: {
+        visibilityState: 'visible',
+        addEventListener: vi.fn((eventName, handler) => {
+          if (eventName === 'visibilitychange') {
+            mocks.visibilityChangeHandler = handler;
+          }
+        }),
+      },
+      configurable: true,
+    });
     Object.defineProperty(globalThis, 'navigator', {
       value: {
         serviceWorker: {
@@ -56,6 +70,7 @@ describe('push-notifications setup', () => {
       disable: mocks.disable,
       enable: mocks.enable,
       ensureEnabledIfGranted: mocks.ensureEnabledIfGranted,
+      dismissAllNotifications: mocks.dismissAllNotifications,
     });
     mocks.initPushNotifications.mockResolvedValue(mocks.getPushNotifications());
     mocks.ensureEnabledIfGranted.mockResolvedValue({ state: 'enabled' });
@@ -78,6 +93,21 @@ describe('push-notifications setup', () => {
     await push.setup();
 
     expect(mocks.initPushNotifications).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses notifications on startup and when returning to the foreground', async () => {
+    const push = await import('../index.js');
+
+    await push.setup();
+    expect(mocks.dismissAllNotifications).toHaveBeenCalledOnce();
+
+    document.visibilityState = 'hidden';
+    mocks.visibilityChangeHandler?.();
+    expect(mocks.dismissAllNotifications).toHaveBeenCalledOnce();
+
+    document.visibilityState = 'visible';
+    mocks.visibilityChangeHandler?.();
+    expect(mocks.dismissAllNotifications).toHaveBeenCalledTimes(2);
   });
 
   it('prompts for push when login finds permission is not decided', async () => {

--- a/src/push/index.js
+++ b/src/push/index.js
@@ -15,6 +15,17 @@ export {
   initPushNotifications,
 } from './push-notifications.js';
 
+async function dismissAllNotifications() {
+  try {
+    await getPushNotifications()?.dismissAllNotifications?.();
+  } catch (error) {
+    console.warn(
+      '[Push Notifications] Failed to dismiss notifications:',
+      error,
+    );
+  }
+}
+
 /**
  * Registers app-level command handlers for push notifications.
  * See the setup contract in `createSingleFlightSetup`.
@@ -24,6 +35,18 @@ export {
 export const setup = createSingleFlightSetup({
   label: '[push-notifications]',
   register: (signal) => {
+    if (typeof document !== 'undefined') {
+      document.addEventListener(
+        'visibilitychange',
+        () => {
+          if (document.visibilityState === 'visible') {
+            void dismissAllNotifications();
+          }
+        },
+        { signal },
+      );
+    }
+
     handleCommand(
       'cmd:push:subscription:disable',
       async () => {
@@ -122,5 +145,13 @@ export const setup = createSingleFlightSetup({
       { signal },
     );
   },
-  start: () => initPushNotifications(),
+  start: async () => {
+    await initPushNotifications();
+    if (
+      typeof document !== 'undefined' &&
+      document.visibilityState === 'visible'
+    ) {
+      await dismissAllNotifications();
+    }
+  },
 });

--- a/src/push/push-notifications.js
+++ b/src/push/push-notifications.js
@@ -478,6 +478,16 @@ export class PushNotifications {
   }
 
   /**
+   * Closes every notification delivered by the current service worker.
+   */
+  async dismissAllNotifications() {
+    const registration = await this.getServiceWorkerRegistration();
+    const notifications = await registration.getNotifications();
+    notifications.forEach((notification) => notification.close());
+    this.activeNotifications.clear();
+  }
+
+  /**
    * Closes visible message notifications associated with one sender.
    */
   async dismissMessageNotifications(senderId) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications are now automatically dismissed when the app starts in a visible state or becomes visible again.
  * Added support for dismissing all currently displayed push notifications at once.

* **Bug Fixes**
  * Improved cleanup of previously delivered notifications to prevent stale notifications from remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->