### PR TITLE
Reconcile conversation messages when the app resumes

### DIFF
--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -7,6 +7,7 @@
 export { createRoomSignaling } from './signaling/index.js';
 export { createConversationChannel } from './conversation-channel.js';
 export { closeUserMailbox, subscribeToUserMailbox } from './user-mailbox.js';
+export { subscribeToWakeSignals } from './wake-signals.js';
 export {
   isConversationServerEvent,
   type ConversationServerEvent,

--- a/src/stores/conversation/message-sync.test.js
+++ b/src/stores/conversation/message-sync.test.js
@@ -112,6 +112,81 @@ describe('message sync reactions', () => {
     expect(snapshots).toEqual([['m1', 'm2']]);
   });
 
+  it('reconciles messages missed while the app was hidden when it becomes visible', async () => {
+    let serverRows = [wireMessage()];
+    const client = {
+      getUserId: () => 'me',
+      loadMessages: vi.fn(async () => serverRows),
+      sendMessage: vi.fn(),
+      setMyReaction: vi.fn(),
+      subscribe: vi.fn(() => () => {}),
+    };
+    const repository = createMessageSyncRepository(client);
+    const snapshots = [];
+
+    const unsubscribe = await repository.watchRecentMessages('c1', (messages) =>
+      snapshots.push(messages.map((message) => message.messageId)),
+    );
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    serverRows = [wireMessage(), { ...wireMessage(), id: 'm2', sentAt: 2 }];
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await vi.waitFor(() => expect(snapshots.at(-1)).toEqual(['m1', 'm2']));
+
+    unsubscribe();
+  });
+
+  it('reconciles again when foregrounded during an in-flight refresh', async () => {
+    let loadCount = 0;
+    let resolveStaleRefresh;
+    const client = {
+      getUserId: () => 'me',
+      loadMessages: vi.fn(() => {
+        loadCount += 1;
+        if (loadCount === 1) return Promise.resolve([wireMessage()]);
+        if (loadCount === 2) {
+          return new Promise((resolve) => {
+            resolveStaleRefresh = resolve;
+          });
+        }
+        return Promise.resolve([
+          wireMessage(),
+          { ...wireMessage(), id: 'm2', sentAt: 2 },
+        ]);
+      }),
+      sendMessage: vi.fn(),
+      setMyReaction: vi.fn(),
+      subscribe: vi.fn(() => () => {}),
+    };
+    const repository = createMessageSyncRepository(client);
+    const snapshots = [];
+    const unsubscribe = await repository.watchRecentMessages('c1', (messages) =>
+      snapshots.push(messages.map((message) => message.messageId)),
+    );
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // A second foreground transition occurs before the stale refresh settles.
+    document.dispatchEvent(new Event('visibilitychange'));
+    resolveStaleRefresh([wireMessage()]);
+
+    await vi.waitFor(() => expect(snapshots.at(-1)).toEqual(['m1', 'm2']));
+    unsubscribe();
+  });
+
   it('persists the desired reaction key without sending user identity', async () => {
     const client = {
       getUserId: () => 'me',

--- a/src/stores/conversation/message-sync.ts
+++ b/src/stores/conversation/message-sync.ts
@@ -5,7 +5,11 @@
 // broadcast into the window (deduped by the server-honored message id).
 
 import type { Reaction } from '@lib/reactions/solid/solid.js';
-import type { ConversationServerEvent, WireMessage } from '@realtime';
+import {
+  subscribeToWakeSignals,
+  type ConversationServerEvent,
+  type WireMessage,
+} from '@realtime';
 import {
   toIncomingMessage,
   toSendMessageInput,
@@ -166,23 +170,16 @@ export function createMessageSyncRepository(
         applyEvent(event);
       });
 
-      const refreshWhenVisible = () => {
-        if (document.visibilityState === 'visible') {
-          void reconcileSnapshot(false);
-        }
-      };
-      if (typeof document !== 'undefined') {
-        document.addEventListener('visibilitychange', refreshWhenVisible);
-      }
+      const unsubscribeWake = subscribeToWakeSignals(() => {
+        void reconcileSnapshot(false);
+      });
 
       await reconcileSnapshot(true);
 
       return () => {
         stopped = true;
         unsubscribe();
-        if (typeof document !== 'undefined') {
-          document.removeEventListener('visibilitychange', refreshWhenVisible);
-        }
+        unsubscribeWake();
       };
     },
 

--- a/src/stores/conversation/message-sync.ts
+++ b/src/stores/conversation/message-sync.ts
@@ -76,6 +76,9 @@ export function createMessageSyncRepository(
       const window = new Map<string, IncomingMessage>();
       const pendingEvents: ConversationServerEvent[] = [];
       let snapshotLoaded = false;
+      let refreshInFlight = false;
+      let refreshRequested = false;
+      let stopped = false;
       const emit = () => {
         const ordered = [...window.values()].sort(
           (a, b) => a.sentAt - b.sentAt,
@@ -118,30 +121,69 @@ export function createMessageSyncRepository(
         emit();
       };
 
+      const applyPendingEvents = () => {
+        if (pendingEvents.length) {
+          for (const event of pendingEvents.splice(0)) applyEvent(event);
+        } else {
+          emit();
+        }
+      };
+
+      const reconcileSnapshot = async (reportError: boolean) => {
+        if (stopped) return;
+        if (refreshInFlight) {
+          refreshRequested = true;
+          return;
+        }
+        refreshInFlight = true;
+        try {
+          const messages = await snapshot(conversationId);
+          if (stopped) return;
+          for (const message of messages) {
+            window.set(message.messageId, message);
+          }
+          snapshotLoaded = true;
+          applyPendingEvents();
+        } catch (error) {
+          if (stopped) return;
+          snapshotLoaded = true;
+          applyPendingEvents();
+          if (reportError) onError?.(error);
+        } finally {
+          refreshInFlight = false;
+          if (refreshRequested && !stopped) {
+            refreshRequested = false;
+            void reconcileSnapshot(false);
+          }
+        }
+      };
+
       const unsubscribe = client.subscribe(conversationId, (event) => {
-        if (!snapshotLoaded) {
+        if (!snapshotLoaded || refreshInFlight) {
           pendingEvents.push(event);
           return;
         }
         applyEvent(event);
       });
 
-      try {
-        for (const m of await snapshot(conversationId)) {
-          window.set(m.messageId, m);
+      const refreshWhenVisible = () => {
+        if (document.visibilityState === 'visible') {
+          void reconcileSnapshot(false);
         }
-        snapshotLoaded = true;
-        if (pendingEvents.length) {
-          for (const event of pendingEvents) applyEvent(event);
-        } else {
-          emit();
-        }
-      } catch (error) {
-        snapshotLoaded = true;
-        onError?.(error);
+      };
+      if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', refreshWhenVisible);
       }
 
-      return unsubscribe;
+      await reconcileSnapshot(true);
+
+      return () => {
+        stopped = true;
+        unsubscribe();
+        if (typeof document !== 'undefined') {
+          document.removeEventListener('visibilitychange', refreshWhenVisible);
+        }
+      };
     },
 
     async send(message) {


### PR DESCRIPTION
## Summary

- refresh the active conversation's persisted message window when the PWA returns to the foreground
- merge by message ID while preserving live events received during reconciliation
- coalesce a follow-up refresh when a visibility event arrives during an in-flight snapshot
- add regression coverage for missed messages and overlapping refreshes

## Why

The conversation WebSocket is broadcast-only. If macOS suspends the PWA and a broadcast is missed, reopening the existing conversation view previously left it stale until a manual reload.

## Impact

Returning to an already-open conversation now reconciles any messages persisted while the PWA was backgrounded.

## Validation

- `vp check`
- `vp test` — 387 passed, 1 skipped
- focused message-sync suite — 7 passed
- development server smoke-tested successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message synchronization when returning to a visible browser window.
  * Ensured messages added while the app is hidden are loaded after it becomes visible.
  * Ensured repeated foreground transitions receive the latest available messages, even during an ongoing refresh.
  * Improved handling of queued live updates during message loading and refresh operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->