### PR TITLE
Fail calls that never connect (#648)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@kidlib/create-component": "^0.1.5",
-    "@kidlib/p2p": "^0.5.0",
+    "@kidlib/p2p": "^0.5.1",
     "@mediabunny/ac3": "^1.49.0",
     "@sentry/browser": "^10.62.0",
     "firebase": "^12.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5
       '@kidlib/p2p':
-        specifier: ^0.5.0
-        version: 0.5.0(solid-js@1.9.13)
+        specifier: ^0.5.1
+        version: 0.5.1(solid-js@1.9.13)
       '@mediabunny/ac3':
         specifier: ^1.49.0
         version: 1.49.0(mediabunny@1.49.0)
@@ -1830,8 +1830,8 @@ packages:
   '@kidlib/create-component@0.1.5':
     resolution: {integrity: sha512-viom5Q6hIMz13plwb6665OT+2N3OBLs+8T7dNT5G9+0UQFcCtOI0iFE0tq0PNf5nnkNsrhS/NkhkyFvclTbMKA==}
 
-  '@kidlib/p2p@0.5.0':
-    resolution: {integrity: sha512-mpakkCLJrfRADfeSMqDyGwBmgHQ8fQzzgCINjvL7rIrPCAs1RMNCtQvIXw2t+ceB7xS8q8Eh07V8ebqPlk0H9A==}
+  '@kidlib/p2p@0.5.1':
+    resolution: {integrity: sha512-9HbDbeb8ifsOIgKOdE9nRBiw7BBl1yXBcj/MQ1sKWMQWsOo92S9CfAtOoJr8tB19gXUbo/kSvboNxTN7fwe+LA==}
     peerDependencies:
       solid-js: '>=1.8.0'
     peerDependenciesMeta:
@@ -7287,7 +7287,7 @@ snapshots:
 
   '@kidlib/create-component@0.1.5': {}
 
-  '@kidlib/p2p@0.5.0(solid-js@1.9.13)':
+  '@kidlib/p2p@0.5.1(solid-js@1.9.13)':
     optionalDependencies:
       solid-js: 1.9.13
 

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -438,7 +438,7 @@ describe('CallHandshakeController', () => {
     }
   });
 
-  it('fails the call when the initial peer connection times out, ignoring other room errors', async () => {
+  it('fails the call on initial peer/session errors, ignoring other room errors', async () => {
     vi.useFakeTimers();
     try {
       let joinOptions;
@@ -468,11 +468,21 @@ describe('CallHandshakeController', () => {
       expect(onReconnectStatus).not.toHaveBeenCalledWith('connect-failed');
 
       joinOptions?.onError?.({
-        error: new Error('Peer.start: connection timed out after 20000ms'),
+        error: new Error('Peer.start: connection failed'),
+      });
+      expect(onReconnectStatus).toHaveBeenLastCalledWith('connect-failed');
+
+      joinOptions?.onError?.({
+        error: new Error(
+          'P2PSession: data channel open timed out after 10000ms',
+        ),
       });
       expect(onReconnectStatus).toHaveBeenLastCalledWith('connect-failed');
       expect(p2p.dispose).not.toHaveBeenCalled();
 
+      // A member event can cancel reconnect grace, but not the bounded exit
+      // scheduled for an initial connection failure.
+      joinOptions?.onMemberJoined?.({ memberId: 'caller-id' });
       vi.advanceTimersByTime(4_000);
       expect(p2p.dispose).toHaveBeenCalledTimes(1);
     } finally {

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -438,6 +438,48 @@ describe('CallHandshakeController', () => {
     }
   });
 
+  it('fails the call when the initial peer connection times out, ignoring other room errors', async () => {
+    vi.useFakeTimers();
+    try {
+      let joinOptions;
+      mocks.respondToIncomingCallInvite.mockReturnValue(deferred().promise);
+      const p2p = createP2PMock({
+        join: vi.fn(async (options) => {
+          joinOptions = options;
+          return { roomId: 'room-1', members: ['callee-id'] };
+        }),
+      });
+      const onReconnectStatus = vi.fn();
+      const controller = createController(p2p, { onReconnectStatus });
+
+      controller.showIncomingCallFromNotification({
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        audioOnly: false,
+        startedAt: Date.now(),
+      });
+      controller.acceptIncoming();
+      await flushPromises();
+
+      expect(joinOptions?.connectedTimeoutMs).toBe(20_000);
+
+      joinOptions?.onError?.({ error: new Error('presence refresh failed') });
+      expect(onReconnectStatus).not.toHaveBeenCalledWith('connect-failed');
+
+      joinOptions?.onError?.({
+        error: new Error('Peer.start: connection timed out after 20000ms'),
+      });
+      expect(onReconnectStatus).toHaveBeenLastCalledWith('connect-failed');
+      expect(p2p.dispose).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(4_000);
+      expect(p2p.dispose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('exits immediately on an explicit `left` departure, skipping the grace window', async () => {
     let joinOptions;
     const acceptResponse = deferred();

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -123,6 +123,7 @@ export class CallHandshakeController {
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private reconnectTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private reconnectFailedTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  private connectFailedTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
   private pendingOutgoingLocalStream: MediaStream | undefined;
@@ -626,17 +627,18 @@ export class CallHandshakeController {
    * is a dead call, not a blip — @kidlib/p2p has already closed that member.
    * Show a bounded failure message, then exit to the lobby so the user can retry.
    *
-   * ponytail: matched on the message — @kidlib/p2p 0.5.1 throws a plain Error
-   * with no code/name. Ask upstream for a structured error to key off instead.
+   * ponytail: matched on the message prefix — @kidlib/p2p 0.5.1 throws plain
+   * Errors with no code/name. Ask upstream for a structured error to key off.
    */
   private handleRoomError(error: unknown): void {
     const message = error instanceof Error ? error.message : String(error);
     console.log('[call] room error', { message });
-    if (!message.includes('connection timed out')) return;
+    if (!/^(?:Peer\.start|P2PSession):/.test(message)) return;
     this.clearReconnectTimers();
+    this.clearConnectFailureTimeout();
     this.onReconnectStatus('connect-failed');
-    this.reconnectFailedTimeoutId = setTimeout(() => {
-      this.reconnectFailedTimeoutId = undefined;
+    this.connectFailedTimeoutId = setTimeout(() => {
+      this.connectFailedTimeoutId = undefined;
       this.hangUp('connect-timeout');
     }, CONNECT_FAILED_DISPLAY_MS);
   }
@@ -677,8 +679,15 @@ export class CallHandshakeController {
     }
   }
 
+  private clearConnectFailureTimeout(): void {
+    if (this.connectFailedTimeoutId == null) return;
+    clearTimeout(this.connectFailedTimeoutId);
+    this.connectFailedTimeoutId = undefined;
+  }
+
   private resetReconnectState(): void {
     this.clearReconnectTimers();
+    this.clearConnectFailureTimeout();
     this.onReconnectStatus('connected');
   }
 

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -79,6 +79,14 @@ type CallHandshakeControllerOptions = {
 const RECONNECT_GRACE_MS = 10_000;
 /** How long "Could not reconnect" is shown before the call finally exits. */
 const RECONNECT_FAILED_DISPLAY_MS = 2_500;
+/**
+ * How long a peer session may sit un-`connected` before @kidlib/p2p fails it.
+ * Covers STUN + TURN-relay setup with room to spare; without it a blocked
+ * connection sits on "Waiting for the other person to connect…" forever.
+ */
+const CONNECTED_TIMEOUT_MS = 20_000;
+/** How long "Could not connect" is shown before the call exits to the lobby. */
+const CONNECT_FAILED_DISPLAY_MS = 4_000;
 
 export type IncomingCallNotificationDetails = {
   roomId: string;
@@ -98,6 +106,7 @@ type HangUpReason =
   | 'user'
   | 'peer-left'
   | 'reconnect-timeout'
+  | 'connect-timeout'
   | 'enter-room-error'
   | 'accept-error';
 
@@ -447,6 +456,8 @@ export class CallHandshakeController {
         dataChannel: true,
         iceServersProvider: provideIceServers,
         iceRecovery: {},
+        connectedTimeoutMs: CONNECTED_TIMEOUT_MS,
+        onError: ({ error }) => this.handleRoomError(error),
         onMemberJoined: () => {
           // A (re)join cancels any in-progress reconnect grace; the peer's back.
           if (autoExitOnEmpty) this.cancelReconnectGrace();
@@ -609,6 +620,26 @@ export class CallHandshakeController {
       console.warn('[call] p2p dispose failed on hangUp:', err);
     });
   };
+
+  /**
+   * A peer session that never reached `connected` within `connectedTimeoutMs`
+   * is a dead call, not a blip — @kidlib/p2p has already closed that member.
+   * Show a bounded failure message, then exit to the lobby so the user can retry.
+   *
+   * ponytail: matched on the message — @kidlib/p2p 0.5.1 throws a plain Error
+   * with no code/name. Ask upstream for a structured error to key off instead.
+   */
+  private handleRoomError(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log('[call] room error', { message });
+    if (!message.includes('connection timed out')) return;
+    this.clearReconnectTimers();
+    this.onReconnectStatus('connect-failed');
+    this.reconnectFailedTimeoutId = setTimeout(() => {
+      this.reconnectFailedTimeoutId = undefined;
+      this.hangUp('connect-timeout');
+    }, CONNECT_FAILED_DISPLAY_MS);
+  }
 
   /** Remote dropped silently (`dropped`): hold the room open for the grace window. */
   private startReconnectGrace(): void {

--- a/src/features/call/call-types.ts
+++ b/src/features/call/call-types.ts
@@ -22,7 +22,12 @@ export type StartCallDetails = {
  * - `reconnecting`: remote dropped silently (`dropped`); inside the grace window.
  * - `failed`: grace window elapsed; shown briefly before teardown.
  */
-export type CallReconnectStatus = 'connected' | 'reconnecting' | 'failed';
+export type CallReconnectStatus =
+  | 'connected'
+  | 'reconnecting'
+  | 'failed'
+  /** Initial WebRTC connection never came up (see `connectedTimeoutMs`). */
+  | 'connect-failed';
 
 export type CallHandshakeState =
   | null

--- a/src/features/call/components/ActiveCallRoom.tsx
+++ b/src/features/call/components/ActiveCallRoom.tsx
@@ -39,9 +39,11 @@ export function ActiveCallRoom() {
       <Show when={reconnectStatus() !== 'connected'}>
         <div class={styles.reconnecting} role='status' aria-live='polite'>
           <p>
-            {reconnectStatus() === 'failed'
-              ? t('call.reconnect_failed')
-              : t('call.reconnecting')}
+            {reconnectStatus() === 'connect-failed'
+              ? t('call.connect_failed')
+              : reconnectStatus() === 'failed'
+                ? t('call.reconnect_failed')
+                : t('call.reconnecting')}
           </p>
         </div>
       </Show>

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -26,6 +26,7 @@
   "call.video.interrupted": "Video connection interrupted. Reconnecting…",
   "call.reconnecting": "Reconnecting…",
   "call.reconnect_failed": "Could not reconnect",
+  "call.connect_failed": "Could not connect. Try again, or switch network.",
   "call.unknown_caller": "Unknown Caller",
   "call.lobby.ephemeral_prompt": "Or make an ephemeral call:",
   "call.lobby.start": "Start a call",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -26,6 +26,7 @@
   "call.video.interrupted": "Myndbandstenging rofnaði. Reyni að tengjast aftur…",
   "call.reconnecting": "Reyni að endurtengja…",
   "call.reconnect_failed": "Ekki tókst að endurtengja",
+  "call.connect_failed": "Ekki tókst að tengja. Prófaðu aftur eða skiptu um net.",
   "call.unknown_caller": "Óþekktur notandi",
   "call.lobby.ephemeral_prompt": "Eða hringdu skyndisímtal:",
   "call.lobby.start": "Hefja símtal",


### PR DESCRIPTION
Closes #648.

`@kidlib/p2p` 0.5.0 → 0.5.1, which adds `P2PRoom.connectedTimeoutMs`. Passing it means a peer session that never reaches `connected` is failed by the package — no app-owned connection timer.

## What happens now

- `connectedTimeoutMs: 20_000` on `p2p.join`.
- Initial `Peer.start:` and `P2PSession:` failures from the package set reconnect status to `connect-failed`.
- `ActiveCallRoom` shows "Could not connect. Try again, or switch network." for 4s, then the call exits to the lobby.
- The connect-failure exit owns a dedicated timer, so a subsequent `memberJoined` event cannot cancel it while cancelling reconnect grace.
- Unrelated room errors remain logged without being treated as initial connection failures.

## Decisions to review later

- **Errors are matched on message prefixes.** `@kidlib/p2p` 0.5.1 throws plain `Error` objects with no stable `code`/`name`. Upstream issue KristinnRoach/p2p#35 proposes documented machine-readable error codes.
- **20s** covers STUN + TURN-relay setup with headroom (`startTimeoutMs` defaults to 8s and only covers SDP). Tune if field reports show it is too tight or too slow.
- **4s failure-message window** before exiting, versus 2.5s for reconnect failure, because the connect-failure copy is longer and actionable.

## Validation

- `vp check`
- `vp test` — 67 files passed, 378 tests passed, 1 skipped
- Controller regression coverage includes `Peer.start:` and `P2PSession:` failures, ignores unrelated room errors, and verifies `memberJoined` cannot cancel the bounded failure exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a call cannot establish its initial connection.
  * Calls now show a clear connection-failed message, allow time for recovery, and close automatically if the connection does not succeed.
  * Reconnection failures are now distinguished from initial connection failures.

* **Localization**
  * Added English and Icelandic translations for the new connection failure message.

* **Tests**
  * Added coverage for connection timeout and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->