### PR TITLE
Fix black call video on iOS 27 Beta

### DIFF
--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -163,10 +163,11 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     // muted video track — the reserved camera slot of an audio-only call —
     // is in srcObject and produces no frames. Attach only the audio tracks
     // until usable video exists.
+    const sourceStream = props.stream;
     const audioOnly = !videoConnected();
     const stream = audioOnly
-      ? new MediaStream(props.stream.getAudioTracks())
-      : props.stream;
+      ? new MediaStream(sourceStream.getAudioTracks())
+      : sourceStream;
 
     const syncAudioTracks = (event: MediaStreamTrackEvent) => {
       if (event.track.kind !== 'audio') return;
@@ -174,8 +175,8 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
       else stream.removeTrack(event.track);
     };
     if (audioOnly) {
-      props.stream.addEventListener('addtrack', syncAudioTracks);
-      props.stream.addEventListener('removetrack', syncAudioTracks);
+      sourceStream.addEventListener('addtrack', syncAudioTracks);
+      sourceStream.addEventListener('removetrack', syncAudioTracks);
     }
 
     const shouldMute = shouldMutePlayback();
@@ -189,22 +190,25 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     configureVideo(video);
 
     const attachedVideo = video;
+    let disposed = false;
     void playback
       .attach(attachedVideo, stream, { muted: shouldMute })
       .then((started) => {
         if (
           !started ||
+          disposed ||
+          props.stream !== sourceStream ||
           video !== attachedVideo ||
           audioOnly ||
           !isIOSDevice() ||
-          rebuiltVideoLayerForStream === props.stream
+          rebuiltVideoLayerForStream === sourceStream
         ) {
           return;
         }
 
         // iOS 27 can decode live frames but paint a black video layer; replacing
         // the element after playback starts forces WebKit to create a working one.
-        rebuiltVideoLayerForStream = props.stream;
+        rebuiltVideoLayerForStream = sourceStream;
         const replacement = attachedVideo.cloneNode(false) as HTMLVideoElement;
         attachedVideo.replaceWith(replacement);
         video = replacement;
@@ -221,10 +225,11 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     video.addEventListener('pause', replay);
 
     onCleanup(() => {
+      disposed = true;
       playback.detach();
       if (audioOnly) {
-        props.stream.removeEventListener('addtrack', syncAudioTracks);
-        props.stream.removeEventListener('removetrack', syncAudioTracks);
+        sourceStream.removeEventListener('addtrack', syncAudioTracks);
+        sourceStream.removeEventListener('removetrack', syncAudioTracks);
       }
       video.removeEventListener('loadedmetadata', replay);
       video.removeEventListener('canplay', replay);

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -10,6 +10,7 @@ import {
 } from 'solid-js';
 import { createMediaPlayback } from '@kidlib/p2p/solid';
 import { t } from '@shared/i18n';
+import { isIOSDevice } from '@lib/utils/detect-device.js';
 
 import styles from './ParticipantMedia.module.css';
 import { PhoneCall, PhoneOff, Mic, MicOff } from 'lucide-solid';
@@ -65,6 +66,7 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   // 'interrupted' rather than 'connecting'. Reset when props.stream changes.
   let videoWasConnected = isReceivingStreamData(props.stream, 'video');
   let audioWasConnected = isReceivingStreamData(props.stream, 'audio');
+  let rebuiltVideoLayerForStream: MediaStream | undefined;
   const [status, setStatus] = createSignal<MediaStatus>({
     video: trackStatus(
       props.videoEnabled ?? true,
@@ -177,13 +179,38 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
     }
 
     const shouldMute = shouldMutePlayback();
-    video.defaultMuted = shouldMute;
-    if (shouldMute) video.setAttribute('muted', '');
-    else video.removeAttribute('muted');
-    video.autoplay = true;
-    video.setAttribute('playsinline', 'true');
+    const configureVideo = (element: HTMLVideoElement) => {
+      element.defaultMuted = shouldMute;
+      if (shouldMute) element.setAttribute('muted', '');
+      else element.removeAttribute('muted');
+      element.autoplay = true;
+      element.setAttribute('playsinline', 'true');
+    };
+    configureVideo(video);
 
-    void playback.attach(video, stream, { muted: shouldMute });
+    const attachedVideo = video;
+    void playback
+      .attach(attachedVideo, stream, { muted: shouldMute })
+      .then((started) => {
+        if (
+          !started ||
+          video !== attachedVideo ||
+          audioOnly ||
+          !isIOSDevice() ||
+          rebuiltVideoLayerForStream === props.stream
+        ) {
+          return;
+        }
+
+        // iOS 27 can decode live frames but paint a black video layer; replacing
+        // the element after playback starts forces WebKit to create a working one.
+        rebuiltVideoLayerForStream = props.stream;
+        const replacement = attachedVideo.cloneNode(false) as HTMLVideoElement;
+        attachedVideo.replaceWith(replacement);
+        video = replacement;
+        configureVideo(replacement);
+        void playback.attach(replacement, stream, { muted: shouldMute });
+      });
 
     const replay = () => {
       if (video.paused) void playback.resumePlayback();


### PR DESCRIPTION
## Summary
- rebuild each active iOS video element once after playback starts, which makes WebKit paint the decoded local and remote call streams
- retain the existing reactive media attachment behavior for camera toggles, camera switching, and screen sharing

## Why this remains intentionally imperative
On iOS 27 Beta, WebKit can report successful playback while painting a black layer. A Solid-owned keyed replacement was tested: the replacement reached readyState 4, decoded 480×640 frames, and play() succeeded, but it still rendered black. The immediate element replacement and reattachment in ParticipantMedia is therefore deliberate.

**Do not refactor or remove this workaround without manually testing local and remote video on an actual iOS >= 27 Beta device**, including repeated camera toggles, camera switching, and screen sharing.

## Validation
- Manually verified on iOS 27 Beta: local and remote streams render correctly through repeated camera toggles, camera switching, and screen sharing.
- Focused ParticipantMedia tests passed before the manual browser verification.

Related to #641, which tracks re-testing on the next beta and researching a permanent solution if WebKit behavior persists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live video playback reliability on iOS by preventing repeated video-element rebuilds for the same stream.
  * Reduced black or missing video during calls by conditionally rebuilding the video layer after playback starts.
  * Strengthened media cleanup to correctly detach playback and listeners when ending or switching streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->