### PR TITLE
Add camera switching and screen sharing

### DIFF
--- a/config/origins.json
+++ b/config/origins.json
@@ -3,11 +3,8 @@
     "https://hangvidu.com",
     "https://www.hangvidu.com",
     "https://vidu-aae11.web.app",
-    "https://vidu-aae11.firebaseapp.com"
-  ],
-  "development": [
-    "https://localhost:5173",
-    "http://localhost:5173",
+    "https://vidu-aae11.firebaseapp.com",
     "https://dev.hangvidu.com"
-  ]
+  ],
+  "development": ["https://localhost:5173", "http://localhost:5173"]
 }

--- a/src/features/call/call-media.test.jsx
+++ b/src/features/call/call-media.test.jsx
@@ -190,6 +190,10 @@ describe('call media', () => {
           deviceId: { exact: 'facetime-camera' },
         }),
       });
+      expect(room.setLocalTrack).toHaveBeenLastCalledWith(
+        PRIMARY_VIDEO_SLOT_ID,
+        frontCamera,
+      );
       expect(backCamera.stop).toHaveBeenCalledOnce();
       dispose();
     });

--- a/src/features/call/call-media.test.jsx
+++ b/src/features/call/call-media.test.jsx
@@ -61,6 +61,7 @@ describe('call media', () => {
       configurable: true,
       value: {
         mediaDevices: {
+          enumerateDevices: vi.fn(async () => []),
           getSupportedConstraints: () => ({}),
           getUserMedia,
         },
@@ -88,7 +89,27 @@ describe('call media', () => {
     ]);
   });
 
-  it('acquires and publishes video for an audio-only call', async () => {
+  it('does not offer camera switching for duplicate entries from one camera', async () => {
+    navigator.mediaDevices.enumerateDevices = vi.fn(async () => [
+      { kind: 'videoinput', deviceId: 'default', groupId: 'camera-1' },
+      { kind: 'videoinput', deviceId: 'camera-1', groupId: 'camera-1' },
+    ]);
+    const p2p = { localStream: () => undefined, room: () => undefined };
+    let media;
+    let dispose;
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      media = createCallMedia(p2p);
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(media.cameraSwitchAvailable()).toBe(false);
+    dispose();
+  });
+
+  it('acquires, publishes, and switches video for an audio-only call', async () => {
     const microphone = createTrack('audio');
     const camera = createTrack('video');
     const localTracks = [microphone];
@@ -128,6 +149,48 @@ describe('call media', () => {
       );
       expect(media.cameraOn()).toBe(true);
       expect(room.setPresenceData).toHaveBeenCalledWith({ cameraOn: true });
+
+      const backCamera = createTrack('video');
+      camera.getSettings = () => ({ deviceId: 'facetime-camera' });
+      navigator.mediaDevices.enumerateDevices = vi.fn(async () => [
+        {
+          kind: 'videoinput',
+          deviceId: 'facetime-camera',
+          groupId: 'facetime-group',
+        },
+        {
+          kind: 'videoinput',
+          deviceId: 'iphone-camera',
+          groupId: 'iphone-group',
+        },
+      ]);
+      getUserMedia.mockResolvedValue(createStream([backCamera]));
+
+      await media.switchCamera();
+
+      expect(getUserMedia).toHaveBeenLastCalledWith({
+        video: expect.objectContaining({
+          deviceId: { exact: 'iphone-camera' },
+        }),
+      });
+      expect(room.setLocalTrack).toHaveBeenLastCalledWith(
+        PRIMARY_VIDEO_SLOT_ID,
+        backCamera,
+      );
+      expect(camera.stop).toHaveBeenCalledOnce();
+
+      const frontCamera = createTrack('video');
+      backCamera.getSettings = () => ({ deviceId: 'iphone-camera' });
+      getUserMedia.mockResolvedValue(createStream([frontCamera]));
+
+      await media.switchCamera();
+
+      expect(getUserMedia).toHaveBeenLastCalledWith({
+        video: expect.objectContaining({
+          deviceId: { exact: 'facetime-camera' },
+        }),
+      });
+      expect(backCamera.stop).toHaveBeenCalledOnce();
       dispose();
     });
   });

--- a/src/features/call/call-media.ts
+++ b/src/features/call/call-media.ts
@@ -308,7 +308,14 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
       try {
         await room.setLocalTrack(PRIMARY_VIDEO_SLOT_ID, nextTrack);
       } catch (error) {
-        nextTrack.stop();
+        if (room.localStream?.getTracks().includes(nextTrack)) {
+          ownedCameraTracks.add(nextTrack);
+          currentTrack.stop();
+          ownedCameraTracks.delete(currentTrack);
+          syncTrackState();
+        } else {
+          nextTrack.stop();
+        }
         throw error;
       }
       ownedCameraTracks.add(nextTrack);
@@ -394,6 +401,19 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
         stream.getTracks().forEach((track) => track.stop());
         throw new Error('Screen capture returned no video track');
       }
+      displayTrack.addEventListener(
+        'ended',
+        () => {
+          if (cameraPending()) {
+            screenStopRequested = true;
+            return;
+          }
+          void stopScreenShare().catch((error) => {
+            console.error('[CallMedia] Failed to stop screen sharing', error);
+          });
+        },
+        { once: true },
+      );
       stream
         .getTracks()
         .filter((track) => track !== displayTrack)
@@ -413,14 +433,6 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
 
       screenTrack = displayTrack;
       setScreenSharing(true);
-      displayTrack.addEventListener(
-        'ended',
-        () =>
-          void stopScreenShare().catch((error) => {
-            console.error('[CallMedia] Failed to stop screen sharing', error);
-          }),
-        { once: true },
-      );
       await finishCommittedCameraChange(room, true, replacementError);
       syncTrackState();
     } catch (error) {

--- a/src/features/call/call-media.ts
+++ b/src/features/call/call-media.ts
@@ -7,12 +7,29 @@ import { getVideoConstraints } from './media-constraints.js';
 export const MICROPHONE_SLOT_ID = 'microphone';
 export const PRIMARY_VIDEO_SLOT_ID = 'primary-video';
 
+const cameraKey = (device: MediaDeviceInfo) =>
+  device.groupId || device.deviceId;
+
+function uniqueCameras(devices: MediaDeviceInfo[]) {
+  const cameras = devices.filter((device) => device.kind === 'videoinput');
+  return cameras.filter(
+    (camera, index) =>
+      cameras.findIndex((other) => cameraKey(other) === cameraKey(camera)) ===
+      index,
+  );
+}
+
 export type CallMedia = {
   micOn: Accessor<boolean>;
   cameraOn: Accessor<boolean>;
   cameraPending: Accessor<boolean>;
+  cameraSwitchAvailable: Accessor<boolean>;
+  screenShareAvailable: Accessor<boolean>;
+  screenSharing: Accessor<boolean>;
   setMicEnabled: (enabled: boolean) => void;
   setCameraEnabled: (enabled: boolean) => Promise<void>;
+  switchCamera: () => Promise<void>;
+  toggleScreenShare: () => Promise<void>;
 };
 
 export function createCallLocalTrackSlots(
@@ -38,6 +55,35 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
   const [micOn, setMicOn] = createSignal(false);
   const [cameraOn, setCameraOn] = createSignal(false);
   const [cameraPending, setCameraPending] = createSignal(false);
+  const [cameraSwitchAvailable, setCameraSwitchAvailable] = createSignal(false);
+  const [screenSharing, setScreenSharing] = createSignal(false);
+  const screenShareAvailable = () =>
+    typeof navigator.mediaDevices?.getDisplayMedia === 'function';
+  let screenTrack: MediaStreamTrack | undefined;
+  let cameraBeforeScreenShare: MediaStreamTrack | null = null;
+  let screenStopRequested = false;
+
+  async function refreshCameraSwitchAvailability(log = false) {
+    const devices = await navigator.mediaDevices
+      ?.enumerateDevices?.()
+      .catch(() => []);
+    const videoDevices =
+      devices?.filter((device) => device.kind === 'videoinput') ?? [];
+    const distinctCameras = uniqueCameras(videoDevices).length;
+    const available = distinctCameras > 1;
+    setCameraSwitchAvailable(available);
+    if (log) {
+      console.info('[CallMedia] Media devices changed', {
+        videoInputs: videoDevices.length,
+        distinctCameras,
+        cameraSwitchAvailable: available,
+      });
+    }
+  }
+
+  const onDeviceChange = () => void refreshCameraSwitchAvailability(true);
+  void refreshCameraSwitchAvailability();
+  navigator.mediaDevices?.addEventListener?.('devicechange', onDeviceChange);
 
   const syncTrackState = () => {
     const stream = localStream();
@@ -80,6 +126,11 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
   });
 
   onCleanup(() => {
+    navigator.mediaDevices?.removeEventListener?.(
+      'devicechange',
+      onDeviceChange,
+    );
+    screenTrack?.stop();
     ownedCameraTracks.forEach((track) => track.stop());
     ownedCameraTracks.clear();
   });
@@ -123,7 +174,7 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
   }
 
   async function setCameraEnabled(enabled: boolean) {
-    if (cameraPending()) return;
+    if (cameraPending() || screenSharing()) return;
     const room = p2p.room();
     if (!room) throw new Error('Cannot change camera without an active room');
 
@@ -178,6 +229,8 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
         .filter((track) => track !== cameraTrack)
         .forEach((track) => track.stop());
 
+      void refreshCameraSwitchAvailability();
+
       let replacementError: unknown;
       try {
         await room.setLocalTrack(PRIMARY_VIDEO_SLOT_ID, cameraTrack);
@@ -205,11 +258,199 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
     }
   }
 
+  async function switchCamera() {
+    if (cameraPending() || screenSharing()) return;
+    const room = p2p.room();
+    if (!room) throw new Error('Cannot switch camera without an active room');
+
+    const currentTrack = localStream()
+      ?.getVideoTracks()
+      .find((track) => track.readyState === 'live');
+    if (!currentTrack) throw new Error('Cannot switch an inactive camera');
+
+    setCameraPending(true);
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const cameras = uniqueCameras(devices);
+      const currentDeviceId = currentTrack.getSettings?.().deviceId;
+      const currentDevice = devices.find(
+        (device) => device.deviceId === currentDeviceId,
+      );
+      const currentCameraKey = currentDevice && cameraKey(currentDevice);
+      const currentIndex = cameras.findIndex(
+        (camera) => cameraKey(camera) === currentCameraKey,
+      );
+      const nextCamera = cameras[(currentIndex + 1) % cameras.length];
+      if (
+        !nextCamera ||
+        (currentCameraKey && cameraKey(nextCamera) === currentCameraKey)
+      ) {
+        throw new Error('No alternate camera is available');
+      }
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          ...getVideoConstraints(),
+          deviceId: { exact: nextCamera.deviceId },
+        },
+      });
+      const nextTrack = stream.getVideoTracks()[0];
+      if (!nextTrack) {
+        stream.getTracks().forEach((track) => track.stop());
+        throw new Error('Camera switch returned no video track');
+      }
+      stream
+        .getTracks()
+        .filter((track) => track !== nextTrack)
+        .forEach((track) => track.stop());
+      nextTrack.enabled = currentTrack.enabled;
+
+      try {
+        await room.setLocalTrack(PRIMARY_VIDEO_SLOT_ID, nextTrack);
+      } catch (error) {
+        nextTrack.stop();
+        throw error;
+      }
+      ownedCameraTracks.add(nextTrack);
+      currentTrack.stop();
+      ownedCameraTracks.delete(currentTrack);
+      syncTrackState();
+    } finally {
+      setCameraPending(false);
+    }
+  }
+
+  async function stopScreenShare() {
+    if (!screenSharing()) return;
+    if (cameraPending()) {
+      screenStopRequested = true;
+      return;
+    }
+    const room = p2p.room();
+    if (!room) {
+      screenTrack?.stop();
+      screenTrack = undefined;
+      cameraBeforeScreenShare = null;
+      setScreenSharing(false);
+      syncTrackState();
+      return;
+    }
+
+    setCameraPending(true);
+    const displayTrack = screenTrack;
+    const restoreTrack =
+      cameraBeforeScreenShare?.readyState === 'live'
+        ? cameraBeforeScreenShare
+        : null;
+    try {
+      let replacementError: unknown;
+      try {
+        await room.setLocalTrack(PRIMARY_VIDEO_SLOT_ID, restoreTrack);
+      } catch (error) {
+        replacementError = error;
+      }
+      await finishCommittedCameraChange(
+        room,
+        restoreTrack !== null,
+        replacementError,
+      );
+
+      screenTrack = undefined;
+      cameraBeforeScreenShare = null;
+      setScreenSharing(false);
+      displayTrack?.stop();
+    } finally {
+      syncTrackState();
+      setCameraPending(false);
+      if (screenStopRequested) {
+        screenStopRequested = false;
+        void stopScreenShare().catch((error) => {
+          console.error('[CallMedia] Failed to stop screen sharing', error);
+        });
+      }
+    }
+  }
+
+  async function toggleScreenShare() {
+    if (screenSharing()) {
+      await stopScreenShare();
+      return;
+    }
+    if (cameraPending()) return;
+    const room = p2p.room();
+    if (!room) throw new Error('Cannot share screen without an active room');
+
+    setCameraPending(true);
+    cameraBeforeScreenShare =
+      localStream()
+        ?.getVideoTracks()
+        .find((track) => track.readyState === 'live') ?? null;
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+      });
+      const displayTrack = stream.getVideoTracks()[0];
+      if (!displayTrack) {
+        stream.getTracks().forEach((track) => track.stop());
+        throw new Error('Screen capture returned no video track');
+      }
+      stream
+        .getTracks()
+        .filter((track) => track !== displayTrack)
+        .forEach((track) => track.stop());
+
+      let replacementError: unknown;
+      try {
+        await room.setLocalTrack(PRIMARY_VIDEO_SLOT_ID, displayTrack);
+      } catch (error) {
+        replacementError = error;
+      }
+      if (!room.localStream?.getTracks().includes(displayTrack)) {
+        displayTrack.stop();
+        if (replacementError) throw replacementError;
+        throw new Error('Screen-share track was not published');
+      }
+
+      screenTrack = displayTrack;
+      setScreenSharing(true);
+      displayTrack.addEventListener(
+        'ended',
+        () =>
+          void stopScreenShare().catch((error) => {
+            console.error('[CallMedia] Failed to stop screen sharing', error);
+          }),
+        { once: true },
+      );
+      await finishCommittedCameraChange(room, true, replacementError);
+      syncTrackState();
+    } catch (error) {
+      if (!room.localStream?.getTracks().includes(screenTrack!)) {
+        screenTrack?.stop();
+        screenTrack = undefined;
+        cameraBeforeScreenShare = null;
+      }
+      throw error;
+    } finally {
+      setCameraPending(false);
+      if (screenStopRequested) {
+        screenStopRequested = false;
+        void stopScreenShare().catch((error) => {
+          console.error('[CallMedia] Failed to stop screen sharing', error);
+        });
+      }
+    }
+  }
+
   return {
     micOn,
     cameraOn,
     cameraPending,
+    cameraSwitchAvailable,
+    screenShareAvailable,
+    screenSharing,
     setMicEnabled,
     setCameraEnabled,
+    switchCamera,
+    toggleScreenShare,
   };
 }

--- a/src/features/call/components/CallControls.test.jsx
+++ b/src/features/call/components/CallControls.test.jsx
@@ -9,8 +9,13 @@ const mocks = vi.hoisted(() => ({
     micOn: () => true,
     cameraOn: () => true,
     cameraPending: () => false,
+    cameraSwitchAvailable: () => false,
+    screenShareAvailable: () => false,
+    screenSharing: () => false,
     setMicEnabled: vi.fn(),
     setCameraEnabled: vi.fn(async () => {}),
+    switchCamera: vi.fn(async () => {}),
+    toggleScreenShare: vi.fn(async () => {}),
   },
 }));
 

--- a/src/features/call/components/CallControls.tsx
+++ b/src/features/call/components/CallControls.tsx
@@ -3,6 +3,9 @@ import {
   MicOff,
   Phone,
   PhoneOff,
+  ScreenShare,
+  ScreenShareOff,
+  SwitchCamera,
   Video,
   VideoOff,
   Volume2,
@@ -16,7 +19,7 @@ import { createCallMedia } from '../call-media';
 
 import styles from './CallControls.module.css';
 import { useI18n } from '@shared/i18n';
-import { onMount } from 'solid-js';
+import { onMount, Show } from 'solid-js';
 
 type StartCallButtonProps = {
   calleeId: string;
@@ -75,6 +78,18 @@ export function ActiveCallControls(props: ActiveCallControlsProps) {
     });
   }
 
+  function switchCamera() {
+    void media.switchCamera().catch((error) => {
+      console.error('[CallMedia] Failed to switch camera', error);
+    });
+  }
+
+  function toggleScreenShare() {
+    void media.toggleScreenShare().catch((error) => {
+      console.error('[CallMedia] Failed to change screen-share state', error);
+    });
+  }
+
   onMount(() => {
     if (import.meta.env.DEV) toggleMic(); // Mute mic by default in dev to avoid feedback
   });
@@ -96,13 +111,40 @@ export function ActiveCallControls(props: ActiveCallControlsProps) {
       <button
         type='button'
         onClick={toggleCam}
-        disabled={media.cameraPending()}
+        disabled={media.cameraPending() || media.screenSharing()}
         classList={{ [styles.off]: !media.cameraOn() }}
         title={media.cameraOn() ? 'Turn camera off' : 'Turn camera on'}
         aria-label={media.cameraOn() ? 'Turn camera off' : 'Turn camera on'}
       >
         {media.cameraOn() ? <Video /> : <VideoOff />}
       </button>
+      <Show when={media.cameraSwitchAvailable()}>
+        <button
+          type='button'
+          onClick={switchCamera}
+          disabled={
+            media.cameraPending() || media.screenSharing() || !media.cameraOn()
+          }
+          title='Switch camera'
+          aria-label='Switch camera'
+        >
+          <SwitchCamera />
+        </button>
+      </Show>
+      <Show when={media.screenShareAvailable()}>
+        <button
+          type='button'
+          onClick={toggleScreenShare}
+          disabled={media.cameraPending()}
+          classList={{ [styles.off]: !media.screenSharing() }}
+          title={media.screenSharing() ? 'Stop sharing screen' : 'Share screen'}
+          aria-label={
+            media.screenSharing() ? 'Stop sharing screen' : 'Share screen'
+          }
+        >
+          {media.screenSharing() ? <ScreenShareOff /> : <ScreenShare />}
+        </button>
+      </Show>
       <button
         type='button'
         onClick={() => props.onRemoteAudioMutedChange(!props.remoteAudioMuted)}


### PR DESCRIPTION
## Summary

- add camera switching to active call controls, cycling distinct `videoinput` devices by exact device ID
- show the switch control only when more than one physical camera group is available and refresh on `devicechange`
- add screen sharing through the existing reserved primary-video slot, restoring the previous camera when sharing stops
- include the existing `dev:mobile` origin fix so the tunnel can use the production API without CORS or mailbox WebSocket rejection

## Why

Desktop browsers treat `facingMode` as a preference, so switching to an iPhone Continuity Camera could silently reacquire the Mac camera. Selecting the next enumerated camera by exact device ID makes switching deterministic while deduplicating browser `default` aliases by group ID.

The reserved video slot added in the previous call-media work also makes screen sharing possible without SDP renegotiation.

## Validation

- personally verified camera switching between a MacBook camera and iPhone Continuity Camera
- personally verified the screen-share PoC in the browser
- `vp check`
- `vp test` — 67 files passed, 363 tests passed, 1 skipped
- CodeRabbit CLI review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-call controls for switching between available cameras.
  * Added screen sharing with controls to start and stop sharing.
  * Camera and screen-sharing controls now reflect availability and active states.
  * Camera switching is disabled during screen sharing or other pending camera operations.
* **Bug Fixes**
  * Improved handling of camera tracks when switching devices or stopping screen sharing.
  * Updated allowed origins for development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->