### PR TITLE
Reconnect sockets immediately on PWA foreground/online

### DIFF
--- a/src/realtime/conversation-channel.ts
+++ b/src/realtime/conversation-channel.ts
@@ -9,6 +9,7 @@ import {
   type ConversationServerEvent,
 } from './conversation-protocol';
 import { buildHangViduWebSocketUrl } from '../infra/hangvidu-api-url';
+import { subscribeToWakeSignals } from './wake-signals';
 
 export interface ConversationChannelOptions {
   /** Data worker base URL, e.g. http://localhost:8788 (http(s) → ws(s)). */
@@ -89,6 +90,17 @@ export function createConversationChannel(
     backoff = Math.min(backoff * 2, maxBackoff);
   }
 
+  // Foreground/online: if we're sitting out a backoff wait, reconnect now.
+  // Only fires mid-wait — an existing socket (even a dying one) is left alone;
+  // its close event re-enters scheduleReconnect with the reset backoff.
+  const unsubscribeWake = subscribeToWakeSignals(() => {
+    if (closed || !reconnectTimer) return;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+    backoff = 500;
+    void connect();
+  });
+
   void connect();
 
   return {
@@ -98,6 +110,7 @@ export function createConversationChannel(
     },
     close() {
       closed = true;
+      unsubscribeWake();
       if (reconnectTimer) clearTimeout(reconnectTimer);
       handlers.clear();
       ws?.close();

--- a/src/realtime/mailbox-channel.ts
+++ b/src/realtime/mailbox-channel.ts
@@ -10,6 +10,7 @@ import {
   type MailboxEnvelope,
 } from '../../shared/user-mailbox/protocol';
 import { buildHangViduWebSocketUrl } from '../infra/hangvidu-api-url';
+import { subscribeToWakeSignals } from './wake-signals';
 
 export interface MailboxChannelOptions {
   /** Data worker base URL, e.g. https://localhost:8788 (http(s) → ws(s)). */
@@ -86,6 +87,17 @@ export function createMailboxChannel(
     backoff = Math.min(backoff * 2, maxBackoff);
   }
 
+  // Foreground/online: if we're sitting out a backoff wait, reconnect now.
+  // Only fires mid-wait — an existing socket (even a dying one) is left alone;
+  // its close event re-enters scheduleReconnect with the reset backoff.
+  const unsubscribeWake = subscribeToWakeSignals(() => {
+    if (closed || !reconnectTimer) return;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+    backoff = 500;
+    void connect();
+  });
+
   void connect();
 
   return {
@@ -95,6 +107,7 @@ export function createMailboxChannel(
     },
     close() {
       closed = true;
+      unsubscribeWake();
       if (reconnectTimer) clearTimeout(reconnectTimer);
       handlers.clear();
       ws?.close();

--- a/src/realtime/signaling-socket.ts
+++ b/src/realtime/signaling-socket.ts
@@ -1,4 +1,5 @@
 import type { ClientMessage, ServerMessage } from './protocol';
+import { subscribeToWakeSignals } from './wake-signals';
 
 /**
  * Thin reconnecting WebSocket client to the signaling worker. Transport only —
@@ -81,6 +82,17 @@ export function createSignalingSocket(
     backoff = Math.min(backoff * 2, maxBackoff);
   }
 
+  // Foreground/online: if we're sitting out a backoff wait, reconnect now.
+  // Only fires mid-wait — an existing socket (even a dying one) is left alone;
+  // its close event re-enters scheduleReconnect with the reset backoff.
+  const unsubscribeWake = subscribeToWakeSignals(() => {
+    if (closed || !reconnectTimer) return;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+    backoff = 500;
+    void connect();
+  });
+
   void connect();
 
   return {
@@ -99,6 +111,7 @@ export function createSignalingSocket(
     },
     close() {
       closed = true;
+      unsubscribeWake();
       if (reconnectTimer) clearTimeout(reconnectTimer);
       sendQueue.length = 0;
       messageHandlers.clear();

--- a/src/realtime/wake-signals.test.js
+++ b/src/realtime/wake-signals.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { subscribeToWakeSignals } from './wake-signals';
+
+describe('subscribeToWakeSignals', () => {
+  it('fires on online and on visibilitychange to visible, not after cleanup', () => {
+    const onWake = vi.fn();
+    const unsubscribe = subscribeToWakeSignals(onWake);
+
+    window.dispatchEvent(new Event('online'));
+    expect(onWake).toHaveBeenCalledTimes(1);
+
+    // visibilitychange only wakes when the document is actually visible.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(onWake).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(onWake).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    window.dispatchEvent(new Event('online'));
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(onWake).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/realtime/wake-signals.ts
+++ b/src/realtime/wake-signals.ts
@@ -1,0 +1,19 @@
+// Wake signals for reconnecting sockets. On iOS PWA resume the network stack
+// is briefly down, so early reconnect attempts fail and exponential backoff
+// stretches the next try — potentially past a call invite's TTL. Foreground
+// (`visibilitychange` → visible) and `online` are the moments connectivity
+// plausibly just returned, so subscribers collapse their backoff wait then.
+export function subscribeToWakeSignals(onWake: () => void): () => void {
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return () => {};
+  }
+  const handleVisibility = () => {
+    if (document.visibilityState === 'visible') onWake();
+  };
+  document.addEventListener('visibilitychange', handleVisibility);
+  window.addEventListener('online', onWake);
+  return () => {
+    document.removeEventListener('visibilitychange', handleVisibility);
+    window.removeEventListener('online', onWake);
+  };
+}


### PR DESCRIPTION
## Context
On iOS PWA resume, the network stack is briefly down: every WebSocket reconnect attempt fails instantly ("The network connection was lost") and exponential backoff stretches the next attempt. For the mailbox WS this can push reconnection past the 45s call-invite TTL, so a retained invite expires before it can replay — observed in field logs 2026-07-16.

## Change
New `src/realtime/wake-signals.ts`: `subscribeToWakeSignals(onWake)` listening to `visibilitychange` (→ visible) and `online`. The three reconnecting transports (`mailbox-channel`, `conversation-channel`, `signaling-socket`) use it to collapse a pending backoff wait: clear the timer, reset backoff to 500ms, connect now.

## Safety
- Fires only while a reconnect timer is pending — an existing socket (even a dying zombie) is left alone; its close event re-enters the normal reconnect path with the reset backoff. No duplicate connections possible.
- Listeners removed in each channel's `close()` (called on conversation switch/logout) — no leaks.
- Helper no-ops without `window`/`document`.
- MDN: `visibilitychange` is baseline-stable and fires on mobile app-switch; a spurious `online` firing no-ops.

## Verification
- New `wake-signals.test.js`: fire-on-online, fire-only-when-visible, cleanup.
- `vp check` clean; full node suite green (332 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time connections now reconnect immediately when the app returns online or becomes visible, rather than waiting for the full retry delay.
  * Reconnection backoff resets after a successful wake signal.

* **Bug Fixes**
  * Prevented reconnect attempts from triggering after a connection has been closed.

* **Tests**
  * Added coverage for online, visibility, and unsubscribe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->