### PR TITLE
Expire stale incoming call invites

### DIFF
--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -172,6 +172,86 @@ describe('CallHandshakeController', () => {
     expect(onStateChange).toHaveBeenLastCalledWith(null);
   });
 
+  it('dismisses an incoming call when its invite expires', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+    try {
+      const onStateChange = vi.fn();
+      const controller = createController(createP2PMock(), { onStateChange });
+
+      controller.init();
+      mocks.incomingCallback?.({
+        type: 'invite',
+        invite: {
+          roomId: 'room-1',
+          callerId: 'caller-id',
+          callerName: 'Caller',
+          startedAt: Date.now(),
+          expiresAt: Date.now() + 1_000,
+        },
+      });
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ direction: 'incoming' }),
+      );
+      vi.advanceTimersByTime(1_000);
+      expect(onStateChange).toHaveBeenLastCalledWith(null);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not surface an invite that is already expired', () => {
+    const onStateChange = vi.fn();
+    const controller = createController(createP2PMock(), { onStateChange });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        startedAt: Date.now() - 2_000,
+        expiresAt: Date.now() - 1_000,
+      },
+    });
+
+    expect(onStateChange).not.toHaveBeenCalled();
+  });
+
+  it('does not accept an invite that expired while its dialog was open', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+    try {
+      const onStateChange = vi.fn();
+      const p2p = createP2PMock();
+      const controller = createController(p2p, { onStateChange });
+
+      controller.init();
+      mocks.incomingCallback?.({
+        type: 'invite',
+        invite: {
+          roomId: 'room-1',
+          callerId: 'caller-id',
+          callerName: 'Caller',
+          startedAt: Date.now(),
+          expiresAt: Date.now() + 1_000,
+        },
+      });
+      vi.setSystemTime(Date.now() + 1_000);
+
+      controller.acceptIncoming();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(null);
+      expect(mocks.getUserMedia).not.toHaveBeenCalled();
+      expect(p2p.join).not.toHaveBeenCalled();
+      expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {
     const join = deferred();
     const p2p = createP2PMock({ join: vi.fn(() => join.promise) });

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -120,6 +120,7 @@ export class CallHandshakeController {
   private readonly onReconnectStatus: (status: CallReconnectStatus) => void;
 
   private _handshakeState: CallHandshakeState = null;
+  private incomingCallTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private outgoingCallTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private reconnectTimeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -148,6 +149,10 @@ export class CallHandshakeController {
   }
 
   private setHandshakeState(state: CallHandshakeState): void {
+    if (this.incomingCallTimeoutId != null) {
+      clearTimeout(this.incomingCallTimeoutId);
+      this.incomingCallTimeoutId = undefined;
+    }
     this._handshakeState = state;
     this.onStateChange(state);
   }
@@ -231,6 +236,7 @@ export class CallHandshakeController {
     call: MailboxInvite,
     callService: NonNullable<ReturnType<typeof getCallService>>,
   ): void {
+    if (this.isExpired(call)) return;
     if (this.isBusyForIncomingCall(call)) {
       callService
         .respondToIncomingCallInvite({
@@ -244,6 +250,22 @@ export class CallHandshakeController {
       return;
     }
     this.setHandshakeState({ direction: 'incoming', call });
+    if (call.expiresAt != null) {
+      this.incomingCallTimeoutId = setTimeout(
+        () => {
+          this.incomingCallTimeoutId = undefined;
+          const state = this._handshakeState;
+          if (
+            state?.direction === 'incoming' &&
+            state.call.roomId === call.roomId &&
+            this.isExpired(state.call)
+          ) {
+            this.setHandshakeState(null);
+          }
+        },
+        Math.max(0, call.expiresAt - Date.now()),
+      );
+    }
     if (import.meta.env.DEV) {
       console.debug('Received incoming call invite:', { call });
     }
@@ -255,6 +277,10 @@ export class CallHandshakeController {
       return state.call.roomId !== call.roomId;
     }
     return state !== null || this.p2p.state() !== 'idle';
+  }
+
+  private isExpired(call: MailboxInvite): boolean {
+    return call.expiresAt != null && call.expiresAt <= Date.now();
   }
 
   startCall = async (details: StartCallDetails): Promise<void> => {
@@ -568,6 +594,10 @@ export class CallHandshakeController {
   acceptIncoming = (): void => {
     const state = this._handshakeState;
     if (!state || state.direction !== 'incoming') return;
+    if (this.isExpired(state.call)) {
+      this.setHandshakeState(null);
+      return;
+    }
     const svc = getCallService();
     const localUID = getLoggedInUserId();
     if (!svc || !localUID) return;


### PR DESCRIPTION
## What changed

- Dismiss incoming-call state when the invite reaches its server-provided expiry.
- Reject invites that are already expired before showing a dialog.
- Re-check expiry before accepting so a delayed timer cannot join an empty room.
- Add regression coverage for all three cases.

## Why

Incoming invite expiry was checked only when the mailbox envelope arrived. If caller cancellation was delayed or lost while either PWA was backgrounded, the callee could retain the dialog and dock badge beyond the 45-second calling window. Accepting that stale dialog joined the room alone and left the UI on “Waiting for the other person to connect…”.

## Scope deliberately skipped

- Wake-lock behavior: its hidden-page rejection is caught and does not affect signaling; changing it would only silence a warning.
- Push payload/schema changes: the final server-built notification already supplies the timestamp used for freshness checks.
- New visibility listeners or server endpoints: the expiry timer plus a synchronous acceptance guard covers the correctness issue without another lifecycle path.

## Validation

- `vp check`
- `vp test` — 70 files passed, 1 skipped; 390 tests passed, 1 skipped
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired incoming call invitations are now automatically dismissed.
  * Invitations that have already expired are ignored.
  * Accepting an expired invitation no longer starts media, joins the call, or sends an acceptance response.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->