### PR TITLE
Defer PWA reloads during calls

### DIFF
--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -175,7 +175,8 @@ describe('CallHandshakeController', () => {
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {
     const join = deferred();
     const p2p = createP2PMock({ join: vi.fn(() => join.promise) });
-    const controller = createController(p2p);
+    const onStateChange = vi.fn();
+    const controller = createController(p2p, { onStateChange });
 
     controller.init();
     mocks.incomingCallback?.({
@@ -204,6 +205,10 @@ describe('CallHandshakeController', () => {
       }),
     );
     expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      direction: 'accepting',
+      call: expect.objectContaining({ roomId: 'room-1' }),
+    });
 
     join.resolve({ roomId: 'room-1', members: ['callee-id'] });
     await flushPromises();
@@ -212,6 +217,9 @@ describe('CallHandshakeController', () => {
       roomId: 'room-1',
       callerId: 'caller-id',
       responseType: 'accepted',
+    });
+    await vi.waitFor(() => {
+      expect(onStateChange).toHaveBeenLastCalledWith(null);
     });
   });
 

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -567,7 +567,7 @@ export class CallHandshakeController {
     const localUID = getLoggedInUserId();
     if (!svc || !localUID) return;
     this.clearOutgoingCallTracking();
-    this.setHandshakeState(null);
+    this.setHandshakeState({ direction: 'accepting', call: state.call });
     this.enterRoom(state.call.roomId, localUID, state.call.audioOnly ?? false)
       .then(() =>
         svc.respondToIncomingCallInvite({
@@ -579,7 +579,8 @@ export class CallHandshakeController {
       .catch((err) => {
         console.error('Error accepting incoming call:', err);
         this.hangUp('accept-error');
-      });
+      })
+      .finally(() => this.setHandshakeState(null));
   };
 
   declineIncoming = (): void => {

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -1,4 +1,11 @@
-import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vite-plus/test';
 import { createSignal } from 'solid-js';
 import { render, cleanup } from '@solidjs/testing-library';
 
@@ -7,13 +14,17 @@ const mocks = vi.hoisted(() => ({
   cleanup: vi.fn(),
   showIncomingCallFromNotification: vi.fn(),
   acceptIncoming: vi.fn(),
+  publish: vi.fn(),
   subscribe: vi.fn(),
   subscriptions: new Map(),
   user: () => null,
+  p2pState: () => 'idle',
+  controllerOptions: undefined,
 }));
 
 vi.mock('./call-handshake-controller.js', () => ({
-  CallHandshakeController: vi.fn(function () {
+  CallHandshakeController: vi.fn(function (options) {
+    mocks.controllerOptions = options;
     return {
       init: mocks.init,
       cleanup: mocks.cleanup,
@@ -25,7 +36,9 @@ vi.mock('./call-handshake-controller.js', () => ({
     };
   }),
 }));
-vi.mock('../../shared/p2p-context.js', () => ({ useP2PContext: () => ({}) }));
+vi.mock('../../shared/p2p-context.js', () => ({
+  useP2PContext: () => ({ state: (...args) => mocks.p2pState(...args) }),
+}));
 vi.mock('@realtime', () => ({ createRoomSignaling: vi.fn() }));
 vi.mock('@auth', () => ({
   getAuthProviderProfileSeed: vi.fn(() => null),
@@ -34,6 +47,7 @@ vi.mock('@auth', () => ({
   useAuth: () => ({ user: (...args) => mocks.user(...args) }),
 }));
 vi.mock('@shared/events/index.js', () => ({
+  publish: (...args) => mocks.publish(...args),
   subscribe: mocks.subscribe,
 }));
 
@@ -46,8 +60,52 @@ describe('CallHandshakeProvider', () => {
       mocks.subscriptions.set(name, handler);
       return vi.fn();
     });
+    mocks.publish.mockImplementation((name, payload) => {
+      mocks.subscriptions.get(name)?.(payload);
+    });
     mocks.user = () => null;
+    mocks.p2pState = () => 'idle';
+    mocks.controllerOptions = undefined;
     window.history.replaceState(null, '', '/');
+  });
+
+  afterEach(() => cleanup());
+
+  it('holds app reloads from an incoming invite through call teardown', async () => {
+    const { whenAppReloadAllowed } =
+      await import('../../shared/app-reload/index.js');
+    const { CallHandshakeProvider } = await import('./call-handshake');
+    const allowed = vi.fn();
+
+    render(() => <CallHandshakeProvider>{null}</CallHandshakeProvider>);
+    mocks.controllerOptions?.onStateChange({
+      direction: 'incoming',
+      call: { roomId: 'room-1' },
+    });
+
+    void whenAppReloadAllowed().then(allowed);
+    await Promise.resolve();
+    expect(allowed).not.toHaveBeenCalled();
+
+    mocks.controllerOptions?.onStateChange(null);
+    await vi.waitFor(() => expect(allowed).toHaveBeenCalledOnce());
+  });
+
+  it('holds app reloads while a P2P call is active', async () => {
+    const [p2pState, setP2pState] = createSignal('connected');
+    mocks.p2pState = p2pState;
+    const { whenAppReloadAllowed } =
+      await import('../../shared/app-reload/index.js');
+    const { CallHandshakeProvider } = await import('./call-handshake');
+    const allowed = vi.fn();
+
+    render(() => <CallHandshakeProvider>{null}</CallHandshakeProvider>);
+    void whenAppReloadAllowed().then(allowed);
+    await Promise.resolve();
+    expect(allowed).not.toHaveBeenCalled();
+
+    setP2pState('idle');
+    await vi.waitFor(() => expect(allowed).toHaveBeenCalledOnce());
   });
 
   it('attaches the incoming-call listener when auth becomes authenticated after mount', async () => {

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -12,6 +12,7 @@ import { getAuthProviderProfileSeed, useAuth } from '@auth';
 import { useP2PContext } from '@shared/p2p-context.js';
 import { createRoomSignaling } from '@realtime';
 import { subscribe } from '@shared/events/index.js';
+import { holdAppReload } from '@shared/app-reload/index.js';
 import { getLoggedInUserProfile } from '../../stores/user-profile-store.js';
 import type { MailboxInvite } from '../../../shared/user-mailbox/protocol';
 import {
@@ -100,6 +101,21 @@ export function CallHandshakeProvider(props: ParentProps) {
   const [isCalleeBusy, setIsCalleeBusy] = createSignal(false);
   const [reconnectStatus, setReconnectStatus] =
     createSignal<CallReconnectStatus>('connected');
+  let releaseReloadHold: (() => void) | undefined;
+
+  createEffect(() => {
+    const isReloadBlockedByCall =
+      handshakeState() !== null || p2p.state() !== 'idle';
+
+    if (isReloadBlockedByCall && !releaseReloadHold) {
+      releaseReloadHold = holdAppReload();
+    } else if (!isReloadBlockedByCall && releaseReloadHold) {
+      releaseReloadHold();
+      releaseReloadHold = undefined;
+    }
+  });
+
+  onCleanup(() => releaseReloadHold?.());
 
   const controller = new CallHandshakeController({
     p2p,

--- a/src/features/call/call-types.ts
+++ b/src/features/call/call-types.ts
@@ -36,6 +36,10 @@ export type CallHandshakeState =
       call: MailboxInvite;
     }
   | {
+      direction: 'accepting';
+      call: MailboxInvite;
+    }
+  | {
       direction: 'outgoing';
       call: OutgoingCall;
     };

--- a/src/push/sw/__tests__/notification-click-handler.test.js
+++ b/src/push/sw/__tests__/notification-click-handler.test.js
@@ -164,6 +164,9 @@ describe('window client selection', () => {
       type: 'NAVIGATE',
       path: '/?contact=user-1',
     });
+    expect(visibleClient.postMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      visibleClient.focus.mock.invocationCallOrder[0],
+    );
     expect(hiddenClient.focus).not.toHaveBeenCalled();
   });
 });

--- a/src/push/sw/notification-click-handler.js
+++ b/src/push/sw/notification-click-handler.js
@@ -105,14 +105,13 @@ export async function openApp(path = '/') {
 
   if (clients.length > 0) {
     const client = selectWindowClient(clients);
-    await client.focus();
-
     if (path !== '/') {
       client.postMessage({
         type: 'NAVIGATE',
         path,
       });
     }
+    await client.focus();
 
     return client;
   }

--- a/src/pwa/reload-page.test.js
+++ b/src/pwa/reload-page.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { reloadPageWhenAllowed } from './reload-page.js';
+
+describe('PWA page reload', () => {
+  it('does not reload until the app reload gate opens', async () => {
+    let allowReload;
+    const whenAllowed = new Promise((resolve) => {
+      allowReload = resolve;
+    });
+    const reload = vi.fn();
+
+    const options = {
+      whenAllowed: () => whenAllowed,
+      reload,
+    };
+    const firstPendingReload = reloadPageWhenAllowed(options);
+    const secondPendingReload = reloadPageWhenAllowed(options);
+    await Promise.resolve();
+    expect(reload).not.toHaveBeenCalled();
+
+    allowReload();
+    await Promise.all([firstPendingReload, secondPendingReload]);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pwa/reload-page.ts
+++ b/src/pwa/reload-page.ts
@@ -1,0 +1,24 @@
+import { whenAppReloadAllowed } from '@shared/app-reload/index.js';
+
+type ReloadPageOptions = {
+  whenAllowed?: () => Promise<void>;
+  reload?: () => void;
+};
+
+let pendingReload: Promise<void> | null = null;
+
+/** Reloads an activated PWA update as soon as the app is safe to interrupt. */
+export function reloadPageWhenAllowed({
+  whenAllowed = whenAppReloadAllowed,
+  reload = () => window.location.reload(),
+}: ReloadPageOptions = {}): Promise<void> {
+  if (pendingReload) return pendingReload;
+
+  pendingReload = Promise.resolve()
+    .then(whenAllowed)
+    .then(reload)
+    .finally(() => {
+      pendingReload = null;
+    });
+  return pendingReload;
+}

--- a/src/pwa/update-handlers.js
+++ b/src/pwa/update-handlers.js
@@ -1,9 +1,10 @@
+import { reloadPageWhenAllowed } from './reload-page.js';
+
 // TODO: Consider reverting to 30min once migration has settled.
 const UPDATE_CHECK_INTERVAL = 20 * 60 * 1000;
 
 let updateCheckIntervalId = null;
 let visibilityAbortController = null;
-let controllerChangeAbortController = null;
 
 /**
  * Dynamically imports the PWA register module.
@@ -60,23 +61,6 @@ async function attemptAutoUpdate(updateSW) {
   } catch (err) {
     console.error('[PWA] Auto-update failed:', err);
   }
-}
-
-/**
- * Reloads as soon as an updated service worker takes control.
- */
-function reloadOnControllerChange() {
-  if (!('serviceWorker' in navigator)) return;
-  controllerChangeAbortController = new AbortController();
-  navigator.serviceWorker.addEventListener(
-    'controllerchange',
-    () => {
-      // TODO: Once app updates are stable, defer while p2p.state() !== 'idle'
-      // and later let the user choose when to reload.
-      window.location.reload();
-    },
-    { once: true, signal: controllerChangeAbortController.signal },
-  );
 }
 
 /**
@@ -163,11 +147,6 @@ export function stopUpdateChecks() {
     visibilityAbortController = null;
   }
 
-  if (controllerChangeAbortController !== null) {
-    controllerChangeAbortController.abort();
-    controllerChangeAbortController = null;
-  }
-
   if (updateCheckIntervalId === null && visibilityAbortController === null) {
     console.info('[PWA] Stopped automatic update checks');
   }
@@ -194,6 +173,9 @@ export async function setupUpdateHandler() {
 
     const updateSW = registerSW({
       immediate: true,
+      onNeedReload() {
+        void reloadPageWhenAllowed();
+      },
       onNeedRefresh() {
         console.info('[PWA] New version available');
         void attemptAutoUpdate(updateSW);
@@ -204,7 +186,6 @@ export async function setupUpdateHandler() {
     });
 
     // Set up all update check mechanisms
-    reloadOnControllerChange();
     await startupUpdateCheck(updateSW);
     await checkForUpdates();
     visibilityChangeCheck();

--- a/src/shared/app-reload/app-reload-state.ts
+++ b/src/shared/app-reload/app-reload-state.ts
@@ -1,0 +1,47 @@
+import { publish, subscribe } from '@shared/events/index.js';
+
+type AppReloadState = {
+  blockerCount: number;
+};
+
+let state: AppReloadState = { blockerCount: 0 };
+
+function snapshot(): AppReloadState {
+  return { ...state };
+}
+
+function setState(next: AppReloadState): void {
+  const prev = snapshot();
+  state = next;
+  publish('evt:app-reload:state:changed', { state: snapshot(), prev });
+}
+
+export function getAppReloadAllowed(): boolean {
+  return state.blockerCount === 0;
+}
+
+export function holdAppReload(): () => void {
+  setState({ blockerCount: state.blockerCount + 1 });
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    setState({ blockerCount: state.blockerCount - 1 });
+  };
+}
+
+export function whenAppReloadAllowed(): Promise<void> {
+  if (getAppReloadAllowed()) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    const unsubscribe = subscribe(
+      'evt:app-reload:state:changed',
+      ({ state: nextState }: { state: AppReloadState }) => {
+        if (nextState.blockerCount !== 0) return;
+        unsubscribe();
+        resolve();
+      },
+    );
+  });
+}

--- a/src/shared/app-reload/index.test.js
+++ b/src/shared/app-reload/index.test.js
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { holdAppReload, whenAppReloadAllowed } from './index.js';
+
+describe('app reload gate', () => {
+  const releases = [];
+
+  afterEach(() => {
+    for (const release of releases.splice(0)) release();
+  });
+
+  it('waits until every active reload hold is released', async () => {
+    const releaseIncomingCall = holdAppReload();
+    const releaseActiveCall = holdAppReload();
+    releases.push(releaseIncomingCall, releaseActiveCall);
+    const allowed = vi.fn();
+
+    void whenAppReloadAllowed().then(allowed);
+    await Promise.resolve();
+    expect(allowed).not.toHaveBeenCalled();
+
+    releaseIncomingCall();
+    await Promise.resolve();
+    expect(allowed).not.toHaveBeenCalled();
+
+    releaseActiveCall();
+    await Promise.resolve();
+    expect(allowed).toHaveBeenCalledOnce();
+  });
+
+  it('allows reload immediately when there are no holds', async () => {
+    await expect(whenAppReloadAllowed()).resolves.toBeUndefined();
+  });
+});

--- a/src/shared/app-reload/index.ts
+++ b/src/shared/app-reload/index.ts
@@ -1,0 +1,5 @@
+export {
+  getAppReloadAllowed,
+  holdAppReload,
+  whenAppReloadAllowed,
+} from './app-reload-state.js';


### PR DESCRIPTION
## What changed

- defer activated PWA page reloads while an incoming, accepting, active, or reconnecting call makes interruption unsafe
- coalesce repeated update events into one pending reload
- preserve the accepting/connecting call state until room entry settles
- deliver notification navigation intent before focusing an existing app window
- remove the unconditional `controllerchange` reload, which also reloaded first-time installs

## Why

Foreground update checks could activate a new service worker and reload the app just as a user opened an incoming-call notification, interrupting the answer flow. Update detection and activation remain aggressive; only the disruptive page reload waits until call teardown.

## Validation

- `vp check`
- `vp test` — 69 files passed, 1 skipped; 383 tests passed, 1 skipped
- focused reload, call lifecycle, PWA, and notification-routing tests — 37 passed
- `vp test src/push/sw/__tests__/notification-click-handler.test.js` — 1 file passed; 11 tests passed
- standards and spec reviews completed with no remaining findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App updates and reloads now wait until active calls and other ongoing activity have finished.
  * Incoming calls display an accepting state while the connection is being established.
  * Improved navigation when opening the app from a notification.

* **Bug Fixes**
  * Prevented premature reloads during call teardown and active connections.
  * Ensured notification navigation messages are delivered reliably.
  * Coordinated simultaneous reload requests to avoid duplicate reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->