### PR TITLE
Consolidate call media state, fix self-preview camera-off UI, call naming cleanup

### DIFF
--- a/src/app/SWNavigation.test.jsx
+++ b/src/app/SWNavigation.test.jsx
@@ -144,7 +144,7 @@ describe('SWNavigation', () => {
     messageListener?.({
       data: {
         type: 'NAVIGATE',
-        path: '/?conversationRoom=room-1&callerId=caller-1&callerName=Caller&accept=1',
+        path: '/?call=1&conversationId=room-1&callerId=caller-1&callerName=Caller&accept=1',
       },
     });
 

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -27,11 +27,19 @@ function optionalTimestamp(searchParams: URLSearchParams): number | undefined {
   return Number.isFinite(timestamp) ? timestamp : undefined;
 }
 
+// call=1 marks an incoming-call link (from the SW call notification);
+// its conversationId is the call room, not a conversation to open.
+function isCallUrl(url: URL): boolean {
+  return url.searchParams.get('call') === '1';
+}
+
 function dispatchUrl(url: URL): void {
-  const conversationRoomId = trimmedParam(url.searchParams, 'conversationRoom');
-  if (conversationRoomId) {
+  const callConversationId = isCallUrl(url)
+    ? trimmedParam(url.searchParams, 'conversationId')
+    : null;
+  if (callConversationId) {
     publish('evt:call:notification:opened', {
-      roomId: conversationRoomId,
+      roomId: callConversationId,
       callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
       callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,
       audioOnly: url.searchParams.get('audioOnly') === '1',
@@ -94,7 +102,7 @@ export default function SWNavigation(props: Props = {}) {
       if (data.type !== 'NAVIGATE' || !data.path) return;
       const url = new URL(data.path, window.location.origin);
 
-      if (trimmedParam(url.searchParams, 'conversationRoom')) {
+      if (isCallUrl(url)) {
         dispatchUrl(url);
         return;
       }

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -246,7 +246,7 @@ describe('CallHandshakeController', () => {
           },
           { id: 'primary-video', kind: 'video', track: null },
         ],
-        presenceData: { cameraOn: false },
+        presenceData: { cameraOn: false, micOn: false },
       }),
     );
     const joinOptions = p2p.join.mock.calls[0][0];

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -356,7 +356,7 @@ describe('CallHandshakeController', () => {
       onCalleeBusy: vi.fn(),
     });
 
-    const start = controller.sendOutgoingCallInvite({
+    const start = controller.startCall({
       calleeId: 'callee-id',
       calleeName: 'Callee',
       audioOnly: false,
@@ -400,7 +400,7 @@ describe('CallHandshakeController', () => {
       onCalleeBusy: vi.fn(),
     });
 
-    await controller.sendOutgoingCallInvite({
+    await controller.startCall({
       calleeId: 'callee-id',
       calleeName: 'Callee',
       audioOnly: false,
@@ -433,7 +433,7 @@ describe('CallHandshakeController', () => {
       onCalleeBusy: vi.fn(),
     });
 
-    await controller.sendOutgoingCallInvite({
+    await controller.startCall({
       calleeId: 'callee-id',
       calleeName: 'Callee',
       audioOnly: false,
@@ -462,7 +462,7 @@ describe('CallHandshakeController', () => {
       onCalleeBusy: vi.fn(),
     });
 
-    await controller.sendOutgoingCallInvite({
+    await controller.startCall({
       calleeId: 'callee-id',
       calleeName: 'Callee',
       audioOnly: false,
@@ -491,7 +491,7 @@ describe('CallHandshakeController', () => {
       onCalleeBusy: vi.fn(),
     });
 
-    const start = controller.sendOutgoingCallInvite({
+    const start = controller.startCall({
       calleeId: 'callee-id',
       calleeName: 'Callee',
       audioOnly: false,

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -15,7 +15,7 @@ import {
 import { createCallLocalTrackSlots } from './call-media.js';
 import type {
   CallHandshakeState,
-  PendingOutgoingCall,
+  OutgoingCall,
   StartCallDetails,
 } from './call-types.js';
 import { resolveDirectConversationId } from '../../stores/conversation/conversations-client.js';
@@ -89,8 +89,12 @@ export class CallHandshakeController {
     this.onStateChange(state);
   }
 
-  private setCalleeBusy(busy: boolean): void {
-    this.onCalleeBusy(busy);
+  private initService(localUID: string) {
+    return initCallService({
+      localUID,
+      baseUrl: DATA_URL,
+      getToken: getLoggedInUserToken,
+    });
   }
 
   // TODO: Proper in-app notification
@@ -122,11 +126,7 @@ export class CallHandshakeController {
 
     if (!localUID) return;
 
-    const callService = initCallService({
-      localUID,
-      baseUrl: DATA_URL,
-      getToken: getLoggedInUserToken,
-    });
+    const callService = this.initService(localUID);
 
     this.unsubscribeIncomingCall = callService.onIncomingCall((event) => {
       if (event.type === 'cancel' || event.type === 'handled') {
@@ -159,12 +159,7 @@ export class CallHandshakeController {
       expiresAt: startedAt + CALLING_TTL_MS,
     };
     if (call.expiresAt != null && call.expiresAt <= Date.now()) return;
-    const callService = initCallService({
-      localUID,
-      baseUrl: DATA_URL,
-      getToken: getLoggedInUserToken,
-    });
-    this.handleIncomingCallInvite(call, callService);
+    this.handleIncomingCallInvite(call, this.initService(localUID));
   }
 
   private handleIncomingCallInvite(
@@ -197,17 +192,13 @@ export class CallHandshakeController {
     return state !== null || this.p2p.state() !== 'idle';
   }
 
-  async sendOutgoingCallInvite(details: StartCallDetails): Promise<void> {
+  startCall = async (details: StartCallDetails): Promise<void> => {
     const localUID = getLoggedInUserId();
     if (!localUID) {
       console.warn('Cannot start outgoing call before login is ready');
       return;
     }
-    const svc = initCallService({
-      localUID,
-      baseUrl: DATA_URL,
-      getToken: getLoggedInUserToken,
-    });
+    const svc = this.initService(localUID);
     this.stopPendingOutgoingLocalStream();
     const mediaAttempt = ++this.outgoingMediaAttempt;
 
@@ -241,7 +232,7 @@ export class CallHandshakeController {
       return;
     }
 
-    const nextOutgoingCall: PendingOutgoingCall = {
+    const nextOutgoingCall: OutgoingCall = {
       calleeId,
       calleeName,
       callerId: localUID,
@@ -266,7 +257,7 @@ export class CallHandshakeController {
     }
 
     this.setHandshakeState({ direction: 'outgoing', call: nextOutgoingCall });
-    this.setCalleeBusy(false);
+    this.onCalleeBusy(false);
     this.scheduleOutgoingCallTimeout(svc, nextOutgoingCall);
 
     let responseReceived = false;
@@ -291,11 +282,11 @@ export class CallHandshakeController {
           if (this.pendingOutgoingLocalStream === localStream) {
             this.pendingOutgoingLocalStream = undefined;
           }
-          this.setCalleeBusy(true);
+          this.onCalleeBusy(true);
           this.clearCalleeBusyResetTimeout();
           this.calleeBusyResetTimeoutId = setTimeout(() => {
             this.calleeBusyResetTimeoutId = undefined;
-            this.setCalleeBusy(false);
+            this.onCalleeBusy(false);
           }, 2_500);
         } else {
           publish('evt:call:invite:declined', nextOutgoingCall);
@@ -307,7 +298,7 @@ export class CallHandshakeController {
       } catch (err) {
         console.error('Error entering room on callee accept:', err);
         this.stopMediaStream(localStream);
-        this.exitActiveRoom();
+        this.hangUp();
       } finally {
         svc
           .ackCallResponse(response.roomId)
@@ -351,7 +342,7 @@ export class CallHandshakeController {
         details,
       });
     }
-  }
+  };
 
   /**
    * The call room handle is the opaque conversationId from the D1 registry,
@@ -373,7 +364,7 @@ export class CallHandshakeController {
 
   private async enterRoom(
     roomId: string,
-    localUserId: string,
+    localUID: string,
     audioOnly = false,
     getLocalStream?: () => Promise<MediaStream>,
     { memberCapacity = 2, autoExitOnEmpty = true }: EnterRoomOptions = {},
@@ -385,7 +376,7 @@ export class CallHandshakeController {
     try {
       room = await this.p2p.join({
         roomId,
-        peerId: localUserId,
+        peerId: localUID,
         createSignaling: this.createSignaling,
         // Keep room ownership/cleanup while making the acquired tracks available
         // when the reserved publication slots are declared before negotiation.
@@ -400,7 +391,7 @@ export class CallHandshakeController {
         dataChannel: true,
         onAlone: (detail) => {
           if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
-          if (autoExitOnEmpty) this.exitActiveRoom();
+          if (autoExitOnEmpty) this.hangUp();
         },
       });
       if (!room)
@@ -439,7 +430,7 @@ export class CallHandshakeController {
 
   private scheduleOutgoingCallTimeout(
     callService: NonNullable<ReturnType<typeof getCallService>>,
-    call: PendingOutgoingCall,
+    call: OutgoingCall,
   ): void {
     this.clearOutgoingCallTimeout();
     this.outgoingCallTimeoutId = setTimeout(() => {
@@ -455,7 +446,7 @@ export class CallHandshakeController {
       this.stopPendingOutgoingLocalStream();
       callService
         .cancelOutgoingCall({
-          recipientUID: call.calleeId,
+          calleeId: call.calleeId,
           roomId: call.roomId,
         })
         .catch((err) =>
@@ -475,11 +466,11 @@ export class CallHandshakeController {
     this.clearOutgoingCallTracking();
     this.stopPendingOutgoingLocalStream();
     this.setHandshakeState(null);
-    this.setCalleeBusy(false);
+    this.onCalleeBusy(false);
     publish('evt:call:invite:unanswered', state.call);
     svc
       .cancelOutgoingCall({
-        recipientUID: state.call.calleeId,
+        calleeId: state.call.calleeId,
         roomId: state.call.roomId,
       })
       .catch((err) =>
@@ -508,7 +499,7 @@ export class CallHandshakeController {
       )
       .catch((err) => {
         console.error('Error accepting incoming call:', err);
-        this.exitActiveRoom();
+        this.hangUp();
       });
   };
 
@@ -527,7 +518,7 @@ export class CallHandshakeController {
       .catch((err) => console.error('Error declining incoming call:', err));
   };
 
-  exitActiveRoom = (): void => {
+  hangUp = (): void => {
     this.p2p.close();
   };
 
@@ -557,7 +548,7 @@ export class CallHandshakeController {
     this.clearCalleeBusyResetTimeout();
     this.stopPendingOutgoingLocalStream();
     this.setHandshakeState(null);
-    this.setCalleeBusy(false);
+    this.onCalleeBusy(false);
     this.p2p.close();
     cleanupCallService();
     this.lastBoundUID = undefined;

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -383,6 +383,9 @@ export class CallHandshakeController {
         getLocalStream: () => Promise.resolve(localStream),
         localTrackSlots: createCallLocalTrackSlots(localStream),
         presenceData: {
+          micOn: localStream
+            .getAudioTracks()
+            .some((track) => track.readyState === 'live' && track.enabled),
           cameraOn: localStream
             .getVideoTracks()
             .some((track) => track.readyState === 'live' && track.enabled),

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -116,7 +116,7 @@ describe('CallHandshakeProvider', () => {
     window.history.replaceState(
       null,
       '',
-      '/?conversationRoom=room-1&callerId=caller-1',
+      '/?call=1&conversationId=room-1&callerId=caller-1',
     );
     const { CallHandshakeProvider } = await import('./call-handshake');
     const [user] = createSignal({ uid: 'u1' });

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -20,7 +20,7 @@ import {
 } from './call-handshake-controller.js';
 import type {
   CallHandshakeState,
-  PendingOutgoingCall,
+  OutgoingCall,
   StartCallDetails,
 } from './call-types.js';
 
@@ -29,9 +29,8 @@ type CallHandshakeContextValue = {
   hangUp: () => void;
 
   isCalleeBusy: Accessor<boolean>;
-  pendingIncomingCall: Accessor<MailboxInvite | null>;
-  pendingOutgoingCall: Accessor<PendingOutgoingCall | null>;
-  exitActiveRoom: () => void;
+  incomingCall: Accessor<MailboxInvite | null>;
+  outgoingCall: Accessor<OutgoingCall | null>;
   cancelOutgoing: () => void;
   acceptIncoming: () => void;
   declineIncoming: () => void;
@@ -56,7 +55,10 @@ function optionalTimestamp(params: URLSearchParams): number | undefined {
 function incomingCallNotificationDetailsFromParams(
   params: URLSearchParams,
 ): IncomingCallNotificationDetails | null {
-  const roomId = params.get('conversationRoom');
+  // call=1 marks an incoming-call link; without it, conversationId is a
+  // plain open-conversation link handled by SWNavigation.
+  if (params.get('call') !== '1') return null;
+  const roomId = params.get('conversationId');
   const callerId = params.get('callerId');
   if (!roomId || !callerId) return null;
 
@@ -118,24 +120,17 @@ export function CallHandshakeProvider(props: ParentProps) {
     return state && state.direction === 'incoming' ? state.call : null;
   };
 
-  const outgoingCall = (): PendingOutgoingCall | null => {
+  const outgoingCall = (): OutgoingCall | null => {
     const state = handshakeState();
     return state && state.direction === 'outgoing' ? state.call : null;
   };
 
-  const startCall = async (details: StartCallDetails) => {
-    await controller.sendOutgoingCallInvite(details);
-  };
-
-  const hangUp = () => controller.exitActiveRoom();
-
   const value: CallHandshakeContextValue = {
-    startCall,
-    hangUp,
+    startCall: controller.startCall,
+    hangUp: controller.hangUp,
     isCalleeBusy,
-    pendingIncomingCall: incomingCall,
-    pendingOutgoingCall: outgoingCall,
-    exitActiveRoom: controller.exitActiveRoom,
+    incomingCall,
+    outgoingCall,
     cancelOutgoing: controller.cancelOutgoing,
     acceptIncoming: controller.acceptIncoming,
     declineIncoming: controller.declineIncoming,
@@ -153,7 +148,7 @@ export function CallHandshakeProvider(props: ParentProps) {
       );
     const [wantAcceptRoomId, setWantAcceptRoomId] = createSignal<string | null>(
       ENABLE_NOTIFICATION_AUTO_ACCEPT && hasAcceptMarker
-        ? params.get('conversationRoom')
+        ? params.get('conversationId')
         : null,
     );
     if (hasAcceptMarker) {

--- a/src/features/call/call-media.test.jsx
+++ b/src/features/call/call-media.test.jsx
@@ -138,6 +138,9 @@ describe('call media', () => {
       const media = createCallMedia(p2p);
 
       expect(media.cameraOn()).toBe(false);
+      await media.setMicEnabled(false);
+      expect(media.micOn()).toBe(false);
+      expect(room.setPresenceData).toHaveBeenCalledWith({ micOn: false });
       await media.setCameraEnabled(true);
 
       expect(getUserMedia).toHaveBeenCalledWith({

--- a/src/features/call/call-media.test.jsx
+++ b/src/features/call/call-media.test.jsx
@@ -119,7 +119,7 @@ describe('call media', () => {
 
     const room = {
       localStream,
-      memberPresence: [],
+      memberPresence: [{ memberId: 'local', data: { cameraOn: true } }],
       peerId: 'local',
       setPresenceData: vi.fn(async () => {}),
       setLocalTrack: vi.fn(async (_slotId, track) => {
@@ -140,7 +140,10 @@ describe('call media', () => {
       expect(media.cameraOn()).toBe(false);
       await media.setMicEnabled(false);
       expect(media.micOn()).toBe(false);
-      expect(room.setPresenceData).toHaveBeenCalledWith({ micOn: false });
+      expect(room.setPresenceData).toHaveBeenCalledWith({
+        cameraOn: true,
+        micOn: false,
+      });
       await media.setCameraEnabled(true);
 
       expect(getUserMedia).toHaveBeenCalledWith({
@@ -198,6 +201,87 @@ describe('call media', () => {
         frontCamera,
       );
       expect(backCamera.stop).toHaveBeenCalledOnce();
+      dispose();
+    });
+  });
+
+  it('serializes microphone and camera presence updates', async () => {
+    const microphone = createTrack('audio');
+    const camera = createTrack('video');
+    camera.enabled = false;
+    const localStream = createStream([microphone, camera]);
+    let releaseFirstUpdate;
+    const firstUpdate = new Promise((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    const room = {
+      localStream,
+      memberPresence: [
+        {
+          memberId: 'local',
+          data: { cameraOn: false, micOn: true },
+        },
+      ],
+      peerId: 'local',
+      setPresenceData: vi.fn(async (data) => {
+        if (room.setPresenceData.mock.calls.length === 1) {
+          await firstUpdate;
+        }
+        room.memberPresence[0].data = data;
+      }),
+      setLocalTrack: vi.fn(async () => {}),
+    };
+    const p2p = {
+      localStream: () => localStream,
+      room: () => room,
+    };
+
+    await createRoot(async (dispose) => {
+      const media = createCallMedia(p2p);
+      const microphoneUpdate = media.setMicEnabled(false);
+      const cameraUpdate = media.setCameraEnabled(true);
+
+      await Promise.resolve();
+      expect(room.setPresenceData).toHaveBeenCalledOnce();
+
+      releaseFirstUpdate();
+      await Promise.all([microphoneUpdate, cameraUpdate]);
+
+      expect(room.setPresenceData).toHaveBeenLastCalledWith({
+        cameraOn: true,
+        micOn: false,
+      });
+      dispose();
+    });
+  });
+
+  it('shows an enabled live camera even when presence publishing fails', async () => {
+    const microphone = createTrack('audio');
+    const camera = createTrack('video');
+    camera.enabled = false;
+    const localStream = createStream([microphone, camera]);
+    const publishError = new Error('presence unavailable');
+    const room = {
+      localStream,
+      memberPresence: [],
+      peerId: 'local',
+      setPresenceData: vi.fn(async () => {
+        throw publishError;
+      }),
+      setLocalTrack: vi.fn(async () => {}),
+    };
+    const p2p = {
+      localStream: () => localStream,
+      room: () => room,
+    };
+
+    await createRoot(async (dispose) => {
+      const media = createCallMedia(p2p);
+
+      await expect(media.setCameraEnabled(true)).rejects.toBe(publishError);
+
+      expect(camera.enabled).toBe(true);
+      expect(media.cameraOn()).toBe(true);
       dispose();
     });
   });

--- a/src/features/call/call-media.ts
+++ b/src/features/call/call-media.ts
@@ -26,7 +26,7 @@ export type CallMedia = {
   cameraSwitchAvailable: Accessor<boolean>;
   screenShareAvailable: Accessor<boolean>;
   screenSharing: Accessor<boolean>;
-  setMicEnabled: (enabled: boolean) => void;
+  setMicEnabled: (enabled: boolean) => Promise<void>;
   setCameraEnabled: (enabled: boolean) => Promise<void>;
   switchCamera: () => Promise<void>;
   toggleScreenShare: () => Promise<void>;
@@ -135,12 +135,21 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
     ownedCameraTracks.clear();
   });
 
-  function setMicEnabled(enabled: boolean) {
+  async function setMicEnabled(enabled: boolean) {
     const tracks = localStream()?.getAudioTracks() ?? [];
     tracks.forEach((track) => {
       track.enabled = enabled;
     });
     syncTrackState();
+
+    const room = p2p.room();
+    if (!room)
+      throw new Error('Cannot change microphone without an active room');
+
+    const currentData =
+      room.memberPresence.find((member) => member.memberId === room.peerId)
+        ?.data ?? {};
+    await room.setPresenceData({ ...currentData, micOn: enabled });
   }
 
   // Broadcasts our cameraOn flag to other members via the room's member data

--- a/src/features/call/call-media.ts
+++ b/src/features/call/call-media.ts
@@ -143,7 +143,9 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
     syncTrackState();
   }
 
-  async function publishCameraPresence(
+  // Broadcasts our cameraOn flag to other members via the room's member data
+  // (@kidlib/p2p "presence" — unrelated to the online/offline presence feature).
+  async function publishCameraOn(
     room: NonNullable<ReturnType<SolidP2PRoom['room']>>,
     cameraOn: boolean,
   ) {
@@ -159,15 +161,15 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
     replacementError?: unknown,
   ) {
     try {
-      await publishCameraPresence(room, cameraOn);
-    } catch (presenceError) {
+      await publishCameraOn(room, cameraOn);
+    } catch (publishError) {
       if (replacementError) {
         console.error(
-          '[CallMedia] Failed to publish camera presence after a partial track replacement',
-          presenceError,
+          '[CallMedia] Failed to publish cameraOn after a partial track replacement',
+          publishError,
         );
       } else {
-        throw presenceError;
+        throw publishError;
       }
     }
     if (replacementError) throw replacementError;
@@ -192,7 +194,7 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
           }
           // currentTracks are stopped unconditionally in finally, so the
           // camera is off locally regardless of replacement outcome —
-          // presence must always reflect that.
+          // the published cameraOn flag must always reflect that.
           await finishCommittedCameraChange(room, false, replacementError);
         } finally {
           // Null is the room's desired state even after a partial pair failure.
@@ -210,7 +212,7 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
       );
       if (liveTrack) {
         liveTrack.enabled = true;
-        await publishCameraPresence(room, true);
+        await publishCameraOn(room, true);
         syncTrackState();
         return;
       }

--- a/src/features/call/call-media.ts
+++ b/src/features/call/call-media.ts
@@ -62,6 +62,21 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
   let screenTrack: MediaStreamTrack | undefined;
   let cameraBeforeScreenShare: MediaStreamTrack | null = null;
   let screenStopRequested = false;
+  let presenceWriteChain = Promise.resolve();
+
+  function enqueuePresenceUpdate(
+    room: NonNullable<ReturnType<SolidP2PRoom['room']>>,
+    data: { micOn?: boolean; cameraOn?: boolean },
+  ) {
+    const update = presenceWriteChain.then(async () => {
+      const currentData =
+        room.memberPresence.find((member) => member.memberId === room.peerId)
+          ?.data ?? {};
+      await room.setPresenceData({ ...currentData, ...data });
+    });
+    presenceWriteChain = update.catch(() => {});
+    return update;
+  }
 
   async function refreshCameraSwitchAvailability(log = false) {
     const devices = await navigator.mediaDevices
@@ -146,10 +161,7 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
     if (!room)
       throw new Error('Cannot change microphone without an active room');
 
-    const currentData =
-      room.memberPresence.find((member) => member.memberId === room.peerId)
-        ?.data ?? {};
-    await room.setPresenceData({ ...currentData, micOn: enabled });
+    await enqueuePresenceUpdate(room, { micOn: micOn() });
   }
 
   // Broadcasts our cameraOn flag to other members via the room's member data
@@ -158,10 +170,7 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
     room: NonNullable<ReturnType<SolidP2PRoom['room']>>,
     cameraOn: boolean,
   ) {
-    const currentData =
-      room.memberPresence.find((member) => member.memberId === room.peerId)
-        ?.data ?? {};
-    await room.setPresenceData({ ...currentData, cameraOn });
+    await enqueuePresenceUpdate(room, { cameraOn });
   }
 
   async function finishCommittedCameraChange(
@@ -221,8 +230,8 @@ export function createCallMedia(p2p: SolidP2PRoom): CallMedia {
       );
       if (liveTrack) {
         liveTrack.enabled = true;
-        await publishCameraOn(room, true);
         syncTrackState();
+        await publishCameraOn(room, true);
         return;
       }
 

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -164,15 +164,15 @@ export class CallService {
   }
 
   cancelOutgoingCall({
-    recipientUID,
+    calleeId,
     roomId,
   }: {
-    recipientUID: string;
+    calleeId: string;
     roomId: string;
   }): Promise<void> {
     return this.post('/calls/cancel', {
       conversationId: roomId,
-      calleeId: recipientUID,
+      calleeId,
     });
   }
 

--- a/src/features/call/call-types.ts
+++ b/src/features/call/call-types.ts
@@ -1,6 +1,6 @@
 import type { MailboxInvite } from '../../../shared/user-mailbox/protocol';
 
-export type PendingOutgoingCall = {
+export type OutgoingCall = {
   calleeId: string;
   calleeName: string;
   callerId: string;
@@ -24,5 +24,5 @@ export type CallHandshakeState =
     }
   | {
       direction: 'outgoing';
-      call: PendingOutgoingCall;
+      call: OutgoingCall;
     };

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -35,16 +35,20 @@ export function ActiveCallRoom() {
 
       <Show
         when={
-          isRoomLinkCall &&
-          p2p.state() === 'joined' &&
-          p2p.remoteMemberStreams().length === 0
+          p2p.state() === 'joined' && p2p.remoteMemberStreams().length === 0
         }
       >
         <div class={styles.waiting}>
-          <p>Room is empty...</p>
-          <button type='button' onClick={copyLink}>
-            {copied() ? 'Link copied' : 'Copy invite link'}
-          </button>
+          <p>
+            {isRoomLinkCall
+              ? 'Room is empty...'
+              : 'Waiting for the other person to connect...'}
+          </p>
+          <Show when={isRoomLinkCall}>
+            <button type='button' onClick={copyLink}>
+              {copied() ? 'Link copied' : 'Copy invite link'}
+            </button>
+          </Show>
         </div>
       </Show>
 

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -2,12 +2,15 @@ import { Show, createSignal } from 'solid-js';
 
 import { MemberStreams } from './MemberStreams';
 import { ActiveCallControls } from './CallControls';
+import { createCallMedia } from '../call-media';
 import { useP2PContext } from '@shared/p2p-context.js';
 
 import styles from './ActiveCallRoom.module.css';
 
 export function ActiveCallRoom() {
   const p2p = useP2PContext();
+  // createCallMedia owns local imperative track state (camera tracks, screen-share track)
+  const media = createCallMedia(p2p);
 
   // Room-link (guest) calls carry ?publicRoom= in the URL; contact calls don't.
   // Only those can re-share the page URL as an invite.
@@ -28,7 +31,7 @@ export function ActiveCallRoom() {
 
   return (
     <div class={styles.room}>
-      <MemberStreams remoteAudioMuted={remoteAudioMuted()} />
+      <MemberStreams remoteAudioMuted={remoteAudioMuted()} media={media} />
 
       <Show
         when={
@@ -47,6 +50,7 @@ export function ActiveCallRoom() {
 
       <Show when={p2p.state() === 'joined'}>
         <ActiveCallControls
+          media={media}
           remoteAudioMuted={remoteAudioMuted()}
           onRemoteAudioMutedChange={setRemoteAudioMuted}
         />

--- a/src/features/call/components/CallControls.test.jsx
+++ b/src/features/call/components/CallControls.test.jsx
@@ -25,12 +25,6 @@ vi.mock('../call-handshake', () => ({
     startCall: mocks.startCall,
   }),
 }));
-vi.mock('../call-media', () => ({
-  createCallMedia: () => mocks.media,
-}));
-vi.mock('@shared/p2p-context.js', () => ({
-  useP2PContext: () => ({}),
-}));
 vi.mock('@shared/createAutoHide', () => ({
   createAutoHide: () => () => true,
 }));
@@ -93,6 +87,7 @@ describe('ActiveCallControls', () => {
     const onRemoteAudioMutedChange = vi.fn();
     const { getByRole } = render(() => (
       <ActiveCallControls
+        media={mocks.media}
         remoteAudioMuted={false}
         onRemoteAudioMutedChange={onRemoteAudioMutedChange}
       />

--- a/src/features/call/components/CallControls.tsx
+++ b/src/features/call/components/CallControls.tsx
@@ -68,7 +68,9 @@ export function ActiveCallControls(props: ActiveCallControlsProps) {
   const visible = createAutoHide(3000);
 
   function toggleMic() {
-    media.setMicEnabled(!media.micOn());
+    void Promise.resolve(media.setMicEnabled(!media.micOn())).catch((error) => {
+      console.error('[CallMedia] Failed to change microphone state', error);
+    });
   }
 
   function toggleCam() {

--- a/src/features/call/components/CallControls.tsx
+++ b/src/features/call/components/CallControls.tsx
@@ -13,9 +13,8 @@ import {
 } from 'lucide-solid';
 
 import { useCallHandshake } from '../call-handshake';
-import { useP2PContext } from '@shared/p2p-context.js';
 import { createAutoHide } from '@shared/createAutoHide';
-import { createCallMedia } from '../call-media';
+import type { CallMedia } from '../call-media';
 
 import styles from './CallControls.module.css';
 import { useI18n } from '@shared/i18n';
@@ -59,13 +58,13 @@ export function StartCallButton(props: StartCallButtonProps) {
 }
 
 type ActiveCallControlsProps = {
+  media: CallMedia;
   remoteAudioMuted: boolean;
   onRemoteAudioMutedChange: (muted: boolean) => void;
 };
 
 export function ActiveCallControls(props: ActiveCallControlsProps) {
-  const p2p = useP2PContext();
-  const media = createCallMedia(p2p);
+  const media = props.media;
   const visible = createAutoHide(3000);
 
   function toggleMic() {

--- a/src/features/call/components/CallDialogs.tsx
+++ b/src/features/call/components/CallDialogs.tsx
@@ -10,7 +10,7 @@ export function CallDialogs() {
 
   return (
     <Switch>
-      <Match when={handshake.pendingOutgoingCall()}>
+      <Match when={handshake.outgoingCall()}>
         {(call) => (
           <OutgoingCallDialog
             calleeName={call().calleeName}
@@ -22,7 +22,7 @@ export function CallDialogs() {
       <Match when={handshake.isCalleeBusy()}>
         <BusyCallDialog />
       </Match>
-      <Match when={handshake.pendingIncomingCall()}>
+      <Match when={handshake.incomingCall()}>
         {(call) => (
           <IncomingCallDialog
             callerName={call().callerName}

--- a/src/features/call/components/MemberStreams.test.jsx
+++ b/src/features/call/components/MemberStreams.test.jsx
@@ -10,6 +10,12 @@ vi.mock('@shared/p2p-context.js', () => ({
 
 const { MemberStreams } = await import('./MemberStreams');
 
+// Minimal CallMedia stand-in: only the accessors MemberStreams reads.
+const fakeMedia = {
+  cameraOn: () => true,
+  screenSharing: () => false,
+};
+
 class FakeTrack extends EventTarget {
   constructor(kind) {
     super();
@@ -62,18 +68,15 @@ describe('MemberStreams', () => {
       remoteMemberStreams: () => [],
     };
     const { container } = render(() => (
-      <MemberStreams remoteAudioMuted={false} />
+      <MemberStreams media={fakeMedia} remoteAudioMuted={false} />
     ));
 
     stream.tracks.push(new FakeTrack('video'));
     setLocalStream(stream);
 
+    // No remote streams in this room, so the only video is the self preview.
     await waitFor(() => {
-      expect(
-        container
-          .querySelector('[data-variant="self-preview"]')
-          ?.getAttribute('data-media-state'),
-      ).toBe('video');
+      expect(container.querySelector('video').hidden).toBe(false);
     });
   });
 
@@ -90,7 +93,7 @@ describe('MemberStreams', () => {
     };
 
     const { container } = render(() => (
-      <MemberStreams remoteAudioMuted={true} />
+      <MemberStreams media={fakeMedia} remoteAudioMuted={true} />
     ));
 
     expect(container.querySelector('video').muted).toBe(true);

--- a/src/features/call/components/MemberStreams.tsx
+++ b/src/features/call/components/MemberStreams.tsx
@@ -1,17 +1,21 @@
 import { For, Show } from 'solid-js';
 import { useP2PContext } from '@shared/p2p-context.js';
 import { ParticipantMedia } from './ParticipantMedia';
+import type { CallMedia } from '../call-media';
 import styles from './MemberStreams.module.css';
 
 type MemberStreamsProps = {
+  media: CallMedia;
   remoteAudioMuted: boolean;
 };
 
 export function MemberStreams(props: MemberStreamsProps) {
   const p2p = useP2PContext();
-  const remoteCameraEnabled = (memberId: string) =>
+  // cameraOn flag published by that member via room member data
+  // (undefined until their first publish → treated as camera off).
+  const memberCameraOn = (memberId: string) =>
     p2p.memberPresence().find((member) => member.memberId === memberId)?.data
-      ?.cameraOn !== false;
+      ?.cameraOn === true;
 
   return (
     <div
@@ -26,6 +30,7 @@ export function MemberStreams(props: MemberStreamsProps) {
           <ParticipantMedia
             stream={p2p.localStream()!}
             variant='self-preview'
+            videoEnabled={props.media.cameraOn() || props.media.screenSharing()}
           />
         )}
       </Show>
@@ -33,13 +38,7 @@ export function MemberStreams(props: MemberStreamsProps) {
         {(remote) => (
           <ParticipantMedia
             stream={remote.stream}
-            videoEnabled={remoteCameraEnabled(remote.memberId)}
-            videoExpected={
-              p2p
-                .memberPresence()
-                .find((member) => member.memberId === remote.memberId)?.data
-                ?.cameraOn === true
-            }
+            videoEnabled={memberCameraOn(remote.memberId)}
             remoteAudioMuted={props.remoteAudioMuted}
           />
         )}

--- a/src/features/call/components/MemberStreams.tsx
+++ b/src/features/call/components/MemberStreams.tsx
@@ -31,6 +31,7 @@ export function MemberStreams(props: MemberStreamsProps) {
             stream={p2p.localStream()!}
             variant='self-preview'
             videoEnabled={props.media.cameraOn() || props.media.screenSharing()}
+            audioEnabled={props.media.micOn()}
           />
         )}
       </Show>

--- a/src/features/call/components/MemberStreams.tsx
+++ b/src/features/call/components/MemberStreams.tsx
@@ -34,6 +34,12 @@ export function MemberStreams(props: MemberStreamsProps) {
           <ParticipantMedia
             stream={remote.stream}
             videoEnabled={remoteCameraEnabled(remote.memberId)}
+            videoExpected={
+              p2p
+                .memberPresence()
+                .find((member) => member.memberId === remote.memberId)?.data
+                ?.cameraOn === true
+            }
             remoteAudioMuted={props.remoteAudioMuted}
           />
         )}

--- a/src/features/call/components/MemberStreams.tsx
+++ b/src/features/call/components/MemberStreams.tsx
@@ -17,6 +17,10 @@ export function MemberStreams(props: MemberStreamsProps) {
     p2p.memberPresence().find((member) => member.memberId === memberId)?.data
       ?.cameraOn === true;
 
+  const memberMicOn = (memberId: string) =>
+    p2p.memberPresence().find((member) => member.memberId === memberId)?.data
+      ?.micOn === true;
+
   return (
     <div
       classList={{
@@ -36,10 +40,11 @@ export function MemberStreams(props: MemberStreamsProps) {
         )}
       </Show>
       <For each={p2p.remoteMemberStreams()}>
-        {(remote) => (
+        {(stream) => (
           <ParticipantMedia
-            stream={remote.stream}
-            videoEnabled={memberCameraOn(remote.memberId)}
+            stream={stream.stream}
+            videoEnabled={memberCameraOn(stream.memberId)}
+            audioEnabled={memberMicOn(stream.memberId)}
             remoteAudioMuted={props.remoteAudioMuted}
           />
         )}

--- a/src/features/call/components/ParticipantMedia.module.css
+++ b/src/features/call/components/ParticipantMedia.module.css
@@ -33,14 +33,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-
-  z-index: 9;
   color: white;
   font-size: 20px;
   text-align: center;
   text-shadow: var(--text-shadow-medium);
   -webkit-user-select: none;
   user-select: none;
+  z-index: 9;
 }
 
 .selfPreview {
@@ -49,9 +48,8 @@
   left: var(--gap);
   max-width: 150px;
   max-height: 150px;
-  z-index: 1;
-
   font-size: 12px;
+  z-index: 1;
 }
 
 .selfPreview .media {

--- a/src/features/call/components/ParticipantMedia.module.css
+++ b/src/features/call/components/ParticipantMedia.module.css
@@ -8,8 +8,9 @@
 }
 
 .media,
-.placeholder,
-.audioOnly {
+.audioOnly,
+.videoStatus,
+.spinner {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -29,30 +30,28 @@
 }
 
 .videoStatus {
-  position: absolute;
-  inset: auto var(--gap) var(--gap);
-  z-index: 1;
-  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  z-index: 9;
   color: white;
+  font-size: 20px;
   text-align: center;
   text-shadow: var(--text-shadow-medium);
-}
-
-.surface[data-media-state='video'] .placeholder {
-  display: none;
-}
-
-.surface:not([data-media-state='audio']) .audioOnly {
-  display: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .selfPreview {
   position: absolute;
   top: var(--gap);
   left: var(--gap);
-  width: 150px;
-  height: 100px;
+  max-width: 150px;
+  max-height: 150px;
   z-index: 1;
+
+  font-size: 12px;
 }
 
 .selfPreview .media {

--- a/src/features/call/components/ParticipantMedia.module.css
+++ b/src/features/call/components/ParticipantMedia.module.css
@@ -28,6 +28,16 @@
   color: lime;
 }
 
+.videoStatus {
+  position: absolute;
+  inset: auto var(--gap) var(--gap);
+  z-index: 1;
+  margin: 0;
+  color: white;
+  text-align: center;
+  text-shadow: var(--text-shadow-medium);
+}
+
 .surface[data-media-state='video'] .placeholder {
   display: none;
 }

--- a/src/features/call/components/ParticipantMedia.test.jsx
+++ b/src/features/call/components/ParticipantMedia.test.jsx
@@ -153,6 +153,24 @@ describe('ParticipantMedia', () => {
     );
   });
 
+  it('keeps an interrupted video sticky across camera presence toggles', async () => {
+    const track = new FakeTrack('video');
+    const stream = new FakeStream([track]);
+    const [videoEnabled, setVideoEnabled] = createSignal(true);
+    const { container } = render(() => (
+      <ParticipantMedia stream={stream} videoEnabled={videoEnabled()} />
+    ));
+
+    track.muted = true;
+    track.dispatchEvent(new Event('mute'));
+    setVideoEnabled(false);
+    setVideoEnabled(true);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain('Video connection interrupted'),
+    );
+  });
+
   it('shows the continue-call prompt only for autoplay-gesture rejections', async () => {
     HTMLMediaElement.prototype.play.mockRejectedValue(
       Object.assign(new Error('gesture required'), {

--- a/src/features/call/components/ParticipantMedia.test.jsx
+++ b/src/features/call/components/ParticipantMedia.test.jsx
@@ -135,6 +135,34 @@ describe('ParticipantMedia', () => {
 
     expect(surface?.getAttribute('data-media-state')).toBe('audio');
     expect(video.hidden).toBe(true);
+    expect(container.textContent).not.toContain('Connecting video');
+  });
+
+  it('explains when an expected remote video track is still connecting', () => {
+    const stream = new FakeStream([
+      new FakeTrack('audio'),
+      new FakeTrack('video', { muted: true }),
+    ]);
+    const { container } = render(() => (
+      <ParticipantMedia stream={stream} videoExpected={true} />
+    ));
+
+    expect(container.textContent).toContain('Connecting video');
+  });
+
+  it('explains when a previously visible remote video is interrupted', async () => {
+    const track = new FakeTrack('video');
+    const stream = new FakeStream([track]);
+    const { container } = render(() => (
+      <ParticipantMedia stream={stream} videoExpected={true} />
+    ));
+
+    track.muted = true;
+    track.dispatchEvent(new Event('mute'));
+
+    await waitFor(() =>
+      expect(container.textContent).toContain('Video connection interrupted'),
+    );
   });
 
   it('shows the continue-call prompt only for autoplay-gesture rejections', async () => {

--- a/src/features/call/components/ParticipantMedia.test.jsx
+++ b/src/features/call/components/ParticipantMedia.test.jsx
@@ -62,10 +62,8 @@ describe('ParticipantMedia', () => {
     const stream = new FakeStream([new FakeTrack('audio')]);
     const { container } = render(() => <ParticipantMedia stream={stream} />);
 
-    const surface = container.querySelector('[data-media-state]');
     const video = container.querySelector('video');
 
-    expect(surface?.getAttribute('data-media-state')).toBe('audio');
     expect(video).not.toBeNull();
     expect(video.hidden).toBe(true);
     expect(video.muted).toBe(false);
@@ -74,17 +72,14 @@ describe('ParticipantMedia', () => {
     expect(video.srcObject.getTracks()).toEqual(stream.getAudioTracks());
   });
 
-  it('mutes and identifies the local self preview', () => {
+  it('shows the local self preview muted', () => {
     const stream = new FakeStream([new FakeTrack('video')]);
     const { container } = render(() => (
       <ParticipantMedia stream={stream} variant='self-preview' />
     ));
 
-    const surface = container.querySelector('[data-variant]');
     const video = container.querySelector('video');
 
-    expect(surface?.getAttribute('data-variant')).toBe('self-preview');
-    expect(surface?.getAttribute('data-media-state')).toBe('video');
     expect(video.hidden).toBe(false);
     expect(video.muted).toBe(true);
   });
@@ -112,11 +107,6 @@ describe('ParticipantMedia', () => {
     stream.addTrack(new FakeTrack('video'));
 
     await waitFor(() => {
-      expect(
-        container
-          .querySelector('[data-media-state]')
-          ?.getAttribute('data-media-state'),
-      ).toBe('video');
       expect(container.querySelector('video').hidden).toBe(false);
     });
   });
@@ -130,10 +120,8 @@ describe('ParticipantMedia', () => {
       <ParticipantMedia stream={stream} videoEnabled={false} />
     ));
 
-    const surface = container.querySelector('[data-media-state]');
     const video = container.querySelector('video');
 
-    expect(surface?.getAttribute('data-media-state')).toBe('audio');
     expect(video.hidden).toBe(true);
     expect(container.textContent).not.toContain('Connecting video');
   });
@@ -144,7 +132,7 @@ describe('ParticipantMedia', () => {
       new FakeTrack('video', { muted: true }),
     ]);
     const { container } = render(() => (
-      <ParticipantMedia stream={stream} videoExpected={true} />
+      <ParticipantMedia stream={stream} videoEnabled={true} />
     ));
 
     expect(container.textContent).toContain('Connecting video');
@@ -154,7 +142,7 @@ describe('ParticipantMedia', () => {
     const track = new FakeTrack('video');
     const stream = new FakeStream([track]);
     const { container } = render(() => (
-      <ParticipantMedia stream={stream} videoExpected={true} />
+      <ParticipantMedia stream={stream} videoEnabled={true} />
     ));
 
     track.muted = true;

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -2,6 +2,7 @@ import {
   createMemo,
   createEffect,
   createSignal,
+  on,
   onCleanup,
   Switch,
   Match,
@@ -73,6 +74,21 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   });
   const videoConnected = createMemo(() => status().video === 'connected');
 
+  const updateStatus = (stream: MediaStream) => {
+    const videoConnected = isReceivingStreamData(stream, 'video');
+    const audioConnected = isReceivingStreamData(stream, 'audio');
+    if (videoConnected) videoWasConnected = true;
+    if (audioConnected) audioWasConnected = true;
+    setStatus({
+      video: trackStatus(
+        props.videoEnabled ?? true,
+        videoConnected,
+        videoWasConnected,
+      ),
+      audio: trackStatus(true, audioConnected, audioWasConnected),
+    });
+  };
+
   const playback = createMediaPlayback({
     playsInline: true,
     onPlaybackBlocked: (err) => {
@@ -87,53 +103,55 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     },
   });
 
-  createEffect(() => {
-    const stream = props.stream;
-    const videoEnabled = props.videoEnabled ?? true;
-    // New stream instance: sticky "was connected" flags reset with it.
-    videoWasConnected = false;
-    audioWasConnected = false;
-    let removeTrackListeners = () => {};
+  createEffect(
+    on(
+      () => props.stream,
+      (stream) => {
+        // New stream instance: sticky "was connected" flags reset with it.
+        videoWasConnected = false;
+        audioWasConnected = false;
+        let removeTrackListeners = () => {};
 
-    const observeTracks = () => {
-      removeTrackListeners();
+        const observeTracks = () => {
+          removeTrackListeners();
 
-      const tracks = stream.getTracks();
-      const update = () => {
-        const videoConnected = isReceivingStreamData(stream, 'video');
-        const audioConnected = isReceivingStreamData(stream, 'audio');
-        if (videoConnected) videoWasConnected = true;
-        if (audioConnected) audioWasConnected = true;
-        setStatus({
-          video: trackStatus(videoEnabled, videoConnected, videoWasConnected),
-          audio: trackStatus(true, audioConnected, audioWasConnected),
+          const tracks = stream.getTracks();
+          const update = () => updateStatus(stream);
+          tracks.forEach((track) => {
+            track.addEventListener('mute', update);
+            track.addEventListener('unmute', update);
+            track.addEventListener('ended', update);
+          });
+          removeTrackListeners = () => {
+            tracks.forEach((track) => {
+              track.removeEventListener('mute', update);
+              track.removeEventListener('unmute', update);
+              track.removeEventListener('ended', update);
+            });
+          };
+          update();
+        };
+
+        stream.addEventListener('addtrack', observeTracks);
+        stream.addEventListener('removetrack', observeTracks);
+        observeTracks();
+
+        onCleanup(() => {
+          stream.removeEventListener('addtrack', observeTracks);
+          stream.removeEventListener('removetrack', observeTracks);
+          removeTrackListeners();
         });
-      };
-      tracks.forEach((track) => {
-        track.addEventListener('mute', update);
-        track.addEventListener('unmute', update);
-        track.addEventListener('ended', update);
-      });
-      removeTrackListeners = () => {
-        tracks.forEach((track) => {
-          track.removeEventListener('mute', update);
-          track.removeEventListener('unmute', update);
-          track.removeEventListener('ended', update);
-        });
-      };
-      update();
-    };
+      },
+    ),
+  );
 
-    stream.addEventListener('addtrack', observeTracks);
-    stream.addEventListener('removetrack', observeTracks);
-    observeTracks();
-
-    onCleanup(() => {
-      stream.removeEventListener('addtrack', observeTracks);
-      stream.removeEventListener('removetrack', observeTracks);
-      removeTrackListeners();
-    });
-  });
+  createEffect(
+    on(
+      () => props.videoEnabled,
+      () => updateStatus(props.stream),
+      { defer: true },
+    ),
+  );
 
   createEffect(() => {
     if (!video) return;

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -1,20 +1,30 @@
-import { createEffect, createSignal, onCleanup, Show } from 'solid-js';
+import {
+  createEffect,
+  createSignal,
+  onCleanup,
+  Switch,
+  Match,
+  Show,
+} from 'solid-js';
 import { createMediaPlayback } from '@kidlib/p2p/solid';
 import { t } from '@shared/i18n';
 
 import styles from './ParticipantMedia.module.css';
-import { Phone } from 'lucide-solid';
+import { PhoneCall } from 'lucide-solid';
+import { Spinner } from '@components/Spinner';
 
 type ParticipantMediaProps = {
   stream: MediaStream;
   variant?: 'remote' | 'self-preview';
   videoEnabled?: boolean;
-  videoExpected?: boolean;
   remoteAudioMuted?: boolean;
 };
 
-type MediaState = 'audio' | 'video' | 'empty';
-type VideoStatus = 'connecting' | 'interrupted' | null;
+// Unambiguous status shared by both tracks: 'off' = not expected on this
+// call at all, 'connecting' = expected but never connected yet,
+// 'interrupted' = was connected, now isn't, 'connected' = connected right now.
+type TrackStatus = 'off' | 'connecting' | 'interrupted' | 'connected';
+type MediaStatus = { audio: TrackStatus; video: TrackStatus };
 
 // Only NotAllowedError means playback needs a user gesture; other
 // rejections (e.g. AbortError from re-attach/pause races) are transient
@@ -23,18 +33,24 @@ function isAutoplayBlockedError(error: unknown): boolean {
   return (error as { name?: string } | undefined)?.name === 'NotAllowedError';
 }
 
-function getMediaState(stream: MediaStream, videoEnabled = true): MediaState {
-  const hasUsableVideo = stream
-    .getVideoTracks()
-    .some(
-      (track) => videoEnabled && track.readyState !== 'ended' && !track.muted,
-    );
-  if (hasUsableVideo) return 'video';
+function trackStatus(
+  expected: boolean,
+  connected: boolean,
+  wasConnected: boolean,
+): TrackStatus {
+  if (!expected) return 'off';
+  if (connected) return 'connected';
+  return wasConnected ? 'interrupted' : 'connecting';
+}
 
-  const hasLiveAudio = stream
-    .getAudioTracks()
-    .some((track) => track.readyState !== 'ended');
-  return hasLiveAudio ? 'audio' : 'empty';
+function isVideoConnected(stream: MediaStream): boolean {
+  return stream
+    .getVideoTracks()
+    .some((track) => track.readyState !== 'ended' && !track.muted);
+}
+
+function isAudioConnected(stream: MediaStream): boolean {
+  return stream.getAudioTracks().some((track) => track.readyState !== 'ended');
 }
 
 export function ParticipantMedia(props: ParticipantMediaProps) {
@@ -42,13 +58,19 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   const variant = () => props.variant ?? 'remote';
   const muted = () =>
     variant() === 'self-preview' || props.remoteAudioMuted === true;
-  const [mediaState, setMediaState] = createSignal<MediaState>(
-    getMediaState(props.stream, props.videoEnabled),
-  );
-  const [videoStatus, setVideoStatus] = createSignal<VideoStatus>(null);
-  const [hasShownVideo, setHasShownVideo] = createSignal(
-    mediaState() === 'video',
-  );
+
+  // Sticky per-stream: once a track has been live, a later drop reads as
+  // 'interrupted' rather than 'connecting'. Reset when props.stream changes.
+  let videoWasConnected = isVideoConnected(props.stream);
+  let audioWasConnected = isAudioConnected(props.stream);
+  const [status, setStatus] = createSignal<MediaStatus>({
+    video: trackStatus(
+      props.videoEnabled ?? true,
+      videoWasConnected,
+      videoWasConnected,
+    ),
+    audio: trackStatus(true, audioWasConnected, audioWasConnected),
+  });
 
   const playback = createMediaPlayback({
     playsInline: true,
@@ -67,6 +89,9 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   createEffect(() => {
     const stream = props.stream;
     const videoEnabled = props.videoEnabled ?? true;
+    // New stream instance: sticky "was connected" flags reset with it.
+    videoWasConnected = false;
+    audioWasConnected = false;
     let removeTrackListeners = () => {};
 
     const observeTracks = () => {
@@ -74,9 +99,14 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
 
       const tracks = stream.getTracks();
       const update = () => {
-        const nextMediaState = getMediaState(stream, videoEnabled);
-        setMediaState(nextMediaState);
-        if (nextMediaState === 'video') setHasShownVideo(true);
+        const videoConnected = isVideoConnected(stream);
+        const audioConnected = isAudioConnected(stream);
+        if (videoConnected) videoWasConnected = true;
+        if (audioConnected) audioWasConnected = true;
+        setStatus({
+          video: trackStatus(videoEnabled, videoConnected, videoWasConnected),
+          audio: trackStatus(true, audioConnected, audioWasConnected),
+        });
       };
       tracks.forEach((track) => {
         track.addEventListener('mute', update);
@@ -105,14 +135,6 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   });
 
   createEffect(() => {
-    if (mediaState() === 'video' || !props.videoExpected) {
-      setVideoStatus(null);
-      return;
-    }
-    setVideoStatus(hasShownVideo() ? 'interrupted' : 'connecting');
-  });
-
-  createEffect(() => {
     // Chromium won't fire loadedmetadata (and outputs no audio) while a
     // muted video track — the reserved camera slot of an audio-only call —
     // is in srcObject and produces no frames. Attach only the audio tracks
@@ -120,7 +142,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     // ponytail: audio tracks snapshotted per attach; fine while the mic slot
     // is fixed at join — revisit if audio tracks can be added mid-call.
     const stream =
-      mediaState() === 'video'
+      status().video === 'connected'
         ? props.stream
         : new MediaStream(props.stream.getAudioTracks());
     if (!video) return;
@@ -154,32 +176,46 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     <div
       class={styles.surface}
       classList={{ [styles.selfPreview]: variant() === 'self-preview' }}
-      data-media-state={mediaState()}
-      data-variant={variant()}
     >
-      <div class={styles.placeholder} aria-hidden='true' />
-
-      <div class={styles.audioOnly} aria-hidden='true'>
-        <Phone size={variant() === 'self-preview' ? 32 : 64} />
-      </div>
-
-      <Show when={videoStatus()}>
-        {(status) => (
-          <p class={styles.videoStatus} role='status'>
-            {status() === 'connecting'
-              ? t('call.video.connecting')
-              : t('call.video.interrupted')}
-          </p>
-        )}
-      </Show>
-
       <video
         ref={video}
         class={styles.media}
-        hidden={mediaState() !== 'video'}
+        hidden={status().video !== 'connected'}
         autoplay
         muted={muted()}
       />
+
+      <Show when={status().video !== 'connected'}>
+        <Switch
+          fallback={
+            <div class={styles.spinner}>
+              <Spinner />
+            </div>
+          }
+        >
+          <Match
+            when={status().audio === 'connected' && status().video === 'off'}
+          >
+            <div class={styles.audioOnly}>
+              <PhoneCall size={variant() === 'self-preview' ? 32 : 64} />
+            </div>
+          </Match>
+
+          <Match
+            when={
+              status().video === 'connecting' ||
+              status().video === 'interrupted'
+            }
+          >
+            <p class={styles.videoStatus} role='status'>
+              {status().video === 'connecting'
+                ? t('call.video.connecting')
+                : t('call.video.interrupted')}
+            </p>
+          </Match>
+        </Switch>
+      </Show>
+
       <Show
         when={
           playback.playbackBlocked() &&
@@ -191,7 +227,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
           class={styles.playbackPrompt}
           onClick={() => void playback.resumePlayback()}
         >
-          Continue call
+          {t('call.continue_prompt')}
         </button>
       </Show>
     </div>

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -1,4 +1,5 @@
 import {
+  createMemo,
   createEffect,
   createSignal,
   onCleanup,
@@ -70,6 +71,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     ),
     audio: trackStatus(true, audioWasConnected, audioWasConnected),
   });
+  const videoConnected = createMemo(() => status().video === 'connected');
 
   const playback = createMediaPlayback({
     playsInline: true,
@@ -140,7 +142,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     // muted video track — the reserved camera slot of an audio-only call —
     // is in srcObject and produces no frames. Attach only the audio tracks
     // until usable video exists.
-    const audioOnly = status().video !== 'connected'; //  && status().audio === 'connected';
+    const audioOnly = !videoConnected();
     const stream = audioOnly
       ? new MediaStream(props.stream.getAudioTracks())
       : props.stream;

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -10,19 +10,17 @@ import { createMediaPlayback } from '@kidlib/p2p/solid';
 import { t } from '@shared/i18n';
 
 import styles from './ParticipantMedia.module.css';
-import { PhoneCall } from 'lucide-solid';
+import { PhoneCall, Mic, MicOff } from 'lucide-solid'; // PhoneOff,
 import { Spinner } from '@components/Spinner';
 
 type ParticipantMediaProps = {
   stream: MediaStream;
   variant?: 'remote' | 'self-preview';
   videoEnabled?: boolean;
+  audioEnabled?: boolean;
   remoteAudioMuted?: boolean;
 };
 
-// Unambiguous status shared by both tracks: 'off' = not expected on this
-// call at all, 'connecting' = expected but never connected yet,
-// 'interrupted' = was connected, now isn't, 'connected' = connected right now.
 type TrackStatus = 'off' | 'connecting' | 'interrupted' | 'connected';
 type MediaStatus = { audio: TrackStatus; video: TrackStatus };
 
@@ -194,10 +192,26 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
           }
         >
           <Match
-            when={status().audio === 'connected' && status().video === 'off'}
+            when={
+              status().audio === 'connected' &&
+              status().video === 'off' &&
+              variant() === 'remote'
+            }
           >
             <div class={styles.audioOnly}>
-              <PhoneCall size={variant() === 'self-preview' ? 32 : 64} />
+              <PhoneCall size={64} />
+            </div>
+          </Match>
+
+          <Match
+            when={
+              status().audio === 'connected' &&
+              status().video === 'off' &&
+              variant() === 'self-preview'
+            }
+          >
+            <div class={styles.audioOnly}>
+              {props.audioEnabled ? <Mic size={32} /> : <MicOff size={32} />}
             </div>
           </Match>
 

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -148,6 +148,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
       : props.stream;
 
     const syncAudioTracks = (event: MediaStreamTrackEvent) => {
+      if (event.track.kind !== 'audio') return;
       if (event.type === 'addtrack') stream.addTrack(event.track);
       else stream.removeTrack(event.track);
     };

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -10,7 +10,7 @@ import { createMediaPlayback } from '@kidlib/p2p/solid';
 import { t } from '@shared/i18n';
 
 import styles from './ParticipantMedia.module.css';
-import { PhoneCall, Mic, MicOff } from 'lucide-solid'; // PhoneOff,
+import { PhoneCall, PhoneOff, Mic, MicOff } from 'lucide-solid';
 import { Spinner } from '@components/Spinner';
 
 type ParticipantMediaProps = {
@@ -21,8 +21,8 @@ type ParticipantMediaProps = {
   remoteAudioMuted?: boolean;
 };
 
-type TrackStatus = 'off' | 'connecting' | 'interrupted' | 'connected';
-type MediaStatus = { audio: TrackStatus; video: TrackStatus };
+type MediaTrackStatus = 'off' | 'connecting' | 'interrupted' | 'connected';
+type MediaStatus = { audio: MediaTrackStatus; video: MediaTrackStatus };
 
 // Only NotAllowedError means playback needs a user gesture; other
 // rejections (e.g. AbortError from re-attach/pause races) are transient
@@ -35,32 +35,33 @@ function trackStatus(
   expected: boolean,
   connected: boolean,
   wasConnected: boolean,
-): TrackStatus {
+): MediaTrackStatus {
   if (!expected) return 'off';
   if (connected) return 'connected';
   return wasConnected ? 'interrupted' : 'connecting';
 }
 
-function isVideoConnected(stream: MediaStream): boolean {
-  return stream
-    .getVideoTracks()
-    .some((track) => track.readyState !== 'ended' && !track.muted);
-}
+function isReceivingStreamData(
+  stream: MediaStream,
+  mediaType: 'audio' | 'video',
+): boolean {
+  const tracks =
+    mediaType === 'video' ? stream.getVideoTracks() : stream.getAudioTracks();
 
-function isAudioConnected(stream: MediaStream): boolean {
-  return stream.getAudioTracks().some((track) => track.readyState !== 'ended');
+  // NOTE: track.muted does NOT mean intentionally muted, that is done via track.enabled == false
+  return tracks.some((track) => track.readyState !== 'ended' && !track.muted);
 }
 
 export function ParticipantMedia(props: ParticipantMediaProps) {
   let video!: HTMLVideoElement;
   const variant = () => props.variant ?? 'remote';
-  const muted = () =>
+  const shouldMutePlayback = () =>
     variant() === 'self-preview' || props.remoteAudioMuted === true;
 
   // Sticky per-stream: once a track has been live, a later drop reads as
   // 'interrupted' rather than 'connecting'. Reset when props.stream changes.
-  let videoWasConnected = isVideoConnected(props.stream);
-  let audioWasConnected = isAudioConnected(props.stream);
+  let videoWasConnected = isReceivingStreamData(props.stream, 'video');
+  let audioWasConnected = isReceivingStreamData(props.stream, 'audio');
   const [status, setStatus] = createSignal<MediaStatus>({
     video: trackStatus(
       props.videoEnabled ?? true,
@@ -97,8 +98,8 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
 
       const tracks = stream.getTracks();
       const update = () => {
-        const videoConnected = isVideoConnected(stream);
-        const audioConnected = isAudioConnected(stream);
+        const videoConnected = isReceivingStreamData(stream, 'video');
+        const audioConnected = isReceivingStreamData(stream, 'audio');
         if (videoConnected) videoWasConnected = true;
         if (audioConnected) audioWasConnected = true;
         setStatus({
@@ -133,19 +134,27 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   });
 
   createEffect(() => {
+    if (!video) return;
+
     // Chromium won't fire loadedmetadata (and outputs no audio) while a
     // muted video track — the reserved camera slot of an audio-only call —
     // is in srcObject and produces no frames. Attach only the audio tracks
     // until usable video exists.
-    // ponytail: audio tracks snapshotted per attach; fine while the mic slot
-    // is fixed at join — revisit if audio tracks can be added mid-call.
-    const stream =
-      status().video === 'connected'
-        ? props.stream
-        : new MediaStream(props.stream.getAudioTracks());
-    if (!video) return;
+    const audioOnly = status().video !== 'connected'; //  && status().audio === 'connected';
+    const stream = audioOnly
+      ? new MediaStream(props.stream.getAudioTracks())
+      : props.stream;
 
-    const shouldMute = muted();
+    const syncAudioTracks = (event: MediaStreamTrackEvent) => {
+      if (event.type === 'addtrack') stream.addTrack(event.track);
+      else stream.removeTrack(event.track);
+    };
+    if (audioOnly) {
+      props.stream.addEventListener('addtrack', syncAudioTracks);
+      props.stream.addEventListener('removetrack', syncAudioTracks);
+    }
+
+    const shouldMute = shouldMutePlayback();
     video.defaultMuted = shouldMute;
     if (shouldMute) video.setAttribute('muted', '');
     else video.removeAttribute('muted');
@@ -164,6 +173,10 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
 
     onCleanup(() => {
       playback.detach();
+      if (audioOnly) {
+        props.stream.removeEventListener('addtrack', syncAudioTracks);
+        props.stream.removeEventListener('removetrack', syncAudioTracks);
+      }
       video.removeEventListener('loadedmetadata', replay);
       video.removeEventListener('canplay', replay);
       video.removeEventListener('pause', replay);
@@ -180,7 +193,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
         class={styles.media}
         hidden={status().video !== 'connected'}
         autoplay
-        muted={muted()}
+        muted={shouldMutePlayback()}
       />
 
       <Show when={status().video !== 'connected'}>
@@ -199,7 +212,11 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
             }
           >
             <div class={styles.audioOnly}>
-              <PhoneCall size={64} />
+              {props.audioEnabled ? (
+                <PhoneCall size={64} />
+              ) : (
+                <PhoneOff size={64} />
+              )}
             </div>
           </Match>
 

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -55,6 +55,7 @@ function isReceivingStreamData(
 }
 
 export function ParticipantMedia(props: ParticipantMediaProps) {
+  // oxlint-disable-next-line no-unassigned-vars
   let video!: HTMLVideoElement;
   const variant = () => props.variant ?? 'remote';
   const shouldMutePlayback = () =>

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createSignal, onCleanup, Show } from 'solid-js';
 import { createMediaPlayback } from '@kidlib/p2p/solid';
+import { t } from '@shared/i18n';
 
 import styles from './ParticipantMedia.module.css';
 import { Phone } from 'lucide-solid';
@@ -8,10 +9,12 @@ type ParticipantMediaProps = {
   stream: MediaStream;
   variant?: 'remote' | 'self-preview';
   videoEnabled?: boolean;
+  videoExpected?: boolean;
   remoteAudioMuted?: boolean;
 };
 
 type MediaState = 'audio' | 'video' | 'empty';
+type VideoStatus = 'connecting' | 'interrupted' | null;
 
 // Only NotAllowedError means playback needs a user gesture; other
 // rejections (e.g. AbortError from re-attach/pause races) are transient
@@ -42,6 +45,10 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   const [mediaState, setMediaState] = createSignal<MediaState>(
     getMediaState(props.stream, props.videoEnabled),
   );
+  const [videoStatus, setVideoStatus] = createSignal<VideoStatus>(null);
+  const [hasShownVideo, setHasShownVideo] = createSignal(
+    mediaState() === 'video',
+  );
 
   const playback = createMediaPlayback({
     playsInline: true,
@@ -66,7 +73,11 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
       removeTrackListeners();
 
       const tracks = stream.getTracks();
-      const update = () => setMediaState(getMediaState(stream, videoEnabled));
+      const update = () => {
+        const nextMediaState = getMediaState(stream, videoEnabled);
+        setMediaState(nextMediaState);
+        if (nextMediaState === 'video') setHasShownVideo(true);
+      };
       tracks.forEach((track) => {
         track.addEventListener('mute', update);
         track.addEventListener('unmute', update);
@@ -91,6 +102,14 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
       stream.removeEventListener('removetrack', observeTracks);
       removeTrackListeners();
     });
+  });
+
+  createEffect(() => {
+    if (mediaState() === 'video' || !props.videoExpected) {
+      setVideoStatus(null);
+      return;
+    }
+    setVideoStatus(hasShownVideo() ? 'interrupted' : 'connecting');
   });
 
   createEffect(() => {
@@ -143,6 +162,16 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
       <div class={styles.audioOnly} aria-hidden='true'>
         <Phone size={variant() === 'self-preview' ? 32 : 64} />
       </div>
+
+      <Show when={videoStatus()}>
+        {(status) => (
+          <p class={styles.videoStatus} role='status'>
+            {status() === 'connecting'
+              ? t('call.video.connecting')
+              : t('call.video.interrupted')}
+          </p>
+        )}
+      </Show>
 
       <video
         ref={video}

--- a/src/push/__tests__/shared-contracts.test.js
+++ b/src/push/__tests__/shared-contracts.test.js
@@ -94,7 +94,7 @@ describe('shared push notification contracts', () => {
   it('parses service worker NAVIGATE messages', () => {
     const message = parseServiceWorkerNavigateMessage({
       type: 'NAVIGATE',
-      path: '/?conversationRoom=room-123',
+      path: '/?call=1&conversationId=room-123',
     });
 
     expect(message.type).toBe('NAVIGATE');

--- a/src/push/sw/__tests__/notification-click-handler.test.js
+++ b/src/push/sw/__tests__/notification-click-handler.test.js
@@ -16,7 +16,7 @@ describe('notification click routing', () => {
         },
         undefined,
       ),
-    ).toBe('/?conversationRoom=room-123');
+    ).toBe('/?call=1&conversationId=room-123');
   });
 
   it('marks the incoming-call path for auto-accept on the explicit accept action', () => {
@@ -25,7 +25,7 @@ describe('notification click routing', () => {
         { type: 'incoming_call', roomId: 'room-123' },
         'accept',
       ),
-    ).toBe('/?conversationRoom=room-123&accept=1');
+    ).toBe('/?call=1&conversationId=room-123&accept=1');
   });
 
   it('carries caller metadata for incoming call notification clicks', () => {
@@ -41,7 +41,7 @@ describe('notification click routing', () => {
         undefined,
       ),
     ).toBe(
-      '/?conversationRoom=room-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
+      '/?call=1&conversationId=room-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
     );
   });
 

--- a/src/push/sw/notification-click-handler.js
+++ b/src/push/sw/notification-click-handler.js
@@ -18,7 +18,9 @@ export function getNotificationNavigationPath(data, action) {
 
   if (isIncomingCallType(type)) {
     if (!roomId) return '/';
-    const params = new URLSearchParams({ conversationRoom: roomId });
+    // call=1 routes the client to the incoming-call flow; a bare
+    // conversationId just opens the conversation UI.
+    const params = new URLSearchParams({ call: '1', conversationId: roomId });
     if (callerId) params.set('callerId', callerId);
     if (callerName) params.set('callerName', callerName);
     if (audioOnly === true || audioOnly === 'true')

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -21,6 +21,8 @@
   "call.busy": "Contact is busy",
   "call.calling": "Calling {name}...",
   "call.waiting": "Waiting for answer...",
+  "call.video.connecting": "Connecting video…",
+  "call.video.interrupted": "Video connection interrupted. Reconnecting…",
   "call.unknown_caller": "Unknown Caller",
   "call.lobby.ephemeral_prompt": "Or make an ephemeral call:",
   "call.lobby.start": "Start a call",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -21,6 +21,7 @@
   "call.busy": "Contact is busy",
   "call.calling": "Calling {name}...",
   "call.waiting": "Waiting for answer...",
+  "call.continue_prompt": "Continue call",
   "call.video.connecting": "Connecting video…",
   "call.video.interrupted": "Video connection interrupted. Reconnecting…",
   "call.unknown_caller": "Unknown Caller",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -21,6 +21,7 @@
   "call.busy": "Notandi er á tali",
   "call.calling": "Hringi í {name}...",
   "call.waiting": "Bíður svars...",
+  "call.continue_prompt": "Halda áfram símtali",
   "call.video.connecting": "Tengist myndbandi…",
   "call.video.interrupted": "Myndbandstenging rofnaði. Reyni að tengjast aftur…",
   "call.unknown_caller": "Óþekktur notandi",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -21,6 +21,8 @@
   "call.busy": "Notandi er á tali",
   "call.calling": "Hringi í {name}...",
   "call.waiting": "Bíður svars...",
+  "call.video.connecting": "Tengist myndbandi…",
+  "call.video.interrupted": "Myndbandstenging rofnaði. Reyni að tengjast aftur…",
   "call.unknown_caller": "Óþekktur notandi",
   "call.lobby.ephemeral_prompt": "Eða hringdu skyndisímtal:",
   "call.lobby.start": "Hefja símtal",


### PR DESCRIPTION
## What

**Fix: self-preview showed "Connecting video" when the camera was toggled off.** Root cause: `createCallMedia` lived inside `ActiveCallControls`, so its `cameraOn`/`screenSharing` state wasn't available to the self-preview, which defaulted to expecting video. There is now one `createCallMedia` instance per call, owned by `ActiveCallRoom` and passed to both `ActiveCallControls` and `MemberStreams`. This also fixes a latent bug where the controls' joined-only `<Show>` unmounting would stop all owned camera tracks mid-call.

**Redundant state removed:** `ParticipantMedia`'s `videoEnabled`/`videoExpected` prop pair always produced the same rendered status; collapsed to a single `videoEnabled` prop driven by the published `cameraOn` flag.

**Naming cleanup (one word per thing):**
- "presence" now refers only to the online/offline feature; the p2p room metadata is `cameraOn`/member data (`publishCameraPresence` → `publishCameraOn`, new `memberCameraOn` helper).
- `exitActiveRoom` (duplicate of `hangUp`) deleted; `pendingIncomingCall`/`pendingOutgoingCall` → `incomingCall`/`outgoingCall`; controller `sendOutgoingCallInvite` → `startCall`; `PendingOutgoingCall` → `OutgoingCall`.
- Call notification URLs: `?conversationRoom=<id>` → `?call=1&conversationId=<id>`. `conversationId` always names the id; the `call` flag carries routing intent (previously the param name itself distinguished call links from open-conversation links).
- Controller: `setCalleeBusy` wrapper inlined, triplicated `initCallService({...})` deduped.

**Tests** now assert user-visible behavior (`video.hidden`, `muted`, fallback text) instead of test-only `data-media-state`/`data-variant` attributes, which are removed from the component.

## Notes

- SW URL param change needs no rollout compat: SW updates are force-immediate.
- `EnterRoomOptions` kept despite being unused — wanted for group calls soon.

## Testing

- `vp check` clean, full `vp test` suite passes (365 passed, 1 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved incoming-call notification routing with explicit call handling and conversation identifier support, including auto-accept behavior.
  * Added localized “continue call” prompt and video connection status messages (connecting and interrupted/reconnecting).
* **Bug Fixes**
  * Improved in-call media UI logic for audio-only vs video, with clearer connecting/interrupted messaging and more reliable mic/camera state propagation.
* **Tests**
  * Updated call and push-notification tests to match the new navigation parameters and revised UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->