### PR TITLE
call: stability — reconnect grace + native left/dropped detection (p2p 0.4.0)

### DIFF
--- a/backend/cloudflare/src/realtime/signaling-room.ts
+++ b/backend/cloudflare/src/realtime/signaling-room.ts
@@ -81,10 +81,15 @@ export class SignalingRoom extends DurableObject<Env> {
         });
         this.broadcastPeers();
         return;
-      case 'leave':
-        this.clearPeerPresence(this.getSocketState(ws).peerId);
-        this.broadcastPeers();
+      case 'leave': {
+        // Explicit leave: tag the departing peer as `left` on the same snapshot
+        // where it drops out of presence, so the client can distinguish an
+        // intentional hangup from a silent drop (socket close/error → dropped).
+        const { peerId } = this.getSocketState(ws);
+        this.clearPeerPresence(peerId);
+        this.broadcastPeers(peerId ? [peerId] : undefined);
         return;
+      }
       case 'presence': {
         // Update self-asserted presence data; ignore until joined (no identity
         // to attach it to). Re-broadcast so a data-only change (e.g. mute
@@ -134,10 +139,11 @@ export class SignalingRoom extends DurableObject<Env> {
     });
   }
 
-  private broadcastPeers(): void {
+  private broadcastPeers(departed?: PeerId[]): void {
     const payload: ServerMessage = {
       t: 'peers',
       peers: this.presenceMembers(),
+      ...(departed && departed.length ? { departed } : {}),
     };
     // All sockets, including watchers — see the connect-time snapshot note.
     for (const ws of this.ctx.getWebSockets()) {

--- a/backend/cloudflare/test/signaling-room.test.ts
+++ b/backend/cloudflare/test/signaling-room.test.ts
@@ -24,6 +24,7 @@ async function connect(roomId: string) {
 
   return {
     send: (m: unknown) => ws.send(JSON.stringify(m)),
+    close: () => ws.close(),
     next: () =>
       new Promise<ServerMessage>((resolve) => {
         const m = queue.shift();
@@ -118,6 +119,59 @@ describe('SignalingRoom', () => {
         peers: [{ peerId: 'peer-a', data: { muted: true } }],
       });
     }
+  });
+
+  it('tags an explicit leave as departed on the snapshot where the peer drops out', async () => {
+    const a = await connect('room-departed');
+    expect(await a.next()).toEqual({ t: 'peers', peers: [] });
+    a.send({ t: 'join', peerId: 'peer-a' });
+    expect(await a.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+    });
+
+    const b = await connect('room-departed');
+    expect(await b.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+    });
+    b.send({ t: 'join', peerId: 'peer-b' });
+    await nextMembers(a, ['peer-a', 'peer-b']);
+    await nextMembers(b, ['peer-a', 'peer-b']);
+
+    // Explicit leave → peer gone from `peers` AND listed in `departed`, atomically.
+    b.send({ t: 'leave' });
+    expect(await a.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+      departed: ['peer-b'],
+    });
+  });
+
+  it('does not tag a silent socket drop as departed', async () => {
+    const a = await connect('room-dropped');
+    expect(await a.next()).toEqual({ t: 'peers', peers: [] });
+    a.send({ t: 'join', peerId: 'peer-a' });
+    expect(await a.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+    });
+
+    const b = await connect('room-dropped');
+    expect(await b.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+    });
+    b.send({ t: 'join', peerId: 'peer-b' });
+    await nextMembers(a, ['peer-a', 'peer-b']);
+
+    // Socket close (no `leave`) → member gone, but NO `departed` (strict equality
+    // fails if the field is present), so the client treats it as a drop.
+    b.close();
+    expect(await a.next()).toEqual({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+    });
   });
 
   it('rejects presence before join', async () => {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@kidlib/create-component": "^0.1.5",
-    "@kidlib/p2p": "^0.3.0",
+    "@kidlib/p2p": "^0.4.0",
     "@mediabunny/ac3": "^1.49.0",
     "@sentry/browser": "^10.62.0",
     "firebase": "^12.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,8 +230,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       '@kidlib/p2p':
-        specifier: ^0.3.0
-        version: 0.3.0(solid-js@1.9.13)
+        specifier: ^0.4.0
+        version: 0.4.0(solid-js@1.9.13)
       '@mediabunny/ac3':
         specifier: ^1.49.0
         version: 1.49.0(mediabunny@1.49.0)
@@ -1827,8 +1827,8 @@ packages:
   '@kidlib/create-component@0.1.5':
     resolution: {integrity: sha512-viom5Q6hIMz13plwb6665OT+2N3OBLs+8T7dNT5G9+0UQFcCtOI0iFE0tq0PNf5nnkNsrhS/NkhkyFvclTbMKA==}
 
-  '@kidlib/p2p@0.3.0':
-    resolution: {integrity: sha512-TNlmeDknNSOfXIgpgwq5J5Dfl22sMy7kAI8pm3gQGUeFRgXsKsZ049mplb90vpRKm8cG484ffRD9fVZEQ8J4oA==}
+  '@kidlib/p2p@0.4.0':
+    resolution: {integrity: sha512-XKxYQCeYzo3SQTyH6XMPoKq6N8ms8xnvNxn+RP5H2sALZwQ6wMRtXyagUxMtI8Fnlg7NbLipq9u7V/nVdHwdeg==}
     peerDependencies:
       solid-js: '>=1.8.0'
     peerDependenciesMeta:
@@ -6640,7 +6640,7 @@ snapshots:
   '@google-cloud/promisify@4.0.0':
     optional: true
 
-  '@google-cloud/storage@7.21.0':
+  '@google-cloud/storage@7.21.0(supports-color@10.2.2)':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
@@ -6649,7 +6649,7 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 5.5.7
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       google-auth-library: 9.15.1
       html-entities: 2.6.0
       mime: 3.0.0
@@ -6965,7 +6965,7 @@ snapshots:
 
   '@kidlib/create-component@0.1.5': {}
 
-  '@kidlib/p2p@0.3.0(solid-js@1.9.13)':
+  '@kidlib/p2p@0.4.0(solid-js@1.9.13)':
     optionalDependencies:
       solid-js: 1.9.13
 
@@ -8447,7 +8447,7 @@ snapshots:
       jwks-rsa: 4.1.0(supports-color@10.2.2)
     optionalDependencies:
       '@google-cloud/firestore': 8.6.0(supports-color@10.2.2)
-      '@google-cloud/storage': 7.21.0
+      '@google-cloud/storage': 7.21.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8570,10 +8570,10 @@ snapshots:
 
   fuzzy-search@3.2.1: {}
 
-  gaxios@6.7.1:
+  gaxios@6.7.1(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-stream: 2.0.1
       node-fetch: 2.7.0
       uuid: 9.0.1
@@ -8585,7 +8585,7 @@ snapshots:
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -8595,14 +8595,14 @@ snapshots:
   gaxios@7.1.5:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@6.1.1:
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -8728,7 +8728,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       gcp-metadata: 6.1.1
       gtoken: 7.1.0
       jws: 4.0.1
@@ -8765,7 +8765,7 @@ snapshots:
 
   gtoken@7.1.0:
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(supports-color@10.2.2)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -8851,7 +8851,7 @@ snapshots:
       - supports-color
     optional: true
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -10045,7 +10045,7 @@ snapshots:
   teeny-request@10.1.3(supports-color@10.2.2):
     dependencies:
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
       stream-events: 1.0.5
     transitivePeerDependencies:

--- a/shared/signaling/protocol.ts
+++ b/shared/signaling/protocol.ts
@@ -35,9 +35,16 @@ export type ClientMessage =
   | { t: 'presence'; data: PresenceData }
   | { t: 'relay'; to: PeerId; channel: RelayChannel; data: unknown };
 
-/** Durable Object → client. */
+/**
+ * Durable Object → client.
+ *
+ * `departed` lists peers that left explicitly (`{t:'leave'}`) in the same
+ * snapshot where they disappear from `peers`. It is populated ONLY on the
+ * explicit-leave path — a socket close/error/eviction never sets it, so the
+ * client treats any absent member without a `departed` entry as a silent drop.
+ */
 export type ServerMessage =
-  | { t: 'peers'; peers: PresenceMember[] }
+  | { t: 'peers'; peers: PresenceMember[]; departed?: PeerId[] }
   | { t: 'relay'; from: PeerId; channel: RelayChannel; data: unknown }
   | { t: 'error'; message: string };
 

--- a/src/features/call/audio-only-call.browser.test.jsx
+++ b/src/features/call/audio-only-call.browser.test.jsx
@@ -25,10 +25,11 @@ function createHub() {
     }
   };
 
-  const snapshot = () =>
-    [...clients.entries()]
+  const snapshot = () => ({
+    members: [...clients.entries()]
       .filter(([, c]) => c.present)
-      .map(([peerId, c]) => ({ memberId: peerId, data: c.data }));
+      .map(([peerId, c]) => ({ memberId: peerId, data: c.data })),
+  });
 
   const broadcastPeers = () => {
     const peers = snapshot();
@@ -167,7 +168,7 @@ describe('audio-only call over reserved slots', () => {
         onError: ({ error }) =>
           log.push(`[${peerId}] error: ${error?.message ?? error}`),
       });
-      cleanups.push(() => room.close());
+      cleanups.push(() => room.dispose());
       return { room, remoteStreams };
     };
 

--- a/src/features/call/audio-only-call.browser.test.jsx
+++ b/src/features/call/audio-only-call.browser.test.jsx
@@ -31,8 +31,10 @@ function createHub() {
       .map(([peerId, c]) => ({ memberId: peerId, data: c.data })),
   });
 
-  const broadcastPeers = () => {
-    const peers = snapshot();
+  const broadcastPeers = (departedId) => {
+    const peers = departedId
+      ? { ...snapshot(), departed: [{ memberId: departedId, reason: 'left' }] }
+      : snapshot();
     peersListeners.forEach((cb) => cb(peers));
   };
 
@@ -51,7 +53,7 @@ function createHub() {
         leave() {
           const c = selfId && clients.get(selfId);
           if (c) c.present = false;
-          broadcastPeers();
+          broadcastPeers(selfId ?? undefined);
         },
         onPeers(cb) {
           peersListeners.add(cb);

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -248,7 +248,7 @@ describe('CallHandshakeController', () => {
     await expect(joinOptions.getLocalStream()).resolves.toBe(stream);
   });
 
-  it('holds a reconnect grace window when the remote peer drops without a bye, then tears down', async () => {
+  it('holds a reconnect grace window when the remote peer drops silently, then tears down', async () => {
     vi.useFakeTimers();
     try {
       let joinOptions;
@@ -274,8 +274,12 @@ describe('CallHandshakeController', () => {
       controller.acceptIncoming();
       await flushPromises();
 
-      // Silent drop (no bye): grace window, not an immediate teardown.
-      joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
+      // Silent drop (`dropped`): grace window, not an immediate teardown.
+      joinOptions?.onAlone?.({
+        members: ['callee-id'],
+        memberCount: 1,
+        reason: 'dropped',
+      });
       expect(onReconnectStatus).toHaveBeenLastCalledWith('reconnecting');
       expect(p2p.dispose).not.toHaveBeenCalled();
 
@@ -291,7 +295,7 @@ describe('CallHandshakeController', () => {
     }
   });
 
-  it('exits immediately when the remote peer sends a bye before leaving', async () => {
+  it('exits immediately on an explicit `left` departure, skipping the grace window', async () => {
     let joinOptions;
     const acceptResponse = deferred();
     mocks.respondToIncomingCallInvite.mockReturnValue(acceptResponse.promise);
@@ -315,9 +319,12 @@ describe('CallHandshakeController', () => {
     controller.acceptIncoming();
     await flushPromises();
 
-    // Intentional leave: bye arrives, then the room goes alone → immediate close.
-    joinOptions?.onDataChannelMessage?.({ data: JSON.stringify({ t: 'bye' }) });
-    joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
+    // Intentional hangup: the room reports `alone` with reason `left` → close now.
+    joinOptions?.onAlone?.({
+      members: ['callee-id'],
+      memberCount: 1,
+      reason: 'left',
+    });
 
     expect(onReconnectStatus).not.toHaveBeenCalledWith('reconnecting');
     expect(p2p.dispose).toHaveBeenCalledTimes(1);
@@ -348,7 +355,11 @@ describe('CallHandshakeController', () => {
       controller.acceptIncoming();
       await flushPromises();
 
-      joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
+      joinOptions?.onAlone?.({
+        members: ['callee-id'],
+        memberCount: 1,
+        reason: 'dropped',
+      });
       expect(onReconnectStatus).toHaveBeenLastCalledWith('reconnecting');
 
       joinOptions?.onMemberJoined?.({ memberId: 'caller-id' });
@@ -360,18 +371,6 @@ describe('CallHandshakeController', () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it('broadcasts a bye when the local user hangs up', async () => {
-    const p2p = createP2PMock({
-      join: vi.fn(async () => ({ roomId: 'room-1', members: ['callee-id'] })),
-    });
-    const controller = createController(p2p);
-
-    controller.hangUp('user');
-
-    expect(p2p.broadcast).toHaveBeenCalledWith(JSON.stringify({ t: 'bye' }));
-    expect(p2p.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('does not notify accepted when joining the room fails', async () => {

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -79,7 +79,7 @@ async function flushPromises() {
 function createP2PMock(overrides = {}) {
   return {
     join: vi.fn(),
-    close: vi.fn(),
+    dispose: vi.fn(() => Promise.resolve()),
     broadcast: vi.fn(),
     state: vi.fn(() => 'idle'),
     members: vi.fn(() => []),
@@ -277,15 +277,15 @@ describe('CallHandshakeController', () => {
       // Silent drop (no bye): grace window, not an immediate teardown.
       joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
       expect(onReconnectStatus).toHaveBeenLastCalledWith('reconnecting');
-      expect(p2p.close).not.toHaveBeenCalled();
+      expect(p2p.dispose).not.toHaveBeenCalled();
 
       // Grace elapses → "failed" shown → final teardown after the display delay.
       vi.advanceTimersByTime(10_000);
       expect(onReconnectStatus).toHaveBeenLastCalledWith('failed');
-      expect(p2p.close).not.toHaveBeenCalled();
+      expect(p2p.dispose).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(2_500);
-      expect(p2p.close).toHaveBeenCalledTimes(1);
+      expect(p2p.dispose).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -320,7 +320,7 @@ describe('CallHandshakeController', () => {
     joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
 
     expect(onReconnectStatus).not.toHaveBeenCalledWith('reconnecting');
-    expect(p2p.close).toHaveBeenCalledTimes(1);
+    expect(p2p.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('cancels the reconnect grace when the peer rejoins', async () => {
@@ -356,7 +356,7 @@ describe('CallHandshakeController', () => {
 
       // Timers were cleared: no teardown even after the full window elapses.
       vi.advanceTimersByTime(20_000);
-      expect(p2p.close).not.toHaveBeenCalled();
+      expect(p2p.dispose).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -371,7 +371,7 @@ describe('CallHandshakeController', () => {
     controller.hangUp('user');
 
     expect(p2p.broadcast).toHaveBeenCalledWith(JSON.stringify({ t: 'bye' }));
-    expect(p2p.close).toHaveBeenCalledTimes(1);
+    expect(p2p.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('does not notify accepted when joining the room fails', async () => {
@@ -400,7 +400,7 @@ describe('CallHandshakeController', () => {
     await flushPromises();
 
     expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(p2p.close).toHaveBeenCalled());
+    await vi.waitFor(() => expect(p2p.dispose).toHaveBeenCalled());
     expect(p2p.error).toHaveBeenCalledTimes(1);
     stream
       .getTracks()

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -76,6 +76,31 @@ async function flushPromises() {
   await Promise.resolve();
 }
 
+function createP2PMock(overrides = {}) {
+  return {
+    join: vi.fn(),
+    close: vi.fn(),
+    broadcast: vi.fn(),
+    state: vi.fn(() => 'idle'),
+    members: vi.fn(() => []),
+    error: vi.fn(),
+    room: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createController(p2p, overrides = {}) {
+  return new CallHandshakeController({
+    p2p,
+    createSignaling: vi.fn(),
+    getCallerName: () => 'Callee',
+    onStateChange: vi.fn(),
+    onCalleeBusy: vi.fn(),
+    onReconnectStatus: vi.fn(),
+    ...overrides,
+  });
+}
+
 const { CallHandshakeController } =
   await import('./call-handshake-controller.js');
 
@@ -114,17 +139,7 @@ describe('CallHandshakeController', () => {
 
   it('dismisses a matching incoming call when another device handles it', () => {
     const onStateChange = vi.fn();
-    const controller = new CallHandshakeController({
-      p2p: {
-        close: vi.fn(),
-        state: vi.fn(() => 'idle'),
-        room: vi.fn(),
-      },
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Callee',
-      onStateChange,
-      onCalleeBusy: vi.fn(),
-    });
+    const controller = createController(createP2PMock(), { onStateChange });
 
     controller.init();
     mocks.incomingCallback?.({
@@ -148,19 +163,8 @@ describe('CallHandshakeController', () => {
 
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {
     const join = deferred();
-    const p2p = {
-      join: vi.fn(() => join.promise),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Callee',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
-    });
+    const p2p = createP2PMock({ join: vi.fn(() => join.promise) });
+    const controller = createController(p2p);
 
     controller.init();
     mocks.incomingCallback?.({
@@ -201,22 +205,13 @@ describe('CallHandshakeController', () => {
   it('reserves a video slot when joining an audio-only call', async () => {
     const stream = createMediaStream({ audio: true, video: false });
     mocks.getUserMedia.mockResolvedValue(stream);
-    const p2p = {
+    const p2p = createP2PMock({
       join: vi.fn(async () => ({
         roomId: 'room-1',
         members: ['callee-id'],
       })),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Callee',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
     });
+    const controller = createController(p2p);
 
     controller.init();
     mocks.incomingCallback?.({
@@ -253,26 +248,61 @@ describe('CallHandshakeController', () => {
     await expect(joinOptions.getLocalStream()).resolves.toBe(stream);
   });
 
-  it('closes a notification-opened call when the remote caller leaves while the accept response is pending', async () => {
-    let onAlone;
+  it('holds a reconnect grace window when the remote peer drops without a bye, then tears down', async () => {
+    vi.useFakeTimers();
+    try {
+      let joinOptions;
+      const acceptResponse = deferred();
+      mocks.respondToIncomingCallInvite.mockReturnValue(acceptResponse.promise);
+      const p2p = createP2PMock({
+        join: vi.fn(async (options) => {
+          joinOptions = options;
+          return { roomId: 'room-1', members: ['callee-id'] };
+        }),
+      });
+      const onReconnectStatus = vi.fn();
+      const controller = createController(p2p, { onReconnectStatus });
+
+      controller.showIncomingCallFromNotification({
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        startedAt: Date.now(),
+      });
+
+      controller.acceptIncoming();
+      await flushPromises();
+
+      // Silent drop (no bye): grace window, not an immediate teardown.
+      joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
+      expect(onReconnectStatus).toHaveBeenLastCalledWith('reconnecting');
+      expect(p2p.close).not.toHaveBeenCalled();
+
+      // Grace elapses → "failed" shown → final teardown after the display delay.
+      vi.advanceTimersByTime(10_000);
+      expect(onReconnectStatus).toHaveBeenLastCalledWith('failed');
+      expect(p2p.close).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(2_500);
+      expect(p2p.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('exits immediately when the remote peer sends a bye before leaving', async () => {
+    let joinOptions;
     const acceptResponse = deferred();
     mocks.respondToIncomingCallInvite.mockReturnValue(acceptResponse.promise);
-    const p2p = {
+    const p2p = createP2PMock({
       join: vi.fn(async (options) => {
-        onAlone = options.onAlone;
+        joinOptions = options;
         return { roomId: 'room-1', members: ['callee-id'] };
       }),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Callee',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
     });
+    const onReconnectStatus = vi.fn();
+    const controller = createController(p2p, { onReconnectStatus });
 
     controller.showIncomingCallFromNotification({
       roomId: 'room-1',
@@ -285,14 +315,62 @@ describe('CallHandshakeController', () => {
     controller.acceptIncoming();
     await flushPromises();
 
-    expect(mocks.respondToIncomingCallInvite).toHaveBeenCalledWith({
-      roomId: 'room-1',
-      callerId: 'caller-id',
-      responseType: 'accepted',
+    // Intentional leave: bye arrives, then the room goes alone → immediate close.
+    joinOptions?.onDataChannelMessage?.({ data: JSON.stringify({ t: 'bye' }) });
+    joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
+
+    expect(onReconnectStatus).not.toHaveBeenCalledWith('reconnecting');
+    expect(p2p.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the reconnect grace when the peer rejoins', async () => {
+    vi.useFakeTimers();
+    try {
+      let joinOptions;
+      const acceptResponse = deferred();
+      mocks.respondToIncomingCallInvite.mockReturnValue(acceptResponse.promise);
+      const p2p = createP2PMock({
+        join: vi.fn(async (options) => {
+          joinOptions = options;
+          return { roomId: 'room-1', members: ['callee-id'] };
+        }),
+      });
+      const onReconnectStatus = vi.fn();
+      const controller = createController(p2p, { onReconnectStatus });
+
+      controller.showIncomingCallFromNotification({
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        startedAt: Date.now(),
+      });
+      controller.acceptIncoming();
+      await flushPromises();
+
+      joinOptions?.onAlone?.({ members: ['callee-id'], memberCount: 1 });
+      expect(onReconnectStatus).toHaveBeenLastCalledWith('reconnecting');
+
+      joinOptions?.onMemberJoined?.({ memberId: 'caller-id' });
+      expect(onReconnectStatus).toHaveBeenLastCalledWith('connected');
+
+      // Timers were cleared: no teardown even after the full window elapses.
+      vi.advanceTimersByTime(20_000);
+      expect(p2p.close).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('broadcasts a bye when the local user hangs up', async () => {
+    const p2p = createP2PMock({
+      join: vi.fn(async () => ({ roomId: 'room-1', members: ['callee-id'] })),
     });
+    const controller = createController(p2p);
 
-    onAlone?.({ members: ['callee-id'], memberCount: 1 });
+    controller.hangUp('user');
 
+    expect(p2p.broadcast).toHaveBeenCalledWith(JSON.stringify({ t: 'bye' }));
     expect(p2p.close).toHaveBeenCalledTimes(1);
   });
 
@@ -300,20 +378,11 @@ describe('CallHandshakeController', () => {
     const joinError = new Error('camera blocked');
     const stream = createMediaStream({ audio: true, video: true });
     mocks.getUserMedia.mockResolvedValue(stream);
-    const p2p = {
+    const p2p = createP2PMock({
       join: vi.fn(() => Promise.resolve(undefined)),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
       error: vi.fn(() => joinError),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Callee',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
     });
+    const controller = createController(p2p);
 
     controller.init();
     mocks.incomingCallback?.({
@@ -342,19 +411,8 @@ describe('CallHandshakeController', () => {
     const send = deferred();
     const join = deferred();
     mocks.sendOutgoingCallInvite.mockReturnValue(send.promise);
-    const p2p = {
-      join: vi.fn(() => join.promise),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Callee',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
-    });
+    const p2p = createP2PMock({ join: vi.fn(() => join.promise) });
+    const controller = createController(p2p);
 
     const start = controller.startCall({
       calleeId: 'callee-id',
@@ -387,17 +445,8 @@ describe('CallHandshakeController', () => {
 
   it('publishes declined when the callee rejects', async () => {
     mocks.getLoggedInUserId.mockReturnValue('caller-id');
-    const controller = new CallHandshakeController({
-      p2p: {
-        join: vi.fn(),
-        close: vi.fn(),
-        state: vi.fn(() => 'idle'),
-        room: vi.fn(),
-      },
-      createSignaling: vi.fn(),
+    const controller = createController(createP2PMock({ join: vi.fn() }), {
       getCallerName: () => 'Caller',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
     });
 
     await controller.startCall({
@@ -420,17 +469,8 @@ describe('CallHandshakeController', () => {
 
   it('publishes unanswered when the caller cancels while ringing', async () => {
     mocks.getLoggedInUserId.mockReturnValue('caller-id');
-    const controller = new CallHandshakeController({
-      p2p: {
-        join: vi.fn(),
-        close: vi.fn(),
-        state: vi.fn(() => 'idle'),
-        room: vi.fn(),
-      },
-      createSignaling: vi.fn(),
+    const controller = createController(createP2PMock({ join: vi.fn() }), {
       getCallerName: () => 'Caller',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
     });
 
     await controller.startCall({
@@ -448,19 +488,8 @@ describe('CallHandshakeController', () => {
 
   it('does not send the invite when caller media permission fails', async () => {
     mocks.getUserMedia.mockRejectedValue(new Error('camera blocked'));
-    const p2p = {
-      join: vi.fn(),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Caller',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
-    });
+    const p2p = createP2PMock({ join: vi.fn() });
+    const controller = createController(p2p, { getCallerName: () => 'Caller' });
 
     await controller.startCall({
       calleeId: 'callee-id',
@@ -477,19 +506,8 @@ describe('CallHandshakeController', () => {
     const media = deferred();
     const stop = vi.fn();
     mocks.getUserMedia.mockReturnValue(media.promise);
-    const p2p = {
-      join: vi.fn(),
-      close: vi.fn(),
-      state: vi.fn(() => 'idle'),
-      room: vi.fn(),
-    };
-    const controller = new CallHandshakeController({
-      p2p,
-      createSignaling: vi.fn(),
-      getCallerName: () => 'Caller',
-      onStateChange: vi.fn(),
-      onCalleeBusy: vi.fn(),
-    });
+    const p2p = createP2PMock({ join: vi.fn() });
+    const controller = createController(p2p, { getCallerName: () => 'Caller' });
 
     const start = controller.startCall({
       calleeId: 'callee-id',

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -15,6 +15,7 @@ import {
 import { createCallLocalTrackSlots } from './call-media.js';
 import type {
   CallHandshakeState,
+  CallReconnectStatus,
   OutgoingCall,
   StartCallDetails,
 } from './call-types.js';
@@ -39,7 +40,29 @@ type CallHandshakeControllerOptions = {
   getCallerName: () => string;
   onStateChange: (state: CallHandshakeState) => void;
   onCalleeBusy: (busy: boolean) => void;
+  onReconnectStatus: (status: CallReconnectStatus) => void;
 };
+
+/**
+ * Grace window after the remote peer drops *without* a `bye` — a silent drop
+ * (backgrounded app, network flap) gets this long to re-join before teardown.
+ */
+const RECONNECT_GRACE_MS = 10_000;
+/** How long "Could not reconnect" is shown before the call finally exits. */
+const RECONNECT_FAILED_DISPLAY_MS = 2_500;
+
+/** Data-channel control message sent to signal an intentional hangup. */
+const BYE_MESSAGE = JSON.stringify({ t: 'bye' });
+
+/** True when `data` is our `{ t: 'bye' }` control message. */
+function isByeMessage(data: unknown): boolean {
+  if (typeof data !== 'string') return false;
+  try {
+    return (JSON.parse(data) as { t?: unknown }).t === 'bye';
+  } catch {
+    return false;
+  }
+}
 
 export type IncomingCallNotificationDetails = {
   roomId: string;
@@ -55,7 +78,12 @@ type EnterRoomOptions = {
 };
 
 /** Why a call was torn down — logged so field reports are unambiguous. */
-type HangUpReason = 'user' | 'peer-left' | 'enter-room-error' | 'accept-error';
+type HangUpReason =
+  | 'user'
+  | 'peer-left'
+  | 'reconnect-timeout'
+  | 'enter-room-error'
+  | 'accept-error';
 
 export class CallHandshakeController {
   private readonly p2p: SolidP2PRoom;
@@ -63,10 +91,16 @@ export class CallHandshakeController {
   private readonly getCallerName: () => string;
   private readonly onStateChange: (state: CallHandshakeState) => void;
   private readonly onCalleeBusy: (busy: boolean) => void;
+  private readonly onReconnectStatus: (status: CallReconnectStatus) => void;
 
   private _handshakeState: CallHandshakeState = null;
   private outgoingCallTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  private reconnectTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  private reconnectFailedTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  // Set when the remote sent a `bye`: their departure was intentional, so
+  // going `alone` should exit immediately instead of waiting out the grace.
+  private peerSaidBye = false;
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
   private pendingOutgoingLocalStream: MediaStream | undefined;
@@ -79,12 +113,14 @@ export class CallHandshakeController {
     getCallerName,
     onStateChange,
     onCalleeBusy,
+    onReconnectStatus,
   }: CallHandshakeControllerOptions) {
     this.p2p = p2p;
     this.createSignaling = createSignaling;
     this.getCallerName = getCallerName;
     this.onStateChange = onStateChange;
     this.onCalleeBusy = onCalleeBusy;
+    this.onReconnectStatus = onReconnectStatus;
   }
 
   private setHandshakeState(state: CallHandshakeState): void {
@@ -375,6 +411,7 @@ export class CallHandshakeController {
     const localStream = await (
       getLocalStream ?? (() => this.getCallLocalStream(audioOnly))
     )();
+    this.resetReconnectState();
     let room;
     try {
       room = await this.p2p.join({
@@ -395,9 +432,20 @@ export class CallHandshakeController {
         },
         memberCapacity,
         dataChannel: true,
+        onMemberJoined: () => {
+          // A (re)join cancels any in-progress reconnect grace; the peer's back.
+          if (autoExitOnEmpty) this.cancelReconnectGrace();
+        },
+        onDataChannelMessage: ({ data }) => {
+          if (isByeMessage(data)) this.peerSaidBye = true;
+        },
         onAlone: (detail) => {
           if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
-          if (autoExitOnEmpty) this.hangUp('peer-left');
+          if (!autoExitOnEmpty) return;
+          // Intentional leave (peer sent `bye`) → exit now. Silent drop → give
+          // the peer a grace window to re-join before tearing the call down.
+          if (this.peerSaidBye) this.hangUp('peer-left');
+          else this.startReconnectGrace();
         },
       });
       if (!room)
@@ -525,6 +573,16 @@ export class CallHandshakeController {
   };
 
   hangUp = (reason: HangUpReason = 'user'): void => {
+    // Tell the peer this leave is intentional so their side exits immediately
+    // instead of showing "Reconnecting…" (best-effort; skipped if the channel
+    // is already gone). Only the local user pressing hang up is intentional.
+    if (reason === 'user') {
+      try {
+        this.p2p.broadcast(BYE_MESSAGE);
+      } catch (err) {
+        console.warn('[call] failed to broadcast bye:', err);
+      }
+    }
     // ponytail: normal console.log (not gated behind DEV) so field reports of
     // "call ended unexpectedly" can be diagnosed from a phone's remote console.
     console.log('[call] hangUp', {
@@ -533,8 +591,51 @@ export class CallHandshakeController {
       members: this.p2p.members(),
       state: this.p2p.state(),
     });
+    this.resetReconnectState();
     this.p2p.close();
   };
+
+  /** Remote dropped without a `bye`: hold the room open for the grace window. */
+  private startReconnectGrace(): void {
+    this.clearReconnectTimers();
+    this.onReconnectStatus('reconnecting');
+    this.reconnectTimeoutId = setTimeout(() => {
+      this.reconnectTimeoutId = undefined;
+      this.onReconnectStatus('failed');
+      this.reconnectFailedTimeoutId = setTimeout(() => {
+        this.reconnectFailedTimeoutId = undefined;
+        this.hangUp('reconnect-timeout');
+      }, RECONNECT_FAILED_DISPLAY_MS);
+    }, RECONNECT_GRACE_MS);
+  }
+
+  /** Peer came back inside the grace window: return to the connected state. */
+  private cancelReconnectGrace(): void {
+    if (
+      this.reconnectTimeoutId == null &&
+      this.reconnectFailedTimeoutId == null
+    )
+      return;
+    this.clearReconnectTimers();
+    this.onReconnectStatus('connected');
+  }
+
+  private clearReconnectTimers(): void {
+    if (this.reconnectTimeoutId != null) {
+      clearTimeout(this.reconnectTimeoutId);
+      this.reconnectTimeoutId = undefined;
+    }
+    if (this.reconnectFailedTimeoutId != null) {
+      clearTimeout(this.reconnectFailedTimeoutId);
+      this.reconnectFailedTimeoutId = undefined;
+    }
+  }
+
+  private resetReconnectState(): void {
+    this.clearReconnectTimers();
+    this.peerSaidBye = false;
+    this.onReconnectStatus('connected');
+  }
 
   private clearOutgoingCallTimeout(): void {
     if (!this.outgoingCallTimeoutId) return;
@@ -560,6 +661,7 @@ export class CallHandshakeController {
     this.unsubscribeIncomingCall = undefined;
     this.clearOutgoingCallTracking();
     this.clearCalleeBusyResetTimeout();
+    this.resetReconnectState();
     this.stopPendingOutgoingLocalStream();
     this.setHandshakeState(null);
     this.onCalleeBusy(false);

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -54,6 +54,9 @@ type EnterRoomOptions = {
   autoExitOnEmpty?: boolean;
 };
 
+/** Why a call was torn down — logged so field reports are unambiguous. */
+type HangUpReason = 'user' | 'peer-left' | 'enter-room-error' | 'accept-error';
+
 export class CallHandshakeController {
   private readonly p2p: SolidP2PRoom;
   private readonly createSignaling: CreateRoomSignaling;
@@ -298,7 +301,7 @@ export class CallHandshakeController {
       } catch (err) {
         console.error('Error entering room on callee accept:', err);
         this.stopMediaStream(localStream);
-        this.hangUp();
+        this.hangUp('enter-room-error');
       } finally {
         svc
           .ackCallResponse(response.roomId)
@@ -394,7 +397,7 @@ export class CallHandshakeController {
         dataChannel: true,
         onAlone: (detail) => {
           if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
-          if (autoExitOnEmpty) this.hangUp();
+          if (autoExitOnEmpty) this.hangUp('peer-left');
         },
       });
       if (!room)
@@ -502,7 +505,7 @@ export class CallHandshakeController {
       )
       .catch((err) => {
         console.error('Error accepting incoming call:', err);
-        this.hangUp();
+        this.hangUp('accept-error');
       });
   };
 
@@ -521,7 +524,15 @@ export class CallHandshakeController {
       .catch((err) => console.error('Error declining incoming call:', err));
   };
 
-  hangUp = (): void => {
+  hangUp = (reason: HangUpReason = 'user'): void => {
+    // ponytail: normal console.log (not gated behind DEV) so field reports of
+    // "call ended unexpectedly" can be diagnosed from a phone's remote console.
+    console.log('[call] hangUp', {
+      reason,
+      roomId: this._handshakeState?.call.roomId,
+      members: this.p2p.members(),
+      state: this.p2p.state(),
+    });
     this.p2p.close();
   };
 

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -564,8 +564,11 @@ export class CallHandshakeController {
     // "call ended unexpectedly" can be diagnosed from a phone's remote console.
     console.log('[call] hangUp', {
       reason,
-      roomId: this._handshakeState?.call.roomId,
-      members: this.p2p.members(),
+      // Live room accessor — _handshakeState is cleared at join, so it would
+      // log undefined here. members().length (not the UIDs) keeps the field
+      // signal without leaking peer identifiers into a production console.
+      roomId: this.p2p.room()?.roomId,
+      memberCount: this.p2p.members().length,
       state: this.p2p.state(),
     });
     this.resetReconnectState();

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -151,7 +151,7 @@ export class CallHandshakeController {
    */
   init(): void {
     // Runs on every auth change incl. login, so it must not tear down an active
-    // call (p2p.close here black-screens a call that's mid-join). Only a switch
+    // call (p2p.dispose here black-screens a call that's mid-join). Only a switch
     // to a *different* user does full teardown; full cleanup() is otherwise
     // reserved for logout/unmount.
     const localUID = getLoggedInUserId();
@@ -592,7 +592,12 @@ export class CallHandshakeController {
       state: this.p2p.state(),
     });
     this.resetReconnectState();
-    this.p2p.close();
+    // dispose() is async in @kidlib/p2p ≥0.4; hangUp stays sync (called from
+    // click + timer callbacks). Surface teardown failures — a silently failed
+    // dispose is the "call won't end / black screen" bug class we log for.
+    void this.p2p.dispose().catch((err) => {
+      console.warn('[call] p2p dispose failed on hangUp:', err);
+    });
   };
 
   /** Remote dropped without a `bye`: hold the room open for the grace window. */
@@ -665,7 +670,9 @@ export class CallHandshakeController {
     this.stopPendingOutgoingLocalStream();
     this.setHandshakeState(null);
     this.onCalleeBusy(false);
-    this.p2p.close();
+    void this.p2p.dispose().catch((err) => {
+      console.warn('[call] p2p dispose failed on cleanup:', err);
+    });
     cleanupCallService();
     this.lastBoundUID = undefined;
   }

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -44,25 +44,13 @@ type CallHandshakeControllerOptions = {
 };
 
 /**
- * Grace window after the remote peer drops *without* a `bye` — a silent drop
- * (backgrounded app, network flap) gets this long to re-join before teardown.
+ * Grace window after the remote peer drops silently (backgrounded app, network
+ * flap) — reported by @kidlib/p2p as a `dropped` departure. The peer gets this
+ * long to re-join before teardown. An explicit `left` departure skips it.
  */
 const RECONNECT_GRACE_MS = 10_000;
 /** How long "Could not reconnect" is shown before the call finally exits. */
 const RECONNECT_FAILED_DISPLAY_MS = 2_500;
-
-/** Data-channel control message sent to signal an intentional hangup. */
-const BYE_MESSAGE = JSON.stringify({ t: 'bye' });
-
-/** True when `data` is our `{ t: 'bye' }` control message. */
-function isByeMessage(data: unknown): boolean {
-  if (typeof data !== 'string') return false;
-  try {
-    return (JSON.parse(data) as { t?: unknown }).t === 'bye';
-  } catch {
-    return false;
-  }
-}
 
 export type IncomingCallNotificationDetails = {
   roomId: string;
@@ -98,9 +86,6 @@ export class CallHandshakeController {
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private reconnectTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private reconnectFailedTimeoutId: ReturnType<typeof setTimeout> | undefined;
-  // Set when the remote sent a `bye`: their departure was intentional, so
-  // going `alone` should exit immediately instead of waiting out the grace.
-  private peerSaidBye = false;
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
   private pendingOutgoingLocalStream: MediaStream | undefined;
@@ -436,15 +421,13 @@ export class CallHandshakeController {
           // A (re)join cancels any in-progress reconnect grace; the peer's back.
           if (autoExitOnEmpty) this.cancelReconnectGrace();
         },
-        onDataChannelMessage: ({ data }) => {
-          if (isByeMessage(data)) this.peerSaidBye = true;
-        },
         onAlone: (detail) => {
           if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
           if (!autoExitOnEmpty) return;
-          // Intentional leave (peer sent `bye`) → exit now. Silent drop → give
-          // the peer a grace window to re-join before tearing the call down.
-          if (this.peerSaidBye) this.hangUp('peer-left');
+          // `left` = every departure that emptied the room was an explicit
+          // signaling leave (intentional hangup) → exit now. `dropped` = a
+          // silent drop → give the peer a grace window to re-join first.
+          if (detail.reason === 'left') this.hangUp('peer-left');
           else this.startReconnectGrace();
         },
       });
@@ -573,16 +556,10 @@ export class CallHandshakeController {
   };
 
   hangUp = (reason: HangUpReason = 'user'): void => {
-    // Tell the peer this leave is intentional so their side exits immediately
-    // instead of showing "Reconnecting…" (best-effort; skipped if the channel
-    // is already gone). Only the local user pressing hang up is intentional.
-    if (reason === 'user') {
-      try {
-        this.p2p.broadcast(BYE_MESSAGE);
-      } catch (err) {
-        console.warn('[call] failed to broadcast bye:', err);
-      }
-    }
+    // The peer's side learns this leave is intentional from the signaling
+    // `leave` the room sends during dispose() — the DO tags it as a `left`
+    // departure, so their `onAlone` exits immediately instead of showing
+    // "Reconnecting…". No app-level control message is needed.
     // ponytail: normal console.log (not gated behind DEV) so field reports of
     // "call ended unexpectedly" can be diagnosed from a phone's remote console.
     console.log('[call] hangUp', {
@@ -600,7 +577,7 @@ export class CallHandshakeController {
     });
   };
 
-  /** Remote dropped without a `bye`: hold the room open for the grace window. */
+  /** Remote dropped silently (`dropped`): hold the room open for the grace window. */
   private startReconnectGrace(): void {
     this.clearReconnectTimers();
     this.onReconnectStatus('reconnecting');
@@ -638,7 +615,6 @@ export class CallHandshakeController {
 
   private resetReconnectState(): void {
     this.clearReconnectTimers();
-    this.peerSaidBye = false;
     this.onReconnectStatus('connected');
   }
 

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -20,6 +20,7 @@ import {
 } from './call-handshake-controller.js';
 import type {
   CallHandshakeState,
+  CallReconnectStatus,
   OutgoingCall,
   StartCallDetails,
 } from './call-types.js';
@@ -29,6 +30,7 @@ type CallHandshakeContextValue = {
   hangUp: () => void;
 
   isCalleeBusy: Accessor<boolean>;
+  reconnectStatus: Accessor<CallReconnectStatus>;
   incomingCall: Accessor<MailboxInvite | null>;
   outgoingCall: Accessor<OutgoingCall | null>;
   cancelOutgoing: () => void;
@@ -96,6 +98,8 @@ export function CallHandshakeProvider(props: ParentProps) {
   const [handshakeState, setHandshakeState] =
     createSignal<CallHandshakeState>(null);
   const [isCalleeBusy, setIsCalleeBusy] = createSignal(false);
+  const [reconnectStatus, setReconnectStatus] =
+    createSignal<CallReconnectStatus>('connected');
 
   const controller = new CallHandshakeController({
     p2p,
@@ -113,6 +117,7 @@ export function CallHandshakeProvider(props: ParentProps) {
     },
     onStateChange: setHandshakeState,
     onCalleeBusy: setIsCalleeBusy,
+    onReconnectStatus: setReconnectStatus,
   });
 
   const incomingCall = (): MailboxInvite | null => {
@@ -127,8 +132,10 @@ export function CallHandshakeProvider(props: ParentProps) {
 
   const value: CallHandshakeContextValue = {
     startCall: controller.startCall,
-    hangUp: controller.hangUp,
+    // Wrap so a click handler's MouseEvent can't leak in as the hangUp reason.
+    hangUp: () => controller.hangUp('user'),
     isCalleeBusy,
+    reconnectStatus,
     incomingCall,
     outgoingCall,
     cancelOutgoing: controller.cancelOutgoing,

--- a/src/features/call/call-types.ts
+++ b/src/features/call/call-types.ts
@@ -16,6 +16,14 @@ export type StartCallDetails = {
   audioOnly: boolean;
 };
 
+/**
+ * In-call connection status.
+ * - `connected`: normal, remote peer present (or call not yet joined).
+ * - `reconnecting`: remote dropped without a `bye`; inside the grace window.
+ * - `failed`: grace window elapsed; shown briefly before teardown.
+ */
+export type CallReconnectStatus = 'connected' | 'reconnecting' | 'failed';
+
 export type CallHandshakeState =
   | null
   | {

--- a/src/features/call/call-types.ts
+++ b/src/features/call/call-types.ts
@@ -19,7 +19,7 @@ export type StartCallDetails = {
 /**
  * In-call connection status.
  * - `connected`: normal, remote peer present (or call not yet joined).
- * - `reconnecting`: remote dropped without a `bye`; inside the grace window.
+ * - `reconnecting`: remote dropped silently (`dropped`); inside the grace window.
  * - `failed`: grace window elapsed; shown briefly before teardown.
  */
 export type CallReconnectStatus = 'connected' | 'reconnecting' | 'failed';

--- a/src/features/call/components/ActiveCallRoom.module.css
+++ b/src/features/call/components/ActiveCallRoom.module.css
@@ -33,6 +33,19 @@
   text-align: center;
 }
 
+.reconnecting {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 3;
+  padding: var(--pad);
+  border-radius: var(--radius);
+  background: rgb(0 0 0 / 70%);
+  text-align: center;
+  font-weight: 700;
+}
+
 .waiting button {
   padding: var(--spacing-sm) var(--spacing-xl);
   border: 1px solid var(--color-border);

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -37,7 +37,7 @@ export function ActiveCallRoom() {
       <MemberStreams remoteAudioMuted={remoteAudioMuted()} media={media} />
 
       <Show when={reconnectStatus() !== 'connected'}>
-        <div class={styles.reconnecting}>
+        <div class={styles.reconnecting} role='status' aria-live='polite'>
           <p>
             {reconnectStatus() === 'failed'
               ? t('call.reconnect_failed')
@@ -48,7 +48,9 @@ export function ActiveCallRoom() {
 
       <Show
         when={
-          p2p.state() === 'joined' && p2p.remoteMemberStreams().length === 0
+          p2p.state() === 'joined' &&
+          p2p.remoteMemberStreams().length === 0 &&
+          reconnectStatus() === 'connected'
         }
       >
         <div class={styles.waiting}>

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -3,12 +3,15 @@ import { Show, createSignal } from 'solid-js';
 import { MemberStreams } from './MemberStreams';
 import { ActiveCallControls } from './CallControls';
 import { createCallMedia } from '../call-media';
+import { useCallHandshake } from '../call-handshake.js';
 import { useP2PContext } from '@shared/p2p-context.js';
+import { t } from '@shared/i18n';
 
 import styles from './ActiveCallRoom.module.css';
 
 export function ActiveCallRoom() {
   const p2p = useP2PContext();
+  const { reconnectStatus } = useCallHandshake();
   // createCallMedia owns local imperative track state (camera tracks, screen-share track)
   const media = createCallMedia(p2p);
 
@@ -32,6 +35,16 @@ export function ActiveCallRoom() {
   return (
     <div class={styles.room}>
       <MemberStreams remoteAudioMuted={remoteAudioMuted()} media={media} />
+
+      <Show when={reconnectStatus() !== 'connected'}>
+        <div class={styles.reconnecting}>
+          <p>
+            {reconnectStatus() === 'failed'
+              ? t('call.reconnect_failed')
+              : t('call.reconnecting')}
+          </p>
+        </div>
+      </Show>
 
       <Show
         when={

--- a/src/realtime/signaling/do-room-signaling.test.js
+++ b/src/realtime/signaling/do-room-signaling.test.js
@@ -63,13 +63,32 @@ describe('createDoRoomSignaling', () => {
         { peerId: 'peer-b' },
       ],
     });
-    // Envelope shape; no `departed` until the DO tags explicit leaves (step 2).
+    // No `departed` on the wire → bare `{ members }` envelope.
     expect(seen).toEqual([
       {
         members: [
           { memberId: 'peer-a', data: { muted: true } },
           { memberId: 'peer-b', data: undefined },
         ],
+      },
+    ]);
+  });
+
+  it('maps wire `departed` onto snapshot departures tagged `left`', () => {
+    const signaling = createDoRoomSignaling({ roomId: 'room-1' });
+    const seen = [];
+    signaling.onPeers((snapshot) => seen.push(snapshot));
+
+    // An explicit leave: peer-b is gone from members and listed in departed.
+    socket.emit({
+      t: 'peers',
+      peers: [{ peerId: 'peer-a' }],
+      departed: ['peer-b'],
+    });
+    expect(seen).toEqual([
+      {
+        members: [{ memberId: 'peer-a', data: undefined }],
+        departed: [{ memberId: 'peer-b', reason: 'left' }],
       },
     ]);
   });

--- a/src/realtime/signaling/do-room-signaling.test.js
+++ b/src/realtime/signaling/do-room-signaling.test.js
@@ -54,7 +54,7 @@ describe('createDoRoomSignaling', () => {
   it('maps presence members onto onPeers subscribers', () => {
     const signaling = createDoRoomSignaling({ roomId: 'room-1' });
     const seen = [];
-    signaling.onPeers((members) => seen.push(members));
+    signaling.onPeers((snapshot) => seen.push(snapshot));
 
     socket.emit({
       t: 'peers',
@@ -63,11 +63,14 @@ describe('createDoRoomSignaling', () => {
         { peerId: 'peer-b' },
       ],
     });
+    // Envelope shape; no `departed` until the DO tags explicit leaves (step 2).
     expect(seen).toEqual([
-      [
-        { memberId: 'peer-a', data: { muted: true } },
-        { memberId: 'peer-b', data: undefined },
-      ],
+      {
+        members: [
+          { memberId: 'peer-a', data: { muted: true } },
+          { memberId: 'peer-b', data: undefined },
+        ],
+      },
     ]);
   });
 

--- a/src/realtime/signaling/do-room-signaling.ts
+++ b/src/realtime/signaling/do-room-signaling.ts
@@ -73,11 +73,17 @@ export function createDoRoomSignaling({
           memberId: p.peerId,
           data: p.data,
         }));
-        // Envelope carries no `departed` yet: the DO doesn't tag explicit
-        // leaves, so every departure defaults to `dropped`. Intentional
-        // hangups are still distinguished by the data-channel `bye`. Populating
-        // `departed` (and dropping `bye`) is the step-2 DO change.
-        const snapshot: P2PRoomPresenceSnapshot = { members };
+        // The DO tags explicit `{t:'leave'}` departures on the same snapshot
+        // where the peer drops out of `members`; anything absent without a
+        // `departed` entry defaults to `dropped` in 0.4.0. This is what lets the
+        // call controller tell an intentional hangup from a silent drop.
+        const departed = message.departed?.map((memberId) => ({
+          memberId,
+          reason: 'left' as const,
+        }));
+        const snapshot: P2PRoomPresenceSnapshot = departed
+          ? { members, departed }
+          : { members };
         peersHandlers.forEach((h) => h(snapshot));
         return;
       }

--- a/src/realtime/signaling/do-room-signaling.ts
+++ b/src/realtime/signaling/do-room-signaling.ts
@@ -3,6 +3,7 @@ import type {
   P2PRoomPeerSignalingOptions,
   P2PRoomPresenceData,
   P2PRoomPresenceMember,
+  P2PRoomPresenceSnapshot,
   P2PRoomSignaling,
   RtcSignalingSource,
 } from '@kidlib/p2p';
@@ -54,7 +55,7 @@ export function createDoRoomSignaling({
 
   let joinedPeerId: string | null = null;
   let localData: P2PRoomPresenceData | undefined;
-  const peersHandlers = new Set<(members: P2PRoomPresenceMember[]) => void>();
+  const peersHandlers = new Set<(snapshot: P2PRoomPresenceSnapshot) => void>();
   const relaySubs = new Set<RelaySubscription>();
 
   // Build the join message, omitting `data` when absent so the no-presence
@@ -72,7 +73,12 @@ export function createDoRoomSignaling({
           memberId: p.peerId,
           data: p.data,
         }));
-        peersHandlers.forEach((h) => h(members));
+        // Envelope carries no `departed` yet: the DO doesn't tag explicit
+        // leaves, so every departure defaults to `dropped`. Intentional
+        // hangups are still distinguished by the data-channel `bye`. Populating
+        // `departed` (and dropping `bye`) is the step-2 DO change.
+        const snapshot: P2PRoomPresenceSnapshot = { members };
+        peersHandlers.forEach((h) => h(snapshot));
         return;
       }
       case 'relay':
@@ -112,8 +118,8 @@ export function createDoRoomSignaling({
       // instead of a stale snapshot. Timeout fallback keeps a flaky server
       // from hanging the join forever (degrades to pre-ack behavior).
       const ack = new Promise<void>((resolve) => {
-        const handler = (members: P2PRoomPresenceMember[]) => {
-          if (!members.some((m) => m.memberId === peerId)) return;
+        const handler = (snapshot: P2PRoomPresenceSnapshot) => {
+          if (!snapshot.members.some((m) => m.memberId === peerId)) return;
           peersHandlers.delete(handler);
           clearTimeout(timeoutId);
           resolve();

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -24,6 +24,8 @@
   "call.continue_prompt": "Continue call",
   "call.video.connecting": "Connecting video…",
   "call.video.interrupted": "Video connection interrupted. Reconnecting…",
+  "call.reconnecting": "Reconnecting…",
+  "call.reconnect_failed": "Could not reconnect",
   "call.unknown_caller": "Unknown Caller",
   "call.lobby.ephemeral_prompt": "Or make an ephemeral call:",
   "call.lobby.start": "Start a call",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -24,6 +24,8 @@
   "call.continue_prompt": "Halda áfram símtali",
   "call.video.connecting": "Tengist myndbandi…",
   "call.video.interrupted": "Myndbandstenging rofnaði. Reyni að tengjast aftur…",
+  "call.reconnecting": "Reyni að endurtengja…",
+  "call.reconnect_failed": "Ekki tókst að endurtengja",
   "call.unknown_caller": "Óþekktur notandi",
   "call.lobby.ephemeral_prompt": "Eða hringdu skyndisímtal:",
   "call.lobby.start": "Hefja símtal",


### PR DESCRIPTION
## Why

Two call-stability issues reported from a production 1:1 call: the remote stream froze a few times, and the call ended unexpectedly several times (like a phantom hangup). Root cause of the phantom hangups: a silent peer drop (backgrounded app, screen lock, network flap) was indistinguishable from an intentional hangup — p2p's `alone` fired and the call tore down instantly on any brief peer disappearance.

## What's here

Four commits, oldest first:

1. **`log hangUp reason unconditionally`** — plain `console.log` (not DEV-gated) at every teardown with reason + room/members/state, so field reports are greppable from a phone's remote console.
2. **`bye signal + reconnect grace window`** — introduced the reconnect grace UX and an interim data-channel `bye` workaround to distinguish intentional hangups. (The `bye` mechanism is removed again in commit 4 — see below.)
3. **`migrate to @kidlib/p2p 0.4.0`** — app-side changes for 0.4.0's `{ members, departed? }` snapshot envelope and `close()` → `dispose()`.
4. **`native left-vs-dropped detection, drop the bye workaround`** — the real fix. The `SignalingRoom` Durable Object now tags an explicit `{t:'leave'}` with `departed: [{memberId, reason:'left'}]` atomically with the snapshot where the member disappears; socket drops / TTL expiry never populate it. The client adapter maps that into the port's `snapshot.departed`, and the call controller branches on the native `AloneDetail.reason` (`'left'` → immediate exit; `'dropped'` → grace window). The interim `bye` machinery is deleted.

Net behavior: an intentional hangup exits immediately (unchanged UX); a silent drop holds the room open for a 10s "Reconnecting…" grace (a peer rejoin cancels it), then shows "Could not reconnect" briefly before teardown. Group-safe — the aggregate `reason` is `'left'` only when every member removed in that transition left explicitly. New i18n keys `call.reconnecting` / `call.reconnect_failed` (en + is).

## Why the DO approach over the data-channel `bye`

`bye` rode the RTCDataChannel, which is torn down by exactly the events we care about (backgrounding, network flap, crash) — so it was least reliable precisely when correctness mattered. The signaling `leave` travels over the WebSocket to the DO, which is authoritative about socket lifecycle, and removes ~40 lines of in-band control-message plumbing. Its one cost is deploy coupling (DO + client must ship together) — see caveat below. Hard crashes / force-quits send neither signal and correctly fall through to `dropped` → grace, which is why the grace window stays regardless.

## Deploy caveat (must confirm before shipping)

0.4.0 intentionally reports `dropped` when `departed` is absent. If the client bundle deploys before the DO (`wrangler deploy`) lands, intentional hangups would report `dropped` and sit through the full 10s grace — a soft, self-healing regression (never a wrong teardown). **Deploy the DO before or atomically with the client.** Per the repo's "no rollout-compat shims" convention we did a clean cutover; if the pipeline can't guarantee that ordering, keeping `bye` one release longer would have avoided the transient window.

## Still open (not in this PR)
- **Frozen stream** (issue A): needs ICE-restart + ephemeral TURN, which live in `@kidlib/p2p` (requested upstream; not in 0.4.0 yet).

## Testing
- Root `vp check` clean (fmt + lint + types, 296 files); Cloudflare worker `tsc --noEmit` clean.
- 60 root call + realtime tests pass, including the real-WebRTC `audio-only-call.browser.test.jsx` (two peers connect over the 0.4.0 envelope, audio delivered, `dispose()` cleanup). 6 DO `signaling-room` tests pass, covering leave-tags-`departed` and drop-does-not-tag.
- Not browser-verified in-app: the reconnect banner needs a live 2-party call a single preview tab can't produce; the state machine is covered by unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added call reconnect lifecycle states (connected, reconnecting, failed) and surfaced them in the active call UI.
  - Implemented explicit “leave” handling so clients can react immediately, while silent drops trigger a grace-based reconnect flow.
- **Bug Fixes**
  - Improved peer presence updates by including optional departure markers only for explicit departures; socket closes/drops no longer generate “departed” events.
- **Documentation**
  - Added localized reconnecting and reconnect-failed messages (English and Icelandic).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->