### PR TITLE
Bound accepted call response requests

### DIFF
--- a/src/features/call/call-service.test.js
+++ b/src/features/call/call-service.test.js
@@ -20,6 +20,8 @@ import { cleanupCallService, initCallService } from './call-service.js';
 describe('initCallService', () => {
   afterEach(() => {
     cleanupCallService();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('replaces a stale singleton when the authenticated UID changes', () => {
@@ -71,5 +73,98 @@ describe('initCallService', () => {
       roomId: 'room-1',
       by: 'callee-id',
     });
+  });
+
+  it('retries an accepted response when token acquisition times out', async () => {
+    vi.useFakeTimers();
+    const getToken = vi
+      .fn()
+      .mockReturnValueOnce(new Promise(() => {}))
+      .mockResolvedValueOnce('fresh-token');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const service = initCallService({
+      localUID: 'callee-id',
+      baseUrl: 'http://localhost:8788',
+      getToken,
+    });
+
+    const response = service.respondToIncomingCallInvite({
+      roomId: 'room-1',
+      callerId: 'caller-id',
+      responseType: 'accepted',
+    });
+    await vi.advanceTimersByTimeAsync(8_000);
+    await response;
+
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('http://localhost:8788/calls/response');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      conversationId: 'room-1',
+      callerId: 'caller-id',
+      responseType: 'accepted',
+      expiresAt: expect.any(Number),
+    });
+  });
+
+  it('retries an accepted response when the request times out', async () => {
+    vi.useFakeTimers();
+    const getToken = vi.fn().mockResolvedValue('fresh-token');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementationOnce((_url, init) => {
+        return new Promise((_, reject) => {
+          init.signal.addEventListener(
+            'abort',
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+        });
+      })
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const service = initCallService({
+      localUID: 'callee-id',
+      baseUrl: 'http://localhost:8788',
+      getToken,
+    });
+
+    const response = service.respondToIncomingCallInvite({
+      roomId: 'room-1',
+      callerId: 'caller-id',
+      responseType: 'accepted',
+    });
+    await vi.advanceTimersByTimeAsync(8_000);
+    await response;
+
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a rejected response when token acquisition times out', async () => {
+    vi.useFakeTimers();
+    const getToken = vi.fn(() => new Promise(() => {}));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const service = initCallService({
+      localUID: 'callee-id',
+      baseUrl: 'http://localhost:8788',
+      getToken,
+    });
+
+    const response = expect(
+      service.respondToIncomingCallInvite({
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        responseType: 'rejected',
+      }),
+    ).rejects.toMatchObject({ name: 'TimeoutError' });
+    await vi.advanceTimersByTimeAsync(8_000);
+    await response;
+
+    expect(getToken).toHaveBeenCalledOnce();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -21,6 +21,16 @@ interface CallServiceOptions {
 }
 
 let callServiceInstance: CallService | null = null;
+const REQUEST_TIMEOUT_MS = 8_000;
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'TimeoutError'
+  );
+}
 
 export function initCallService(options: CallServiceOptions): CallService {
   if (
@@ -88,25 +98,60 @@ export class CallService {
     };
   }
 
-  private async post(path: string, body: unknown): Promise<void> {
-    const token = await this.getToken();
-    if (!token) throw new Error('[CallService] not authenticated');
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(body),
+  private async post(
+    path: string,
+    body: unknown,
+    { retryOnTimeout = false }: { retryOnTimeout?: boolean } = {},
+  ): Promise<void> {
+    try {
+      await this.postOnce(path, body);
+    } catch (error) {
+      if (!retryOnTimeout || !isTimeoutError(error)) throw error;
+      await this.postOnce(path, body);
+    }
+  }
+
+  private async postOnce(path: string, body: unknown): Promise<void> {
+    const controller = new AbortController();
+    const timeoutError = new DOMException(
+      `[CallService] ${path} timed out`,
+      'TimeoutError',
+    );
+    const timeoutId = setTimeout(
+      () => controller.abort(timeoutError),
+      REQUEST_TIMEOUT_MS,
+    );
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener(
+        'abort',
+        () => reject(controller.signal.reason ?? timeoutError),
+        { once: true },
+      );
     });
-    if (!res.ok) {
-      if (res.status === 401) {
-        // Body goes to reportApiAuthFailure only — backend-controlled text
-        // must not leak into thrown errors (logged/telemetered downstream).
-        const detail = await res.text().catch(() => '');
-        reportApiAuthFailure(`call ${path}`, res.status, detail);
+
+    try {
+      const token = await Promise.race([this.getToken(), timeoutPromise]);
+      if (!token) throw new Error('[CallService] not authenticated');
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        if (res.status === 401) {
+          // Body goes to reportApiAuthFailure only — backend-controlled text
+          // must not leak into thrown errors (logged/telemetered downstream).
+          const detail = await res.text().catch(() => '');
+          reportApiAuthFailure(`call ${path}`, res.status, detail);
+        }
+        throw new Error(`[CallService] ${path} failed: ${res.status}`);
       }
-      throw new Error(`[CallService] ${path} failed: ${res.status}`);
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 
@@ -155,12 +200,16 @@ export class CallService {
     callerId: string;
     responseType: MailboxResponse['responseType'];
   }): Promise<void> {
-    await this.post('/calls/response', {
-      conversationId: roomId,
-      callerId,
-      responseType,
-      expiresAt: Date.now() + CALLING_TTL_MS,
-    });
+    await this.post(
+      '/calls/response',
+      {
+        conversationId: roomId,
+        callerId,
+        responseType,
+        expiresAt: Date.now() + CALLING_TTL_MS,
+      },
+      { retryOnTimeout: responseType === 'accepted' },
+    );
   }
 
   cancelOutgoingCall({


### PR DESCRIPTION
## Summary

- bound call mailbox POST attempts to 8 seconds across token acquisition and fetch
- retry timed-out accepted responses once, while leaving other outcomes and HTTP failures single-attempt
- cover stalled token acquisition, stalled fetch, and rejected-response behavior

## Root cause

An accepted response could wait indefinitely while resolving a Firebase token or performing fetch. In the token-stall case, `/calls/response` was never initiated and the caller could ring until its 45-second timeout.

## Validation

- `vp check`
- `vp test` — 371 passed, 1 skipped
- two-axis code review — no remaining standards or spec findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout handling for call response requests to prevent requests from hanging indefinitely.
  * Accepted incoming call responses now automatically retry once after a timeout.
  * Rejected incoming call responses no longer retry after token acquisition timeouts.
  * Improved reliability when network requests or authentication token retrieval time out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->