### PR TITLE
Fix guest call media initialization

### DIFF
--- a/src/features/call/components/CallLobby.test.jsx
+++ b/src/features/call/components/CallLobby.test.jsx
@@ -34,6 +34,34 @@ vi.mock('@shared/i18n', () => ({
 
 const { CallLobby } = await import('./CallLobby');
 
+function setupMediaDevices() {
+  const microphone = {
+    kind: 'audio',
+    enabled: true,
+    readyState: 'live',
+    stop: vi.fn(),
+  };
+  const camera = {
+    kind: 'video',
+    enabled: true,
+    readyState: 'live',
+    stop: vi.fn(),
+  };
+  const localStream = {
+    getTracks: () => [microphone, camera],
+    getAudioTracks: () => [microphone],
+    getVideoTracks: () => [camera],
+  };
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getSupportedConstraints: () => ({}),
+      getUserMedia: vi.fn(async () => localStream),
+    },
+  });
+  return { camera, localStream, microphone };
+}
+
 describe('CallLobby', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,30 +78,7 @@ describe('CallLobby', () => {
   });
 
   it('joins guest calls with initial presence and stable media slots', async () => {
-    const microphone = {
-      kind: 'audio',
-      enabled: true,
-      readyState: 'live',
-      stop: vi.fn(),
-    };
-    const camera = {
-      kind: 'video',
-      enabled: true,
-      readyState: 'live',
-      stop: vi.fn(),
-    };
-    const localStream = {
-      getTracks: () => [microphone, camera],
-      getAudioTracks: () => [microphone],
-      getVideoTracks: () => [camera],
-    };
-    Object.defineProperty(navigator, 'mediaDevices', {
-      configurable: true,
-      value: {
-        getSupportedConstraints: () => ({}),
-        getUserMedia: vi.fn(async () => localStream),
-      },
-    });
+    const { camera, localStream, microphone } = setupMediaDevices();
     mocks.signInAsGuest.mockResolvedValue('guest-user');
     mocks.p2p.join.mockResolvedValue({ roomId: 'guest-room' });
 
@@ -95,5 +100,20 @@ describe('CallLobby', () => {
     await expect(options.getLocalStream()).resolves.toBe(localStream);
     expect(microphone.stop).not.toHaveBeenCalled();
     expect(camera.stop).not.toHaveBeenCalled();
+  });
+
+  it('stops acquired media when joining a guest call fails', async () => {
+    const { camera, microphone } = setupMediaDevices();
+    const joinError = new Error('signaling unavailable');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.signInAsGuest.mockResolvedValue('guest-user');
+    mocks.p2p.join.mockRejectedValue(joinError);
+
+    const { getByRole } = render(() => <CallLobby />);
+    fireEvent.click(getByRole('button', { name: 'call.lobby.join' }));
+
+    await waitFor(() => expect(mocks.p2p.join).toHaveBeenCalledOnce());
+    await waitFor(() => expect(microphone.stop).toHaveBeenCalledOnce());
+    expect(camera.stop).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/call/components/CallLobby.test.jsx
+++ b/src/features/call/components/CallLobby.test.jsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vite-plus/test';
+
+const mocks = vi.hoisted(() => ({
+  p2p: {
+    state: vi.fn(() => 'idle'),
+    join: vi.fn(),
+    error: vi.fn(),
+    errorKind: vi.fn(),
+  },
+  signInAsGuest: vi.fn(),
+  createRoomSignaling: vi.fn(),
+}));
+
+vi.mock('@shared/p2p-context.js', () => ({
+  useP2PContext: () => mocks.p2p,
+}));
+vi.mock('@realtime', () => ({
+  createRoomSignaling: mocks.createRoomSignaling,
+}));
+vi.mock('@auth', () => ({
+  signInAsGuest: mocks.signInAsGuest,
+}));
+vi.mock('@shared/i18n', () => ({
+  t: (key) => key,
+}));
+
+const { CallLobby } = await import('./CallLobby');
+
+describe('CallLobby', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(
+      null,
+      '',
+      '/?publicRoom=12345678-1234-1234-1234-123456789abc',
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('joins guest calls with initial presence and stable media slots', async () => {
+    const microphone = {
+      kind: 'audio',
+      enabled: true,
+      readyState: 'live',
+      stop: vi.fn(),
+    };
+    const camera = {
+      kind: 'video',
+      enabled: true,
+      readyState: 'live',
+      stop: vi.fn(),
+    };
+    const localStream = {
+      getTracks: () => [microphone, camera],
+      getAudioTracks: () => [microphone],
+      getVideoTracks: () => [camera],
+    };
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getSupportedConstraints: () => ({}),
+        getUserMedia: vi.fn(async () => localStream),
+      },
+    });
+    mocks.signInAsGuest.mockResolvedValue('guest-user');
+    mocks.p2p.join.mockResolvedValue({ roomId: 'guest-room' });
+
+    const { getByRole } = render(() => <CallLobby />);
+    fireEvent.click(getByRole('button', { name: 'call.lobby.join' }));
+
+    await waitFor(() => expect(mocks.p2p.join).toHaveBeenCalledOnce());
+    const options = mocks.p2p.join.mock.calls[0][0];
+    expect(options).toEqual(
+      expect.objectContaining({
+        createSignaling: mocks.createRoomSignaling,
+        localTrackSlots: [
+          { id: 'microphone', kind: 'audio', track: microphone },
+          { id: 'primary-video', kind: 'video', track: camera },
+        ],
+        presenceData: { micOn: true, cameraOn: true },
+      }),
+    );
+    await expect(options.getLocalStream()).resolves.toBe(localStream);
+    expect(microphone.stop).not.toHaveBeenCalled();
+    expect(camera.stop).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/call/components/CallLobby.tsx
+++ b/src/features/call/components/CallLobby.tsx
@@ -11,6 +11,7 @@ import {
   getAudioConstraints,
   getVideoConstraints,
 } from '../media-constraints.js';
+import { createCallLocalTrackSlots } from '../call-media.js';
 
 function joinErrorMessage(err: unknown, kind: string | undefined): string {
   if (kind === 'room-full') return t('call.lobby.error.full');
@@ -106,6 +107,7 @@ export function CallLobby() {
     setJoining(true);
     setCallEnded(false);
     setError(null);
+    let localStream: MediaStream | undefined;
     try {
       const uid = await signInAsGuest();
       // peerId must be unique per tab, not per user: the anonymous session is
@@ -113,20 +115,37 @@ export function CallLobby() {
       // peers by peerId (the verified identity is authn-only). Two tabs
       // joining with the same uid would collide as one peer.
       const peerId = `${uid.slice(0, 6)}-${crypto.randomUUID().slice(0, 8)}`;
+      const acquiredStream = await navigator.mediaDevices.getUserMedia({
+        video: getVideoConstraints(),
+        audio: getAudioConstraints(),
+      });
+      localStream = acquiredStream;
       const room = await p2p.join({
         roomId: id,
         peerId,
         createSignaling: createRoomSignaling,
         memberCapacity: 4,
         dataChannel: true,
-        getLocalStream: () =>
-          navigator.mediaDevices.getUserMedia({
-            video: getVideoConstraints(),
-            audio: getAudioConstraints(),
-          }),
+        // Guest calls use the same stable publication slots and initial media
+        // presence as contact calls. Without these, remote video is hidden
+        // until another control publishes presence, and camera replacement
+        // fails because the primary-video slot does not exist.
+        getLocalStream: () => Promise.resolve(acquiredStream),
+        localTrackSlots: createCallLocalTrackSlots(acquiredStream),
+        presenceData: {
+          micOn: acquiredStream
+            .getAudioTracks()
+            .some((track) => track.readyState === 'live' && track.enabled),
+          cameraOn: acquiredStream
+            .getVideoTracks()
+            .some((track) => track.readyState === 'live' && track.enabled),
+        },
       });
       if (!room) throw p2p.error() ?? new Error('Room join returned no room');
     } catch (err) {
+      // A signaling failure can happen before p2p invokes getLocalStream and
+      // assumes ownership of the tracks.
+      localStream?.getTracks().forEach((track) => track.stop());
       console.error('[CallLobby] Failed to join guest room:', err);
       setError(joinErrorMessage(err, p2p.errorKind()));
       setJoining(false);


### PR DESCRIPTION
## Summary

- initialize guest calls with the same stable microphone and video publication slots as authenticated calls
- publish initial microphone and camera presence when a guest joins
- stop acquired media tracks when guest-room signaling fails before ownership transfers
- add regression coverage for guest join media options

## Root cause

The ephemeral-call join path had drifted from the authenticated call path. It did not declare the `primary-video` slot or publish initial `cameraOn` and `micOn` presence. Remote video therefore remained hidden until another control triggered a presence update, and camera replacement failed with an unknown-slot error.

## Impact

Guest callers see remote video as soon as both peers connect, and camera disable/re-enable uses the registered video slot without logging replacement errors.

## Validation

- `vp check`
- `vp test --run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guest call joining by acquiring microphone and camera access before entering the call.
  * Ensured local media remains available consistently after joining.
  * Cleaned up media tracks when joining fails to prevent devices from remaining active.

* **Tests**
  * Added coverage for guest joining, initial media state, stable media controls, and track activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->