### PR TITLE
Correlate call invites through acceptance

### DIFF
--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -45,6 +45,7 @@ import { isSystemMessageType } from '../../../../shared/conversation-channel/pro
 import { CALLING_TTL_MS } from '../../../../shared/constants';
 
 const MAX_ATTACHMENT_FILE_NAME_LENGTH = 180;
+const MAX_CALL_INVITE_ID_LENGTH = 128;
 const TURN_CREDENTIAL_TTL_SECONDS = 3_600;
 const TURN_CREDENTIAL_FETCH_TIMEOUT_MS = 5_000;
 
@@ -211,7 +212,14 @@ export async function handleDataRequest(
     const startedAt = now;
     // The fallback keeps already-deployed clients working while every new
     // client creates and carries its own callInviteId end to end.
-    const callInviteId = str(body?.callInviteId) ?? crypto.randomUUID();
+    const suppliedCallInviteId = str(body?.callInviteId);
+    if (
+      suppliedCallInviteId &&
+      suppliedCallInviteId.length > MAX_CALL_INVITE_ID_LENGTH
+    ) {
+      return json({ error: 'callInviteId too long' }, 400, cors);
+    }
+    const callInviteId = suppliedCallInviteId ?? crypto.randomUUID();
     const expiresAt = numOrUndef(body?.expiresAt) ?? startedAt + CALLING_TTL_MS;
     await env.USER_MAILBOX.getByName(calleeId).deliver({
       t: 'invite',

--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -209,10 +209,14 @@ export async function handleDataRequest(
       return json({ error: 'not_found' }, 404, cors);
     }
     const startedAt = now;
+    // The fallback keeps already-deployed clients working while every new
+    // client creates and carries its own callInviteId end to end.
+    const callInviteId = str(body?.callInviteId) ?? crypto.randomUUID();
     const expiresAt = numOrUndef(body?.expiresAt) ?? startedAt + CALLING_TTL_MS;
     await env.USER_MAILBOX.getByName(calleeId).deliver({
       t: 'invite',
       invite: {
+        callInviteId,
         roomId: conversationId,
         callerId,
         calleeId,
@@ -222,12 +226,13 @@ export async function handleDataRequest(
         expiresAt,
       },
     });
-    return json({ ok: true }, 200, cors);
+    return json({ ok: true, callInviteId }, 200, cors);
   }
 
   if (request.method === 'POST' && url.pathname === '/calls/response') {
     const body = await readJson(request);
     const conversationId = str(body?.conversationId);
+    const callInviteId = str(body?.callInviteId) ?? undefined;
     const targetCallerId = str(body?.callerId);
     const responseType = str(body?.responseType);
     if (
@@ -251,17 +256,31 @@ export async function handleDataRequest(
     if (otherMember !== targetCallerId) {
       return json({ error: 'not_found' }, 404, cors);
     }
-    // Retire this invite on the responder's OWN other sockets (other tabs/
-    // devices still ringing): `handled` both clears the retained invite and
-    // fans a dismiss to them. `by` is the responder who handled it.
-    await env.USER_MAILBOX.getByName(callerId).deliver({
-      t: 'handled',
-      roomId: conversationId,
-      by: callerId,
-    });
-    await env.USER_MAILBOX.getByName(targetCallerId).deliver({
+    const calleeMailbox = env.USER_MAILBOX.getByName(callerId);
+    const callerMailbox = env.USER_MAILBOX.getByName(targetCallerId);
+    const invite = await calleeMailbox.handlePendingCallInvite(
+      conversationId,
+      callInviteId,
+      targetCallerId,
+      callerId,
+    );
+    if (!invite) {
+      // Accepted responses retry after client-side request timeouts. If the
+      // first request already stored this exact response, the retry succeeded.
+      const isAcceptedRetry =
+        responseType === 'accepted' &&
+        (await callerMailbox.hasPendingAcceptedResponse(
+          conversationId,
+          callInviteId,
+          callerId,
+        ));
+      if (isAcceptedRetry) return json({ ok: true }, 200, cors);
+      return json({ error: 'stale_call_invite' }, 409, cors);
+    }
+    await callerMailbox.deliver({
       t: 'response',
       response: {
+        callInviteId: invite.callInviteId,
         roomId: conversationId,
         responseType,
         by: callerId,
@@ -273,7 +292,9 @@ export async function handleDataRequest(
   }
 
   if (request.method === 'POST' && url.pathname === '/calls/response/ack') {
-    const conversationId = str((await readJson(request))?.conversationId);
+    const body = await readJson(request);
+    const conversationId = str(body?.conversationId);
+    const callInviteId = str(body?.callInviteId) ?? undefined;
     if (!conversationId)
       return json({ error: 'conversationId required' }, 400, cors);
     if (!(await isMember(env.DB, conversationId, callerId))) {
@@ -281,6 +302,7 @@ export async function handleDataRequest(
     }
     await env.USER_MAILBOX.getByName(callerId).clearPendingResponse(
       conversationId,
+      callInviteId,
     );
     return json({ ok: true }, 200, cors);
   }
@@ -288,6 +310,7 @@ export async function handleDataRequest(
   if (request.method === 'POST' && url.pathname === '/calls/cancel') {
     const body = await readJson(request);
     const conversationId = str(body?.conversationId);
+    const callInviteId = str(body?.callInviteId) ?? undefined;
     const calleeId = str(body?.calleeId);
     if (!conversationId || !calleeId) {
       return json({ error: 'conversationId and calleeId required' }, 400, cors);
@@ -298,11 +321,11 @@ export async function handleDataRequest(
     ) {
       return json({ error: 'not_found' }, 404, cors);
     }
-    await env.USER_MAILBOX.getByName(calleeId).deliver({
-      t: 'cancel',
-      roomId: conversationId,
-      by: callerId,
-    });
+    await env.USER_MAILBOX.getByName(calleeId).cancelPendingCallInvite(
+      conversationId,
+      callInviteId,
+      callerId,
+    );
     return json({ ok: true }, 200, cors);
   }
 

--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -285,17 +285,27 @@ export async function handleDataRequest(
       if (isAcceptedRetry) return json({ ok: true }, 200, cors);
       return json({ error: 'stale_call_invite' }, 409, cors);
     }
-    await callerMailbox.deliver({
-      t: 'response',
-      response: {
-        callInviteId: invite.callInviteId,
+    try {
+      await callerMailbox.deliver({
+        t: 'response',
+        response: {
+          callInviteId: invite.callInviteId,
+          roomId: conversationId,
+          responseType,
+          by: callerId,
+          respondedAt: now,
+          expiresAt: numOrUndef(body?.expiresAt),
+        },
+      });
+    } catch (err) {
+      console.error('[data] call response delivery failed after consumption', {
         roomId: conversationId,
+        callInviteId: invite.callInviteId,
         responseType,
-        by: callerId,
-        respondedAt: now,
-        expiresAt: numOrUndef(body?.expiresAt),
-      },
-    });
+        err,
+      });
+      throw err;
+    }
     return json({ ok: true }, 200, cors);
   }
 

--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -339,6 +339,7 @@ export async function handleDataRequest(
     ) {
       return json({ error: 'not_found' }, 404, cors);
     }
+    // Cancellation is idempotent when the invite is already gone.
     await env.USER_MAILBOX.getByName(calleeId).cancelPendingCallInvite(
       conversationId,
       callInviteId,

--- a/backend/cloudflare/src/realtime/user-mailbox.ts
+++ b/backend/cloudflare/src/realtime/user-mailbox.ts
@@ -86,10 +86,69 @@ export class UserMailbox extends DurableObject<Env> {
         responseKey(envelope.response.roomId),
         envelope.response,
       );
-    } else if (envelope.t === 'cancel' || envelope.t === 'handled') {
-      await this.clearPendingInvite(envelope.roomId);
     }
 
+    this.broadcast(envelope);
+  }
+
+  async handlePendingCallInvite(
+    roomId: string,
+    callInviteId: string | undefined,
+    callerId: string,
+    by: string,
+  ): Promise<MailboxInvite | null> {
+    const invite = await this.takePendingCallInvite(
+      roomId,
+      callInviteId,
+      callerId,
+    );
+    if (!invite) return null;
+    this.broadcast({
+      t: 'handled',
+      callInviteId: invite.callInviteId,
+      roomId,
+      by,
+    });
+    return invite;
+  }
+
+  async cancelPendingCallInvite(
+    roomId: string,
+    callInviteId: string | undefined,
+    callerId: string,
+  ): Promise<boolean> {
+    const invite = await this.takePendingCallInvite(
+      roomId,
+      callInviteId,
+      callerId,
+    );
+    if (!invite) return false;
+    this.broadcast({
+      t: 'cancel',
+      callInviteId: invite.callInviteId,
+      roomId,
+      by: callerId,
+    });
+    return true;
+  }
+
+  async hasPendingAcceptedResponse(
+    roomId: string,
+    callInviteId: string | undefined,
+    calleeId: string,
+  ): Promise<boolean> {
+    const response = await this.ctx.storage.get<MailboxResponse>(
+      responseKey(roomId),
+    );
+    return (
+      response?.responseType === 'accepted' &&
+      response.by === calleeId &&
+      (callInviteId == null || response.callInviteId === callInviteId) &&
+      (response.expiresAt == null || response.expiresAt > Date.now())
+    );
+  }
+
+  private broadcast(envelope: MailboxEnvelope): void {
     const payload = JSON.stringify(envelope);
     for (const ws of this.ctx.getWebSockets()) {
       try {
@@ -100,12 +159,16 @@ export class UserMailbox extends DurableObject<Env> {
     }
   }
 
-  async clearPendingInvite(roomId: string): Promise<void> {
-    await this.ctx.storage.delete(inviteKey(roomId));
-  }
-
-  async clearPendingResponse(roomId: string): Promise<void> {
-    await this.ctx.storage.delete(responseKey(roomId));
+  async clearPendingResponse(
+    roomId: string,
+    callInviteId?: string,
+  ): Promise<void> {
+    const key = responseKey(roomId);
+    if (callInviteId != null) {
+      const response = await this.ctx.storage.get<MailboxResponse>(key);
+      if (response?.callInviteId !== callInviteId) return;
+    }
+    await this.ctx.storage.delete(key);
   }
 
   private async storePendingInvite(invite: MailboxInvite): Promise<void> {
@@ -115,6 +178,29 @@ export class UserMailbox extends DurableObject<Env> {
       return;
     }
     await this.ctx.storage.put(key, invite);
+  }
+
+  private async takePendingCallInvite(
+    roomId: string,
+    callInviteId: string | undefined,
+    callerId: string,
+  ): Promise<MailboxInvite | null> {
+    const key = inviteKey(roomId);
+    return this.ctx.storage.transaction(async (storage) => {
+      const invite = await storage.get<MailboxInvite>(key);
+      if (
+        !invite ||
+        invite.callerId !== callerId ||
+        (callInviteId != null && invite.callInviteId !== callInviteId)
+      )
+        return null;
+      if (invite.expiresAt != null && invite.expiresAt <= Date.now()) {
+        await storage.delete(key);
+        return null;
+      }
+      await storage.delete(key);
+      return invite;
+    });
   }
 
   /** All non-expired pending invites; sweeps any expired keys it encounters. */

--- a/backend/cloudflare/src/realtime/user-mailbox.ts
+++ b/backend/cloudflare/src/realtime/user-mailbox.ts
@@ -116,20 +116,19 @@ export class UserMailbox extends DurableObject<Env> {
     roomId: string,
     callInviteId: string | undefined,
     callerId: string,
-  ): Promise<boolean> {
+  ): Promise<void> {
     const invite = await this.takePendingCallInvite(
       roomId,
       callInviteId,
       callerId,
     );
-    if (!invite) return false;
+    if (!invite) return;
     this.broadcast({
       t: 'cancel',
       callInviteId: invite.callInviteId,
       roomId,
       by: callerId,
     });
-    return true;
   }
 
   async hasPendingAcceptedResponse(

--- a/backend/cloudflare/src/realtime/user-mailbox.ts
+++ b/backend/cloudflare/src/realtime/user-mailbox.ts
@@ -164,11 +164,15 @@ export class UserMailbox extends DurableObject<Env> {
     callInviteId?: string,
   ): Promise<void> {
     const key = responseKey(roomId);
-    if (callInviteId != null) {
-      const response = await this.ctx.storage.get<MailboxResponse>(key);
-      if (response?.callInviteId !== callInviteId) return;
+    if (callInviteId == null) {
+      await this.ctx.storage.delete(key);
+      return;
     }
-    await this.ctx.storage.delete(key);
+    await this.ctx.storage.transaction(async (storage) => {
+      const response = await storage.get<MailboxResponse>(key);
+      if (response?.callInviteId !== callInviteId) return;
+      await storage.delete(key);
+    });
   }
 
   private async storePendingInvite(invite: MailboxInvite): Promise<void> {

--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -686,6 +686,7 @@ describe('call cancel mailbox route', () => {
   });
 
   it('delivers the cancel envelope with room and caller identity', async () => {
+    const callInviteId = `invite-${crypto.randomUUID()}`;
     const convoId = await resolveOrCreateDirect(
       env.DB,
       'user-a',
@@ -697,7 +698,18 @@ describe('call cancel mailbox route', () => {
     const mailbox = await connectMailbox(calleeToken);
 
     try {
+      expect(
+        (
+          await jsonPost('/calls/invite', callerToken, {
+            callInviteId,
+            conversationId: convoId,
+            calleeId: 'user-b',
+          })
+        ).status,
+      ).toBe(200);
+      await mailbox.next();
       const res = await jsonPost('/calls/cancel', callerToken, {
+        callInviteId,
         conversationId: convoId,
         calleeId: 'user-b',
       });
@@ -706,6 +718,7 @@ describe('call cancel mailbox route', () => {
       expect(await res.json()).toEqual({ ok: true });
       expect(await mailbox.next()).toEqual({
         t: 'cancel',
+        callInviteId,
         roomId: convoId,
         by: 'user-a',
       });
@@ -717,6 +730,7 @@ describe('call cancel mailbox route', () => {
 
 describe('call invite retention', () => {
   it('replays a fresh pending invite when the callee connects late', async () => {
+    const callInviteId = `invite-${crypto.randomUUID()}`;
     const callerId = `caller-${crypto.randomUUID()}`;
     const calleeId = `callee-${crypto.randomUUID()}`;
     const convoId = await resolveOrCreateDirect(
@@ -729,6 +743,7 @@ describe('call invite retention', () => {
     const calleeToken = await signToken(validClaims(calleeId));
 
     const res = await jsonPost('/calls/invite', callerToken, {
+      callInviteId,
       conversationId: convoId,
       calleeId,
       callerName: 'Caller',
@@ -742,6 +757,7 @@ describe('call invite retention', () => {
       expect(await mailbox.next()).toEqual({
         t: 'invite',
         invite: {
+          callInviteId,
           roomId: convoId,
           callerId,
           calleeId,
@@ -757,6 +773,7 @@ describe('call invite retention', () => {
   });
 
   it('does not replay a pending invite after caller cancel', async () => {
+    const callInviteId = `invite-${crypto.randomUUID()}`;
     const callerId = `caller-${crypto.randomUUID()}`;
     const calleeId = `callee-${crypto.randomUUID()}`;
     const convoId = await resolveOrCreateDirect(
@@ -771,6 +788,7 @@ describe('call invite retention', () => {
     expect(
       (
         await jsonPost('/calls/invite', callerToken, {
+          callInviteId,
           conversationId: convoId,
           calleeId,
           expiresAt: Date.now() + 30_000,
@@ -780,6 +798,7 @@ describe('call invite retention', () => {
     expect(
       (
         await jsonPost('/calls/cancel', callerToken, {
+          callInviteId,
           conversationId: convoId,
           calleeId,
         })
@@ -795,6 +814,7 @@ describe('call invite retention', () => {
   });
 
   it('does not replay a pending invite after callee response', async () => {
+    const callInviteId = `invite-${crypto.randomUUID()}`;
     const callerId = `caller-${crypto.randomUUID()}`;
     const calleeId = `callee-${crypto.randomUUID()}`;
     const convoId = await resolveOrCreateDirect(
@@ -809,6 +829,7 @@ describe('call invite retention', () => {
     expect(
       (
         await jsonPost('/calls/invite', callerToken, {
+          callInviteId,
           conversationId: convoId,
           calleeId,
           expiresAt: Date.now() + 30_000,
@@ -818,6 +839,7 @@ describe('call invite retention', () => {
     expect(
       (
         await jsonPost('/calls/response', calleeToken, {
+          callInviteId,
           conversationId: convoId,
           callerId,
           responseType: 'accepted',
@@ -831,6 +853,51 @@ describe('call invite retention', () => {
     } finally {
       mailbox.close();
     }
+  });
+
+  it('rejects a response for an older call invite without consuming the current invite', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const currentCallInviteId = `invite-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(
+      env.DB,
+      callerId,
+      calleeId,
+      1000,
+    );
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    expect(
+      (
+        await jsonPost('/calls/invite', callerToken, {
+          callInviteId: currentCallInviteId,
+          conversationId: convoId,
+          calleeId,
+          expiresAt: Date.now() + 30_000,
+        })
+      ).status,
+    ).toBe(200);
+
+    const stale = await jsonPost('/calls/response', calleeToken, {
+      callInviteId: 'older-call-invite',
+      conversationId: convoId,
+      callerId,
+      responseType: 'accepted',
+    });
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({ error: 'stale_call_invite' });
+
+    expect(
+      (
+        await jsonPost('/calls/response', calleeToken, {
+          callInviteId: currentCallInviteId,
+          conversationId: convoId,
+          callerId,
+          responseType: 'accepted',
+        })
+      ).status,
+    ).toBe(200);
   });
 
   it('rejects a forged response that targets the responder instead of the caller', async () => {
@@ -859,6 +926,7 @@ describe('call invite retention', () => {
     // device must dismiss the incoming dialog everywhere, not just clear storage.
     const callerId = `caller-${crypto.randomUUID()}`;
     const calleeId = `callee-${crypto.randomUUID()}`;
+    const callInviteId = `invite-${crypto.randomUUID()}`;
     const convoId = await resolveOrCreateDirect(
       env.DB,
       callerId,
@@ -873,6 +941,7 @@ describe('call invite retention', () => {
       expect(
         (
           await jsonPost('/calls/invite', callerToken, {
+            callInviteId,
             conversationId: convoId,
             calleeId,
             expiresAt: Date.now() + 30_000,
@@ -885,6 +954,7 @@ describe('call invite retention', () => {
       expect(
         (
           await jsonPost('/calls/response', calleeToken, {
+            callInviteId,
             conversationId: convoId,
             callerId,
             responseType: 'accepted',
@@ -894,6 +964,7 @@ describe('call invite retention', () => {
 
       expect(await otherTab.next()).toEqual({
         t: 'handled',
+        callInviteId,
         roomId: convoId,
         by: calleeId,
       });
@@ -929,6 +1000,7 @@ describe('call invite retention', () => {
       expect(
         (
           await jsonPost('/calls/invite', token, {
+            callInviteId: `invite-${convoId}`,
             conversationId: convoId,
             calleeId,
             expiresAt: Date.now() + 30_000,
@@ -959,6 +1031,7 @@ describe('call invite retention', () => {
 
 describe('call response retention', () => {
   it('replays an accepted response until the caller acknowledges it', async () => {
+    const callInviteId = `invite-${crypto.randomUUID()}`;
     const callerId = `caller-${crypto.randomUUID()}`;
     const calleeId = `callee-${crypto.randomUUID()}`;
     const convoId = await resolveOrCreateDirect(
@@ -972,7 +1045,18 @@ describe('call response retention', () => {
 
     expect(
       (
+        await jsonPost('/calls/invite', callerToken, {
+          callInviteId,
+          conversationId: convoId,
+          calleeId,
+          expiresAt: Date.now() + 30_000,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
         await jsonPost('/calls/response', calleeToken, {
+          callInviteId,
           conversationId: convoId,
           callerId,
           responseType: 'accepted',
@@ -986,6 +1070,7 @@ describe('call response retention', () => {
       expect(await mailbox.next()).toEqual({
         t: 'response',
         response: {
+          callInviteId,
           roomId: convoId,
           responseType: 'accepted',
           by: calleeId,
@@ -1000,6 +1085,7 @@ describe('call response retention', () => {
     expect(
       (
         await jsonPost('/calls/response/ack', callerToken, {
+          callInviteId,
           conversationId: convoId,
         })
       ).status,
@@ -1010,6 +1096,45 @@ describe('call response retention', () => {
       expect(await nextOrNoMessage(reconnected)).toBe(NO_MESSAGE);
     } finally {
       reconnected.close();
+    }
+  });
+
+  it('treats a retried accepted response as idempotent', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const callInviteId = `invite-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(
+      env.DB,
+      callerId,
+      calleeId,
+      1000,
+    );
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+
+    expect(
+      (
+        await jsonPost('/calls/invite', callerToken, {
+          callInviteId,
+          conversationId: convoId,
+          calleeId,
+          expiresAt: Date.now() + 30_000,
+        })
+      ).status,
+    ).toBe(200);
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(
+        (
+          await jsonPost('/calls/response', calleeToken, {
+            callInviteId,
+            conversationId: convoId,
+            callerId,
+            responseType: 'accepted',
+            expiresAt: Date.now() + 30_000,
+          })
+        ).status,
+      ).toBe(200);
     }
   });
 });

--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -729,6 +729,27 @@ describe('call cancel mailbox route', () => {
 });
 
 describe('call invite retention', () => {
+  it('rejects an oversized client-supplied invite identifier', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(
+      env.DB,
+      callerId,
+      calleeId,
+      1000,
+    );
+    const callerToken = await signToken(validClaims(callerId));
+
+    const response = await jsonPost('/calls/invite', callerToken, {
+      callInviteId: 'x'.repeat(129),
+      conversationId: convoId,
+      calleeId,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'callInviteId too long' });
+  });
+
   it('replays a fresh pending invite when the callee connects late', async () => {
     const callInviteId = `invite-${crypto.randomUUID()}`;
     const callerId = `caller-${crypto.randomUUID()}`;
@@ -1135,6 +1156,51 @@ describe('call response retention', () => {
           })
         ).status,
       ).toBe(200);
+    }
+  });
+
+  it('supports an omitted invite identifier during the compatibility window', async () => {
+    const callerId = `caller-${crypto.randomUUID()}`;
+    const calleeId = `callee-${crypto.randomUUID()}`;
+    const convoId = await resolveOrCreateDirect(
+      env.DB,
+      callerId,
+      calleeId,
+      1000,
+    );
+    const callerToken = await signToken(validClaims(callerId));
+    const calleeToken = await signToken(validClaims(calleeId));
+    const mailbox = await connectMailbox(calleeToken);
+
+    try {
+      const inviteResponse = await jsonPost('/calls/invite', callerToken, {
+        conversationId: convoId,
+        calleeId,
+        expiresAt: Date.now() + 30_000,
+      });
+      expect(inviteResponse.status).toBe(200);
+      const inviteBody = (await inviteResponse.json()) as {
+        callInviteId: string;
+      };
+      expect(inviteBody.callInviteId).toBeTypeOf('string');
+      expect(inviteBody.callInviteId.length).toBeGreaterThan(0);
+      expect(await mailbox.next()).toEqual({
+        t: 'invite',
+        invite: expect.objectContaining({
+          callInviteId: inviteBody.callInviteId,
+          roomId: convoId,
+        }),
+      });
+
+      const response = await jsonPost('/calls/response', calleeToken, {
+        conversationId: convoId,
+        callerId,
+        responseType: 'accepted',
+        expiresAt: Date.now() + 30_000,
+      });
+      expect(response.status).toBe(200);
+    } finally {
+      mailbox.close();
     }
   });
 });

--- a/backend/firebase/push-notifications/notification-payload-builder.js
+++ b/backend/firebase/push-notifications/notification-payload-builder.js
@@ -51,6 +51,9 @@ function buildCallPayload(callData = {}) {
     body,
     data: {
       type,
+      ...(type === 'incoming_call' && callData.callInviteId
+        ? { callInviteId: callData.callInviteId }
+        : {}),
       roomId: callData.roomId || '',
       callerId: callData.callerId || '',
       callerName: callData.callerName || 'Unknown caller',

--- a/shared/push-notifications/notification-schemas.js
+++ b/shared/push-notifications/notification-schemas.js
@@ -13,6 +13,7 @@ const NotificationDataBaseSchema = z.object({
 export const IncomingCallNotificationDataSchema =
   NotificationDataBaseSchema.extend({
     type: z.literal('incoming_call'),
+    callInviteId: NonEmptyStringSchema,
     roomId: NonEmptyStringSchema,
     callerId: NonEmptyStringSchema,
     callerName: NonEmptyStringSchema,

--- a/shared/push-notifications/request-schemas.js
+++ b/shared/push-notifications/request-schemas.js
@@ -7,6 +7,9 @@ import {
 } from './storage-schemas.js';
 
 export const OutboundCallNotificationDataSchema = z.object({
+  // Optional only at this deployed-client boundary. New incoming-call sends
+  // include it; missed calls do not carry a completed invite's identifier.
+  callInviteId: NonEmptyStringSchema.optional(),
   roomId: NonEmptyStringSchema,
   callerId: NonEmptyStringSchema,
   callerName: NonEmptyStringSchema,

--- a/shared/push-notifications/request-schemas.js
+++ b/shared/push-notifications/request-schemas.js
@@ -6,7 +6,7 @@ import {
   WebPushSubscriptionSchema,
 } from './storage-schemas.js';
 
-export const OutboundCallNotificationDataSchema = z.object({
+const OutboundCallNotificationDataBaseSchema = z.object({
   // Optional only at this deployed-client boundary. New incoming-call sends
   // include it; missed calls do not carry a completed invite's identifier.
   callInviteId: NonEmptyStringSchema.optional(),
@@ -17,13 +17,24 @@ export const OutboundCallNotificationDataSchema = z.object({
   type: z.enum(['incoming_call', 'missed_call']).default('incoming_call'),
 });
 
+export const OutboundCallNotificationDataSchema =
+  OutboundCallNotificationDataBaseSchema.superRefine((data, ctx) => {
+    if (data.type === 'incoming_call' && !data.callInviteId) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['callInviteId'],
+        message: 'callInviteId is required for incoming calls',
+      });
+    }
+  });
+
 export const SendCallNotificationRequestSchema = z.object({
   targetUserId: NonEmptyStringSchema,
   callData: OutboundCallNotificationDataSchema,
 });
 
 export const SendDebugCallNotificationRequestSchema = z.object({
-  callData: OutboundCallNotificationDataSchema.partial().optional(),
+  callData: OutboundCallNotificationDataBaseSchema.partial().optional(),
 });
 
 export const RemovePushSubscriptionRequestSchema = z.object({

--- a/shared/user-mailbox/protocol.ts
+++ b/shared/user-mailbox/protocol.ts
@@ -16,6 +16,7 @@
  */
 
 export interface MailboxInvite {
+  callInviteId: string;
   roomId: string;
   callerId: string;
   calleeId: string;
@@ -26,6 +27,7 @@ export interface MailboxInvite {
 }
 
 export interface MailboxResponse {
+  callInviteId: string;
   roomId: string;
   responseType: 'accepted' | 'rejected' | 'busy';
   by: string;
@@ -44,8 +46,8 @@ export interface MailboxResponse {
 export type MailboxEnvelope =
   | { t: 'invite'; invite: MailboxInvite }
   | { t: 'response'; response: MailboxResponse }
-  | { t: 'cancel'; roomId: string; by: string }
-  | { t: 'handled'; roomId: string; by: string }
+  | { t: 'cancel'; callInviteId: string; roomId: string; by: string }
+  | { t: 'handled'; callInviteId: string; roomId: string; by: string }
   // Fire-and-forget "a message landed in one of your conversations" ping, fanned
   // to every member except the sender. Not persisted (no resurface on reconnect).
   | { t: 'activity'; conversationId: string; senderId: string; sentAt: number }
@@ -65,6 +67,7 @@ export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
     const i = e.invite as Record<string, unknown> | undefined;
     return (
       !!i &&
+      typeof i.callInviteId === 'string' &&
       typeof i.roomId === 'string' &&
       typeof i.callerId === 'string' &&
       typeof i.calleeId === 'string' &&
@@ -75,6 +78,7 @@ export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
     const r = e.response as Record<string, unknown> | undefined;
     return (
       !!r &&
+      typeof r.callInviteId === 'string' &&
       typeof r.roomId === 'string' &&
       (r.responseType === 'accepted' ||
         r.responseType === 'rejected' ||
@@ -84,7 +88,11 @@ export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
     );
   }
   if (e.t === 'cancel' || e.t === 'handled') {
-    return typeof e.roomId === 'string' && typeof e.by === 'string';
+    return (
+      typeof e.callInviteId === 'string' &&
+      typeof e.roomId === 'string' &&
+      typeof e.by === 'string'
+    );
   }
   if (e.t === 'activity') {
     return (

--- a/src/app/SWNavigation.test.jsx
+++ b/src/app/SWNavigation.test.jsx
@@ -144,13 +144,14 @@ describe('SWNavigation', () => {
     messageListener?.({
       data: {
         type: 'NAVIGATE',
-        path: '/?call=1&conversationId=room-1&callerId=caller-1&callerName=Caller&accept=1',
+        path: '/?call=1&conversationId=room-1&callInviteId=call-invite-1&callerId=caller-1&callerName=Caller&accept=1',
       },
     });
 
     expect(mocks.publish).toHaveBeenCalledWith(
       'evt:call:notification:opened',
       expect.objectContaining({
+        callInviteId: 'call-invite-1',
         roomId: 'room-1',
         callerId: 'caller-1',
         callerName: 'Caller',

--- a/src/app/SWNavigation.tsx
+++ b/src/app/SWNavigation.tsx
@@ -39,6 +39,7 @@ function dispatchUrl(url: URL): void {
     : null;
   if (callConversationId) {
     publish('evt:call:notification:opened', {
+      callInviteId: trimmedParam(url.searchParams, 'callInviteId') ?? undefined,
       roomId: callConversationId,
       callerId: trimmedParam(url.searchParams, 'callerId') ?? undefined,
       callerName: trimmedParam(url.searchParams, 'callerName') ?? undefined,

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -424,9 +424,55 @@ describe('CallHandshakeController', () => {
     await flushPromises();
     expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith('[call] incoming acceptance stopped', {
-      reason: 'dismissed-during-acceptance',
+      reason: 'cancelled-during-acceptance',
       roomId: 'room-1',
       callInviteId: CALL_INVITE_ID,
+    });
+  });
+
+  it('keeps accepting when the responding callee receives its handled echo', async () => {
+    const response = deferred();
+    mocks.respondToIncomingCallInvite.mockReturnValue(response.promise);
+    let joinOptions;
+    const onStateChange = vi.fn();
+    const p2p = createP2PMock({
+      join: vi.fn(async (options) => {
+        joinOptions = options;
+        return { roomId: 'room-1', members: ['callee-id'] };
+      }),
+    });
+    const controller = createController(p2p, { onStateChange });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        callInviteId: CALL_INVITE_ID,
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+    controller.acceptIncoming();
+    await flushPromises();
+
+    mocks.incomingCallback?.({
+      type: 'handled',
+      callInviteId: CALL_INVITE_ID,
+      roomId: 'room-1',
+      by: 'callee-id',
+    });
+
+    expect(joinOptions.signal.aborted).toBe(false);
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      direction: 'accepting',
+      call: expect.objectContaining({ callInviteId: CALL_INVITE_ID }),
+    });
+
+    response.resolve();
+    await vi.waitFor(() => {
+      expect(onStateChange).toHaveBeenLastCalledWith(null);
     });
   });
 

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -301,6 +301,88 @@ describe('CallHandshakeController', () => {
     }
   });
 
+  it('does not accept when the invite expires before a delayed join resolves', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+    try {
+      const join = deferred();
+      let joinOptions;
+      const p2p = createP2PMock({
+        join: vi.fn((options) => {
+          joinOptions = options;
+          return join.promise;
+        }),
+      });
+      const controller = createController(p2p);
+
+      controller.init();
+      mocks.incomingCallback?.({
+        type: 'invite',
+        invite: {
+          callInviteId: CALL_INVITE_ID,
+          roomId: 'room-1',
+          callerId: 'caller-id',
+          callerName: 'Caller',
+          startedAt: Date.now(),
+          expiresAt: Date.now() + 1_000,
+        },
+      });
+      controller.acceptIncoming();
+      await flushPromises();
+
+      // Move the clock past the deadline without running the timeout callback.
+      vi.setSystemTime(Date.now() + 1_000);
+      join.resolve({ roomId: 'room-1', members: ['callee-id'] });
+      await flushPromises();
+
+      expect(joinOptions.signal.aborted).toBe(true);
+      expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts an active acceptance when the invite is dismissed', async () => {
+    const join = deferred();
+    let joinOptions;
+    const onStateChange = vi.fn();
+    const p2p = createP2PMock({
+      join: vi.fn((options) => {
+        joinOptions = options;
+        return join.promise;
+      }),
+    });
+    const controller = createController(p2p, { onStateChange });
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        callInviteId: CALL_INVITE_ID,
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+    controller.acceptIncoming();
+    await flushPromises();
+
+    mocks.incomingCallback?.({
+      type: 'cancel',
+      callInviteId: CALL_INVITE_ID,
+      roomId: 'room-1',
+      by: 'caller-id',
+    });
+
+    expect(joinOptions.signal.aborted).toBe(true);
+    expect(onStateChange).toHaveBeenLastCalledWith(null);
+
+    join.resolve({ roomId: 'room-1', members: ['callee-id'] });
+    await flushPromises();
+    expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+  });
+
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {
     const join = deferred();
     const p2p = createP2PMock({ join: vi.fn(() => join.promise) });

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -110,12 +110,14 @@ function createController(p2p, overrides = {}) {
 
 const { CallHandshakeController } =
   await import('./call-handshake-controller.js');
+const CALL_INVITE_ID = 'call-invite-1';
 
 describe('CallHandshakeController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.incomingCallback = undefined;
     mocks.responseCallback = undefined;
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(CALL_INVITE_ID);
     Object.defineProperty(globalThis, 'navigator', {
       value: {
         mediaDevices: {
@@ -156,6 +158,7 @@ describe('CallHandshakeController', () => {
     mocks.incomingCallback?.({
       type: 'invite',
       invite: {
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -165,6 +168,7 @@ describe('CallHandshakeController', () => {
     });
     mocks.incomingCallback?.({
       type: 'handled',
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       by: 'callee-id',
     });
@@ -183,6 +187,7 @@ describe('CallHandshakeController', () => {
       mocks.incomingCallback?.({
         type: 'invite',
         invite: {
+          callInviteId: CALL_INVITE_ID,
           roomId: 'room-1',
           callerId: 'caller-id',
           callerName: 'Caller',
@@ -209,6 +214,7 @@ describe('CallHandshakeController', () => {
     mocks.incomingCallback?.({
       type: 'invite',
       invite: {
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -232,6 +238,7 @@ describe('CallHandshakeController', () => {
       mocks.incomingCallback?.({
         type: 'invite',
         invite: {
+          callInviteId: CALL_INVITE_ID,
           roomId: 'room-1',
           callerId: 'caller-id',
           callerName: 'Caller',
@@ -252,6 +259,48 @@ describe('CallHandshakeController', () => {
     }
   });
 
+  it('aborts acceptance when media permission resolves after invite expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+    try {
+      const localStream = createMediaStream({ audio: true, video: true });
+      const pendingMedia = deferred();
+      mocks.getUserMedia.mockReturnValue(pendingMedia.promise);
+      const onStateChange = vi.fn();
+      const p2p = createP2PMock();
+      const controller = createController(p2p, { onStateChange });
+
+      controller.init();
+      mocks.incomingCallback?.({
+        type: 'invite',
+        invite: {
+          callInviteId: CALL_INVITE_ID,
+          roomId: 'room-1',
+          callerId: 'caller-id',
+          callerName: 'Caller',
+          startedAt: Date.now(),
+          expiresAt: Date.now() + 1_000,
+        },
+      });
+      controller.acceptIncoming();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushPromises();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(null);
+      expect(p2p.join).not.toHaveBeenCalled();
+      expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+
+      pendingMedia.resolve(localStream);
+      await flushPromises();
+      localStream
+        .getTracks()
+        .forEach((track) => expect(track.stop).toHaveBeenCalledOnce());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {
     const join = deferred();
     const p2p = createP2PMock({ join: vi.fn(() => join.promise) });
@@ -262,6 +311,7 @@ describe('CallHandshakeController', () => {
     mocks.incomingCallback?.({
       type: 'invite',
       invite: {
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -294,6 +344,7 @@ describe('CallHandshakeController', () => {
     await flushPromises();
 
     expect(mocks.respondToIncomingCallInvite).toHaveBeenCalledWith({
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       callerId: 'caller-id',
       responseType: 'accepted',
@@ -325,6 +376,7 @@ describe('CallHandshakeController', () => {
     });
     const controller = createController(p2p);
     controller.showIncomingCallFromNotification({
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       callerId: 'caller-id',
     });
@@ -373,6 +425,7 @@ describe('CallHandshakeController', () => {
       });
       const controller = createController(p2p);
       controller.showIncomingCallFromNotification({
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
       });
@@ -407,6 +460,7 @@ describe('CallHandshakeController', () => {
     });
     const controller = createController(p2p);
     controller.showIncomingCallFromNotification({
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       callerId: 'caller-id',
     });
@@ -448,6 +502,7 @@ describe('CallHandshakeController', () => {
     mocks.incomingCallback?.({
       type: 'invite',
       invite: {
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -495,6 +550,7 @@ describe('CallHandshakeController', () => {
       const controller = createController(p2p, { onReconnectStatus });
 
       controller.showIncomingCallFromNotification({
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -541,6 +597,7 @@ describe('CallHandshakeController', () => {
       const controller = createController(p2p, { onReconnectStatus });
 
       controller.showIncomingCallFromNotification({
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -592,6 +649,7 @@ describe('CallHandshakeController', () => {
     const controller = createController(p2p, { onReconnectStatus });
 
     controller.showIncomingCallFromNotification({
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       callerId: 'caller-id',
       callerName: 'Caller',
@@ -629,6 +687,7 @@ describe('CallHandshakeController', () => {
       const controller = createController(p2p, { onReconnectStatus });
 
       controller.showIncomingCallFromNotification({
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -670,6 +729,7 @@ describe('CallHandshakeController', () => {
     mocks.incomingCallback?.({
       type: 'invite',
       invite: {
+        callInviteId: CALL_INVITE_ID,
         roomId: 'room-1',
         callerId: 'caller-id',
         callerName: 'Caller',
@@ -705,6 +765,7 @@ describe('CallHandshakeController', () => {
     expect(mocks.responseCallback).toBeTypeOf('function');
 
     const response = mocks.responseCallback?.({
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       responseType: 'accepted',
       by: 'callee-id',
@@ -722,7 +783,10 @@ describe('CallHandshakeController', () => {
 
     join.resolve({ roomId: 'room-1', members: ['caller-id'] });
     await response;
-    expect(mocks.ackCallResponse).toHaveBeenCalledWith('room-1');
+    expect(mocks.ackCallResponse).toHaveBeenCalledWith(
+      'room-1',
+      CALL_INVITE_ID,
+    );
   });
 
   it('publishes declined when the callee rejects', async () => {
@@ -737,6 +801,7 @@ describe('CallHandshakeController', () => {
       audioOnly: false,
     });
     await mocks.responseCallback?.({
+      callInviteId: CALL_INVITE_ID,
       roomId: 'room-1',
       responseType: 'rejected',
       by: 'callee-id',

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -230,6 +230,7 @@ describe('CallHandshakeController', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
     try {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
       const onStateChange = vi.fn();
       const p2p = createP2PMock();
       const controller = createController(p2p, { onStateChange });
@@ -254,9 +255,43 @@ describe('CallHandshakeController', () => {
       expect(mocks.getUserMedia).not.toHaveBeenCalled();
       expect(p2p.join).not.toHaveBeenCalled();
       expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith('[call] incoming acceptance stopped', {
+        reason: 'expired-before-start',
+        roomId: 'room-1',
+        callInviteId: CALL_INVITE_ID,
+      });
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('logs when incoming acceptance cannot start without its service', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = createController(createP2PMock());
+
+    controller.init();
+    mocks.incomingCallback?.({
+      type: 'invite',
+      invite: {
+        callInviteId: CALL_INVITE_ID,
+        roomId: 'room-1',
+        callerId: 'caller-id',
+        callerName: 'Caller',
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+    mocks.getCallService.mockReturnValue(null);
+
+    controller.acceptIncoming();
+
+    expect(warn).toHaveBeenCalledWith(
+      '[call] incoming acceptance unavailable',
+      {
+        reason: 'service-unavailable',
+        roomId: 'room-1',
+        callInviteId: CALL_INVITE_ID,
+      },
+    );
   });
 
   it('aborts acceptance when media permission resolves after invite expiry', async () => {
@@ -305,6 +340,7 @@ describe('CallHandshakeController', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
     try {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
       const join = deferred();
       let joinOptions;
       const p2p = createP2PMock({
@@ -337,12 +373,18 @@ describe('CallHandshakeController', () => {
 
       expect(joinOptions.signal.aborted).toBe(true);
       expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith('[call] incoming acceptance stopped', {
+        reason: 'expired-during-acceptance',
+        roomId: 'room-1',
+        callInviteId: CALL_INVITE_ID,
+      });
     } finally {
       vi.useRealTimers();
     }
   });
 
   it('aborts an active acceptance when the invite is dismissed', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     const join = deferred();
     let joinOptions;
     const onStateChange = vi.fn();
@@ -381,6 +423,11 @@ describe('CallHandshakeController', () => {
     join.resolve({ roomId: 'room-1', members: ['callee-id'] });
     await flushPromises();
     expect(mocks.respondToIncomingCallInvite).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('[call] incoming acceptance stopped', {
+      reason: 'dismissed-during-acceptance',
+      roomId: 'room-1',
+      callInviteId: CALL_INVITE_ID,
+    });
   });
 
   it('joins the room before notifying the caller that an incoming call was accepted', async () => {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -203,11 +203,17 @@ export class CallHandshakeController {
 
     this.unsubscribeIncomingCall = callService.onIncomingCall((event) => {
       if (event.type === 'cancel' || event.type === 'handled') {
+        const state = this._handshakeState;
         if (
-          this._handshakeState &&
-          this._handshakeState.direction === 'incoming' &&
-          this._handshakeState.call.callInviteId === event.callInviteId
+          state &&
+          (state.direction === 'incoming' || state.direction === 'accepting') &&
+          state.call.callInviteId === event.callInviteId
         ) {
+          if (state.direction === 'accepting') {
+            this.incomingAcceptanceAbortController?.abort(
+              new DOMException('Call invite dismissed', 'AbortError'),
+            );
+          }
           this.setHandshakeState(null);
         }
         return;
@@ -671,6 +677,11 @@ export class CallHandshakeController {
       { signal },
     )
       .then(() => {
+        if (this.isExpired(state.call) && !signal.aborted) {
+          abortController.abort(
+            new DOMException('Call invite expired', 'TimeoutError'),
+          );
+        }
         if (signal.aborted) throw signal.reason;
         return svc.respondToIncomingCallInvite({
           callInviteId: state.call.callInviteId,

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -90,6 +90,7 @@ const CONNECTED_TIMEOUT_MS = 20_000;
 const CONNECT_FAILED_DISPLAY_MS = 4_000;
 
 export type IncomingCallNotificationDetails = {
+  callInviteId: string;
   roomId: string;
   callerId: string;
   callerName?: string;
@@ -100,6 +101,7 @@ export type IncomingCallNotificationDetails = {
 type EnterRoomOptions = {
   memberCapacity?: number;
   autoExitOnEmpty?: boolean;
+  signal?: AbortSignal;
 };
 
 /** Why a call was torn down — logged so field reports are unambiguous. */
@@ -120,6 +122,7 @@ export class CallHandshakeController {
   private readonly onReconnectStatus: (status: CallReconnectStatus) => void;
 
   private _handshakeState: CallHandshakeState = null;
+  private incomingAcceptanceAbortController: AbortController | undefined;
   private incomingCallTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private outgoingCallTimeoutId: ReturnType<typeof setTimeout> | undefined;
   private calleeBusyResetTimeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -203,7 +206,7 @@ export class CallHandshakeController {
         if (
           this._handshakeState &&
           this._handshakeState.direction === 'incoming' &&
-          this._handshakeState.call.roomId === event.roomId
+          this._handshakeState.call.callInviteId === event.callInviteId
         ) {
           this.setHandshakeState(null);
         }
@@ -217,9 +220,16 @@ export class CallHandshakeController {
     details: IncomingCallNotificationDetails,
   ): void {
     const localUID = getLoggedInUserId();
-    if (!localUID || !details.roomId || !details.callerId) return;
+    if (
+      !localUID ||
+      !details.callInviteId ||
+      !details.roomId ||
+      !details.callerId
+    )
+      return;
     const startedAt = details.startedAt ?? Date.now();
     const call: MailboxInvite = {
+      callInviteId: details.callInviteId,
       roomId: details.roomId,
       callerId: details.callerId,
       calleeId: localUID,
@@ -240,6 +250,7 @@ export class CallHandshakeController {
     if (this.isBusyForIncomingCall(call)) {
       callService
         .respondToIncomingCallInvite({
+          callInviteId: call.callInviteId,
           roomId: call.roomId,
           callerId: call.callerId,
           responseType: 'busy',
@@ -257,7 +268,7 @@ export class CallHandshakeController {
           const state = this._handshakeState;
           if (
             state?.direction === 'incoming' &&
-            state.call.roomId === call.roomId &&
+            state.call.callInviteId === call.callInviteId &&
             this.isExpired(state.call)
           ) {
             this.setHandshakeState(null);
@@ -326,6 +337,7 @@ export class CallHandshakeController {
     }
 
     const nextOutgoingCall: OutgoingCall = {
+      callInviteId: crypto.randomUUID(),
       calleeId,
       calleeName,
       callerId: localUID,
@@ -356,7 +368,8 @@ export class CallHandshakeController {
     let responseReceived = false;
     this.unsubCalleeResponse?.();
     this.unsubCalleeResponse = svc.onCalleeResponse(async (response) => {
-      if (!response || response.roomId !== roomId) return;
+      if (!response || response.callInviteId !== nextOutgoingCall.callInviteId)
+        return;
       responseReceived = true;
       this.clearOutgoingCallTracking();
       try {
@@ -394,7 +407,7 @@ export class CallHandshakeController {
         this.hangUp('enter-room-error');
       } finally {
         svc
-          .ackCallResponse(response.roomId)
+          .ackCallResponse(response.roomId, response.callInviteId)
           .catch((err) =>
             console.warn(
               '[CallHandshake] Failed to acknowledge call response:',
@@ -407,6 +420,7 @@ export class CallHandshakeController {
 
     try {
       await svc.sendOutgoingCallInvite({
+        callInviteId: nextOutgoingCall.callInviteId,
         roomId,
         calleeId,
         callerName,
@@ -426,7 +440,7 @@ export class CallHandshakeController {
       state &&
       !responseReceived &&
       state.direction === 'outgoing' &&
-      state.call.roomId === roomId
+      state.call.callInviteId === nextOutgoingCall.callInviteId
     ) {
       publish('evt:call:invite:sent', nextOutgoingCall);
     }
@@ -460,11 +474,19 @@ export class CallHandshakeController {
     localUID: string,
     audioOnly = false,
     getLocalStream?: () => Promise<MediaStream>,
-    { memberCapacity = 2, autoExitOnEmpty = true }: EnterRoomOptions = {},
+    {
+      memberCapacity = 2,
+      autoExitOnEmpty = true,
+      signal,
+    }: EnterRoomOptions = {},
   ) {
     const localStream = await (
-      getLocalStream ?? (() => this.getCallLocalStream(audioOnly))
+      getLocalStream ?? (() => this.getCallLocalStream(audioOnly, signal))
     )();
+    if (signal?.aborted) {
+      this.stopMediaStream(localStream);
+      throw signal.reason;
+    }
     this.resetReconnectState();
     let room;
     try {
@@ -489,6 +511,7 @@ export class CallHandshakeController {
         iceServersProvider: provideIceServers,
         iceRecovery: {},
         connectedTimeoutMs: CONNECTED_TIMEOUT_MS,
+        signal,
         onError: ({ error }) => this.handleRoomError(error),
         onMemberJoined: () => {
           // A (re)join cancels any in-progress reconnect grace; the peer's back.
@@ -521,11 +544,31 @@ export class CallHandshakeController {
     return room;
   }
 
-  private getCallLocalStream(audioOnly: boolean): Promise<MediaStream> {
-    return navigator.mediaDevices.getUserMedia({
+  private async getCallLocalStream(
+    audioOnly: boolean,
+    signal?: AbortSignal,
+  ): Promise<MediaStream> {
+    const streamPromise = navigator.mediaDevices.getUserMedia({
       video: audioOnly ? false : getVideoConstraints(),
       audio: getAudioConstraints(),
     });
+    if (!signal) return streamPromise;
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      signal.addEventListener(
+        'abort',
+        () =>
+          reject(signal.reason ?? new DOMException('Aborted', 'AbortError')),
+        { once: true },
+      );
+    });
+    void streamPromise.then(
+      (stream) => {
+        if (signal.aborted) this.stopMediaStream(stream);
+      },
+      () => {},
+    );
+    return Promise.race([streamPromise, abortPromise]);
   }
 
   private stopMediaStream(stream: MediaStream): void {
@@ -548,7 +591,7 @@ export class CallHandshakeController {
       if (
         !state ||
         state.direction !== 'outgoing' ||
-        state.call.roomId !== call.roomId
+        state.call.callInviteId !== call.callInviteId
       )
         return;
       this.setHandshakeState(null);
@@ -556,6 +599,7 @@ export class CallHandshakeController {
       this.stopPendingOutgoingLocalStream();
       callService
         .cancelOutgoingCall({
+          callInviteId: call.callInviteId,
           calleeId: call.calleeId,
           roomId: call.roomId,
         })
@@ -580,6 +624,7 @@ export class CallHandshakeController {
     publish('evt:call:invite:unanswered', state.call);
     svc
       .cancelOutgoingCall({
+        callInviteId: state.call.callInviteId,
         calleeId: state.call.calleeId,
         roomId: state.call.roomId,
       })
@@ -602,20 +647,55 @@ export class CallHandshakeController {
     const localUID = getLoggedInUserId();
     if (!svc || !localUID) return;
     this.clearOutgoingCallTracking();
+    this.incomingAcceptanceAbortController?.abort();
+    const abortController = new AbortController();
+    this.incomingAcceptanceAbortController = abortController;
     this.setHandshakeState({ direction: 'accepting', call: state.call });
-    this.enterRoom(state.call.roomId, localUID, state.call.audioOnly ?? false)
-      .then(() =>
-        svc.respondToIncomingCallInvite({
+    if (state.call.expiresAt != null) {
+      this.incomingCallTimeoutId = setTimeout(
+        () => {
+          this.incomingCallTimeoutId = undefined;
+          abortController.abort(
+            new DOMException('Call invite expired', 'TimeoutError'),
+          );
+        },
+        Math.max(0, state.call.expiresAt - Date.now()),
+      );
+    }
+    const { signal } = abortController;
+    this.enterRoom(
+      state.call.roomId,
+      localUID,
+      state.call.audioOnly ?? false,
+      undefined,
+      { signal },
+    )
+      .then(() => {
+        if (signal.aborted) throw signal.reason;
+        return svc.respondToIncomingCallInvite({
+          callInviteId: state.call.callInviteId,
           roomId: state.call.roomId,
           callerId: state.call.callerId,
           responseType: 'accepted',
-        }),
-      )
+        });
+      })
       .catch((err) => {
+        if (signal.aborted) return;
         console.error('Error accepting incoming call:', err);
         this.hangUp('accept-error');
       })
-      .finally(() => this.setHandshakeState(null));
+      .finally(() => {
+        if (this.incomingAcceptanceAbortController === abortController) {
+          this.incomingAcceptanceAbortController = undefined;
+        }
+        const current = this._handshakeState;
+        if (
+          current?.direction === 'accepting' &&
+          current.call.callInviteId === state.call.callInviteId
+        ) {
+          this.setHandshakeState(null);
+        }
+      });
   };
 
   declineIncoming = (): void => {
@@ -626,6 +706,7 @@ export class CallHandshakeController {
     this.setHandshakeState(null);
     svc
       .respondToIncomingCallInvite({
+        callInviteId: state.call.callInviteId,
         roomId: state.call.roomId,
         callerId: state.call.callerId,
         responseType: 'rejected',
@@ -747,6 +828,8 @@ export class CallHandshakeController {
 
   cleanup(): void {
     this.outgoingMediaAttempt += 1;
+    this.incomingAcceptanceAbortController?.abort();
+    this.incomingAcceptanceAbortController = undefined;
     this.unsubscribeIncomingCall?.();
     this.unsubscribeIncomingCall = undefined;
     this.clearOutgoingCallTracking();

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -646,12 +646,24 @@ export class CallHandshakeController {
     const state = this._handshakeState;
     if (!state || state.direction !== 'incoming') return;
     if (this.isExpired(state.call)) {
+      console.log('[call] incoming acceptance stopped', {
+        reason: 'expired-before-start',
+        roomId: state.call.roomId,
+        callInviteId: state.call.callInviteId,
+      });
       this.setHandshakeState(null);
       return;
     }
     const svc = getCallService();
     const localUID = getLoggedInUserId();
-    if (!svc || !localUID) return;
+    if (!svc || !localUID) {
+      console.warn('[call] incoming acceptance unavailable', {
+        reason: svc ? 'not-authenticated' : 'service-unavailable',
+        roomId: state.call.roomId,
+        callInviteId: state.call.callInviteId,
+      });
+      return;
+    }
     this.clearOutgoingCallTracking();
     this.incomingAcceptanceAbortController?.abort();
     const abortController = new AbortController();
@@ -691,7 +703,24 @@ export class CallHandshakeController {
         });
       })
       .catch((err) => {
-        if (signal.aborted) return;
+        if (signal.aborted) {
+          const reason = signal.reason;
+          const stopReason =
+            reason instanceof DOMException && reason.name === 'TimeoutError'
+              ? 'expired-during-acceptance'
+              : reason instanceof DOMException &&
+                  reason.message === 'Call invite dismissed'
+                ? 'dismissed-during-acceptance'
+                : null;
+          if (stopReason) {
+            console.log('[call] incoming acceptance stopped', {
+              reason: stopReason,
+              roomId: state.call.roomId,
+              callInviteId: state.call.callInviteId,
+            });
+          }
+          return;
+        }
         console.error('Error accepting incoming call:', err);
         this.hangUp('accept-error');
       })

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -204,17 +204,20 @@ export class CallHandshakeController {
     this.unsubscribeIncomingCall = callService.onIncomingCall((event) => {
       if (event.type === 'cancel' || event.type === 'handled') {
         const state = this._handshakeState;
-        if (
-          state &&
-          (state.direction === 'incoming' || state.direction === 'accepting') &&
-          state.call.callInviteId === event.callInviteId
-        ) {
-          if (state.direction === 'accepting') {
+        if (state && state.call.callInviteId === event.callInviteId) {
+          if (state.direction === 'incoming') {
+            this.setHandshakeState(null);
+          } else if (
+            state.direction === 'accepting' &&
+            event.type === 'cancel'
+          ) {
+            // `handled` is echoed to the responding callee too; only a caller
+            // cancellation invalidates an acceptance already in progress.
             this.incomingAcceptanceAbortController?.abort(
-              new DOMException('Call invite dismissed', 'AbortError'),
+              new DOMException('Call invite cancelled', 'AbortError'),
             );
+            this.setHandshakeState(null);
           }
-          this.setHandshakeState(null);
         }
         return;
       }
@@ -709,8 +712,8 @@ export class CallHandshakeController {
             reason instanceof DOMException && reason.name === 'TimeoutError'
               ? 'expired-during-acceptance'
               : reason instanceof DOMException &&
-                  reason.message === 'Call invite dismissed'
-                ? 'dismissed-during-acceptance'
+                  reason.message === 'Call invite cancelled'
+                ? 'cancelled-during-acceptance'
                 : null;
           if (stopReason) {
             console.log('[call] incoming acceptance stopped', {

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -155,6 +155,7 @@ describe('CallHandshakeProvider', () => {
 
     const handler = mocks.subscriptions.get('evt:call:notification:opened');
     handler?.({
+      callInviteId: 'call-invite-1',
       roomId: 'room-1',
       callerId: 'caller-1',
       callerName: 'Caller',
@@ -162,6 +163,7 @@ describe('CallHandshakeProvider', () => {
     });
 
     expect(mocks.showIncomingCallFromNotification).toHaveBeenCalledWith({
+      callInviteId: 'call-invite-1',
       roomId: 'room-1',
       callerId: 'caller-1',
       callerName: 'Caller',
@@ -174,7 +176,7 @@ describe('CallHandshakeProvider', () => {
     window.history.replaceState(
       null,
       '',
-      '/?call=1&conversationId=room-1&callerId=caller-1',
+      '/?call=1&conversationId=room-1&callInviteId=call-invite-1&callerId=caller-1',
     );
     const { CallHandshakeProvider } = await import('./call-handshake');
     const [user] = createSignal({ uid: 'u1' });
@@ -184,6 +186,7 @@ describe('CallHandshakeProvider', () => {
 
     expect(mocks.showIncomingCallFromNotification).toHaveBeenCalledWith(
       expect.objectContaining({
+        callInviteId: 'call-invite-1',
         roomId: 'room-1',
         callerId: 'caller-1',
         startedAt: undefined,

--- a/src/features/call/call-handshake.test.jsx
+++ b/src/features/call/call-handshake.test.jsx
@@ -172,6 +172,27 @@ describe('CallHandshakeProvider', () => {
     });
   });
 
+  it('logs missing correlation data without surfacing the notification', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { CallHandshakeProvider } = await import('./call-handshake');
+    const [user] = createSignal({ uid: 'u1' });
+    mocks.user = user;
+
+    render(() => <CallHandshakeProvider>{null}</CallHandshakeProvider>);
+
+    const handler = mocks.subscriptions.get('evt:call:notification:opened');
+    handler?.({
+      roomId: 'room-1',
+      callerId: 'caller-1',
+    });
+
+    expect(mocks.showIncomingCallFromNotification).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      '[call] ignored invalid incoming-call notification',
+      { source: 'event', missing: ['callInviteId'] },
+    );
+  });
+
   it('keeps a missing notification URL timestamp undefined', async () => {
     window.history.replaceState(
       null,

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -64,7 +64,17 @@ function incomingCallNotificationDetailsFromParams(
   const roomId = params.get('conversationId');
   const callInviteId = params.get('callInviteId');
   const callerId = params.get('callerId');
-  if (!callInviteId || !roomId || !callerId) return null;
+  if (!callInviteId || !roomId || !callerId) {
+    console.warn('[call] ignored invalid incoming-call notification', {
+      source: 'url',
+      missing: [
+        ...(!callInviteId ? ['callInviteId'] : []),
+        ...(!roomId ? ['conversationId'] : []),
+        ...(!callerId ? ['callerId'] : []),
+      ],
+    });
+    return null;
+  }
 
   return {
     callInviteId,
@@ -79,16 +89,27 @@ function incomingCallNotificationDetailsFromParams(
 function incomingCallNotificationDetailsFromPayload(
   payload: IncomingCallNotificationOpenedPayload,
 ): IncomingCallNotificationDetails | null {
-  if (
-    typeof payload.roomId !== 'string' ||
-    typeof payload.callInviteId !== 'string' ||
-    typeof payload.callerId !== 'string'
-  )
+  const callInviteId =
+    typeof payload.callInviteId === 'string' ? payload.callInviteId : undefined;
+  const roomId =
+    typeof payload.roomId === 'string' ? payload.roomId : undefined;
+  const callerId =
+    typeof payload.callerId === 'string' ? payload.callerId : undefined;
+  if (!callInviteId || !roomId || !callerId) {
+    console.warn('[call] ignored invalid incoming-call notification', {
+      source: 'event',
+      missing: [
+        ...(!callInviteId ? ['callInviteId'] : []),
+        ...(!roomId ? ['roomId'] : []),
+        ...(!callerId ? ['callerId'] : []),
+      ],
+    });
     return null;
+  }
   return {
-    callInviteId: payload.callInviteId,
-    roomId: payload.roomId,
-    callerId: payload.callerId,
+    callInviteId,
+    roomId,
+    callerId,
     callerName:
       typeof payload.callerName === 'string' ? payload.callerName : undefined,
     audioOnly: payload.audioOnly === true,

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -169,13 +169,17 @@ export function CallHandshakeProvider(props: ParentProps) {
   if (typeof window !== 'undefined') {
     const params = new URLSearchParams(window.location.search);
     const hasAcceptMarker = params.get('accept') === '1';
+    const initialNotificationDetails =
+      incomingCallNotificationDetailsFromParams(params);
     const [queuedNotificationDetails, setQueuedNotificationDetails] =
       createSignal<IncomingCallNotificationDetails | null>(
-        incomingCallNotificationDetailsFromParams(params),
+        initialNotificationDetails,
       );
-    const [wantAcceptRoomId, setWantAcceptRoomId] = createSignal<string | null>(
+    const [wantAcceptCallInviteId, setWantAcceptCallInviteId] = createSignal<
+      string | null
+    >(
       ENABLE_NOTIFICATION_AUTO_ACCEPT && hasAcceptMarker
-        ? params.get('conversationId')
+        ? (initialNotificationDetails?.callInviteId ?? null)
         : null,
     );
     if (hasAcceptMarker) {
@@ -202,9 +206,9 @@ export function CallHandshakeProvider(props: ParentProps) {
         if (
           ENABLE_NOTIFICATION_AUTO_ACCEPT &&
           payload.accept &&
-          typeof payload.roomId === 'string'
+          notificationDetails
         ) {
-          setWantAcceptRoomId(payload.roomId);
+          setWantAcceptCallInviteId(notificationDetails.callInviteId);
         }
       },
     );
@@ -220,9 +224,9 @@ export function CallHandshakeProvider(props: ParentProps) {
 
     createEffect(() => {
       const call = incomingCall();
-      const roomId = wantAcceptRoomId();
-      if (roomId && call?.roomId === roomId) {
-        setWantAcceptRoomId(null);
+      const callInviteId = wantAcceptCallInviteId();
+      if (callInviteId && call?.callInviteId === callInviteId) {
+        setWantAcceptCallInviteId(null);
         controller.acceptIncoming();
       }
     });

--- a/src/features/call/call-handshake.tsx
+++ b/src/features/call/call-handshake.tsx
@@ -62,10 +62,12 @@ function incomingCallNotificationDetailsFromParams(
   // plain open-conversation link handled by SWNavigation.
   if (params.get('call') !== '1') return null;
   const roomId = params.get('conversationId');
+  const callInviteId = params.get('callInviteId');
   const callerId = params.get('callerId');
-  if (!roomId || !callerId) return null;
+  if (!callInviteId || !roomId || !callerId) return null;
 
   return {
+    callInviteId,
     roomId,
     callerId,
     callerName: params.get('callerName') || undefined,
@@ -79,10 +81,12 @@ function incomingCallNotificationDetailsFromPayload(
 ): IncomingCallNotificationDetails | null {
   if (
     typeof payload.roomId !== 'string' ||
+    typeof payload.callInviteId !== 'string' ||
     typeof payload.callerId !== 'string'
   )
     return null;
   return {
+    callInviteId: payload.callInviteId,
     roomId: payload.roomId,
     callerId: payload.callerId,
     callerName:

--- a/src/features/call/call-service.test.js
+++ b/src/features/call/call-service.test.js
@@ -64,12 +64,14 @@ describe('initCallService', () => {
     service.onIncomingCall(callback);
     mocks.envelopeCallback?.({
       t: 'handled',
+      callInviteId: 'call-invite-1',
       roomId: 'room-1',
       by: 'callee-id',
     });
 
     expect(callback).toHaveBeenCalledWith({
       type: 'handled',
+      callInviteId: 'call-invite-1',
       roomId: 'room-1',
       by: 'callee-id',
     });
@@ -91,6 +93,7 @@ describe('initCallService', () => {
     });
 
     const response = service.respondToIncomingCallInvite({
+      callInviteId: 'call-invite-1',
       roomId: 'room-1',
       callerId: 'caller-id',
       responseType: 'accepted',
@@ -104,6 +107,7 @@ describe('initCallService', () => {
     expect(url).toBe('http://localhost:8788/calls/response');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual({
+      callInviteId: 'call-invite-1',
       conversationId: 'room-1',
       callerId: 'caller-id',
       responseType: 'accepted',
@@ -133,6 +137,7 @@ describe('initCallService', () => {
     });
 
     const response = service.respondToIncomingCallInvite({
+      callInviteId: 'call-invite-1',
       roomId: 'room-1',
       callerId: 'caller-id',
       responseType: 'accepted',
@@ -156,6 +161,7 @@ describe('initCallService', () => {
 
     const response = expect(
       service.respondToIncomingCallInvite({
+        callInviteId: 'call-invite-1',
         roomId: 'room-1',
         callerId: 'caller-id',
         responseType: 'rejected',

--- a/src/features/call/call-service.ts
+++ b/src/features/call/call-service.ts
@@ -9,8 +9,8 @@ import { reportApiAuthFailure } from '../../infra/api-auth-failure.js';
 
 export type IncomingCallEvent =
   | { type: 'invite'; invite: MailboxInvite }
-  | { type: 'cancel'; roomId: string; by: string }
-  | { type: 'handled'; roomId: string; by: string };
+  | { type: 'cancel'; callInviteId: string; roomId: string; by: string }
+  | { type: 'handled'; callInviteId: string; roomId: string; by: string };
 
 interface CallServiceOptions {
   localUID: string;
@@ -164,6 +164,7 @@ export class CallService {
       } else if (envelope.t === 'cancel' || envelope.t === 'handled') {
         callback({
           type: envelope.t,
+          callInviteId: envelope.callInviteId,
           roomId: envelope.roomId,
           by: envelope.by,
         });
@@ -172,17 +173,20 @@ export class CallService {
   }
 
   async sendOutgoingCallInvite({
+    callInviteId,
     roomId,
     calleeId,
     callerName,
     audioOnly,
   }: {
+    callInviteId: string;
     roomId: string;
     calleeId: string;
     callerName: string;
     audioOnly: boolean;
   }): Promise<void> {
     await this.post('/calls/invite', {
+      callInviteId,
       conversationId: roomId,
       calleeId,
       callerName,
@@ -192,10 +196,12 @@ export class CallService {
   }
 
   async respondToIncomingCallInvite({
+    callInviteId,
     roomId,
     callerId,
     responseType,
   }: {
+    callInviteId: string;
     roomId: string;
     callerId: string;
     responseType: MailboxResponse['responseType'];
@@ -203,6 +209,7 @@ export class CallService {
     await this.post(
       '/calls/response',
       {
+        callInviteId,
         conversationId: roomId,
         callerId,
         responseType,
@@ -213,13 +220,16 @@ export class CallService {
   }
 
   cancelOutgoingCall({
+    callInviteId,
     calleeId,
     roomId,
   }: {
+    callInviteId: string;
     calleeId: string;
     roomId: string;
   }): Promise<void> {
     return this.post('/calls/cancel', {
+      callInviteId,
       conversationId: roomId,
       calleeId,
     });
@@ -236,8 +246,11 @@ export class CallService {
     });
   }
 
-  ackCallResponse(roomId: string): Promise<void> {
-    return this.post('/calls/response/ack', { conversationId: roomId });
+  ackCallResponse(roomId: string, callInviteId: string): Promise<void> {
+    return this.post('/calls/response/ack', {
+      conversationId: roomId,
+      callInviteId,
+    });
   }
 
   cleanup(): void {

--- a/src/features/call/call-types.ts
+++ b/src/features/call/call-types.ts
@@ -1,6 +1,7 @@
 import type { MailboxInvite } from '../../../shared/user-mailbox/protocol';
 
 export type OutgoingCall = {
+  callInviteId: string;
   calleeId: string;
   calleeName: string;
   callerId: string;

--- a/src/features/call/components/ParticipantMedia.test.jsx
+++ b/src/features/call/components/ParticipantMedia.test.jsx
@@ -172,6 +172,7 @@ describe('ParticipantMedia', () => {
   });
 
   it('shows the continue-call prompt only for autoplay-gesture rejections', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     HTMLMediaElement.prototype.play.mockRejectedValue(
       Object.assign(new Error('gesture required'), {
         name: 'NotAllowedError',
@@ -184,6 +185,11 @@ describe('ParticipantMedia', () => {
       expect(container.querySelector('button')?.textContent).toBe(
         'Continue call',
       );
+    });
+    expect(warn).toHaveBeenCalledWith('[ParticipantMedia] play() rejected', {
+      variant: 'remote',
+      name: 'NotAllowedError',
+      message: 'gesture required',
     });
   });
 

--- a/src/features/call/components/ParticipantMedia.test.jsx
+++ b/src/features/call/components/ParticipantMedia.test.jsx
@@ -188,6 +188,7 @@ describe('ParticipantMedia', () => {
   });
 
   it('ignores transient play() rejections like AbortError', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     HTMLMediaElement.prototype.play.mockRejectedValue(
       Object.assign(new Error('interrupted by a new load request'), {
         name: 'AbortError',
@@ -203,5 +204,6 @@ describe('ParticipantMedia', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(container.querySelector('button')).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/features/call/components/ParticipantMedia.tsx
+++ b/src/features/call/components/ParticipantMedia.tsx
@@ -101,8 +101,8 @@ export function ParticipantMedia(props: ParticipantMediaProps) {
   const playback = createMediaPlayback({
     playsInline: true,
     onPlaybackBlocked: (err) => {
-      if (import.meta.env.DEV) {
-        const error = err as { name?: string; message?: string };
+      const error = err as { name?: string; message?: string };
+      if (import.meta.env.DEV && error?.name !== 'AbortError') {
         console.warn('[ParticipantMedia] play() rejected', {
           variant: variant(),
           name: error?.name,

--- a/src/push/__tests__/push-notifications.browser.test.js
+++ b/src/push/__tests__/push-notifications.browser.test.js
@@ -437,6 +437,14 @@ describe('PushNotifications', () => {
     expect(notifications[1].close).toHaveBeenCalledOnce();
   });
 
+  it('treats a missing service worker registration as nothing to dismiss', async () => {
+    navigator.serviceWorker.getRegistration.mockResolvedValue(null);
+
+    await expect(controller.dismissAllNotifications()).resolves.toBeUndefined();
+
+    expect(registration.getNotifications).not.toHaveBeenCalled();
+  });
+
   it('fails fast when no active service worker registration exists', async () => {
     navigator.serviceWorker.getRegistration.mockResolvedValue(null);
 

--- a/src/push/__tests__/setup.test.js
+++ b/src/push/__tests__/setup.test.js
@@ -133,6 +133,7 @@ describe('push-notifications setup', () => {
 
     await push.setup();
     mocks.handlers.get('evt:call:invite:sent')?.({
+      callInviteId: 'call-invite-1',
       calleeId: 'callee',
       callerId: 'caller',
       callerName: 'Caller',
@@ -141,6 +142,7 @@ describe('push-notifications setup', () => {
 
     expect(sendIncomingCall).toHaveBeenCalledWith({
       targetUserId: 'callee',
+      callInviteId: 'call-invite-1',
       callerId: 'caller',
       callerName: 'Caller',
       roomId: 'room-1',

--- a/src/push/__tests__/shared-contracts.test.js
+++ b/src/push/__tests__/shared-contracts.test.js
@@ -76,6 +76,32 @@ describe('shared push notification contracts', () => {
     expect(request.callData.type).toBe('incoming_call');
   });
 
+  it('requires invite correlation only for incoming-call requests', () => {
+    expect(() =>
+      parseSendCallNotificationRequest({
+        targetUserId: 'bob',
+        callData: {
+          type: 'incoming_call',
+          roomId: 'room-123',
+          callerId: 'alice',
+          callerName: 'Alice',
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      parseSendCallNotificationRequest({
+        targetUserId: 'bob',
+        callData: {
+          type: 'missed_call',
+          roomId: 'room-123',
+          callerId: 'alice',
+          callerName: 'Alice',
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it('parses registerPushSubscription request bodies', () => {
     const request = parseRegisterPushSubscriptionRequest({
       subscription: {

--- a/src/push/__tests__/shared-contracts.test.js
+++ b/src/push/__tests__/shared-contracts.test.js
@@ -15,6 +15,7 @@ describe('shared push notification contracts', () => {
       body: 'Tap to answer',
       data: {
         type: 'incoming_call',
+        callInviteId: 'call-invite-123',
         roomId: 'room-123',
         callerId: 'alice',
         callerName: 'Alice',
@@ -35,6 +36,7 @@ describe('shared push notification contracts', () => {
         body: 'Tap to answer',
         data: {
           type: 'call',
+          callInviteId: 'call-invite-legacy',
           roomId: 'room-legacy',
           callerId: 'alice',
           callerName: 'Alice',
@@ -48,6 +50,7 @@ describe('shared push notification contracts', () => {
     expect(() =>
       parseCanonicalPushNotificationData({
         type: 'call',
+        callInviteId: 'call-invite-legacy',
         roomId: 'room-legacy',
         callerId: 'alice',
         callerName: 'Alice',
@@ -63,6 +66,7 @@ describe('shared push notification contracts', () => {
       targetUserId: 'bob',
       callData: {
         type: 'incoming_call',
+        callInviteId: 'call-invite-123',
         roomId: 'room-123',
         callerId: 'alice',
         callerName: 'Alice',

--- a/src/push/index.js
+++ b/src/push/index.js
@@ -104,6 +104,7 @@ export const setup = createSingleFlightSetup({
     // Payload is the call's { calleeId, roomId, callerId, callerName }.
     const toSendArgs = (call) => ({
       targetUserId: call.calleeId,
+      callInviteId: call.callInviteId,
       roomId: call.roomId,
       callerId: call.callerId,
       callerName: call.callerName,

--- a/src/push/push-notifications.js
+++ b/src/push/push-notifications.js
@@ -481,7 +481,11 @@ export class PushNotifications {
    * Closes every notification delivered by the current service worker.
    */
   async dismissAllNotifications() {
-    const registration = await this.getServiceWorkerRegistration();
+    const registration = await navigator.serviceWorker?.getRegistration();
+    if (!registration) {
+      this.activeNotifications.clear();
+      return;
+    }
     const notifications = await registration.getNotifications();
     notifications.forEach((notification) => notification.close());
     this.activeNotifications.clear();

--- a/src/push/push-notifications.js
+++ b/src/push/push-notifications.js
@@ -589,6 +589,7 @@ export class PushNotifications {
 
   async formatCallNotification(callData) {
     const {
+      callInviteId,
       roomId,
       callerId,
       callerName,
@@ -604,6 +605,7 @@ export class PushNotifications {
     }
 
     return {
+      ...(type === 'incoming_call' && callInviteId ? { callInviteId } : {}),
       roomId,
       callerId,
       callerName: callerLabel,

--- a/src/push/sw/__tests__/notification-click-handler.test.js
+++ b/src/push/sw/__tests__/notification-click-handler.test.js
@@ -12,20 +12,27 @@ describe('notification click routing', () => {
       getNotificationNavigationPath(
         {
           type: 'incoming_call',
+          callInviteId: 'call-invite-123',
           roomId: 'room-123',
         },
         undefined,
       ),
-    ).toBe('/?call=1&conversationId=room-123');
+    ).toBe('/?call=1&conversationId=room-123&callInviteId=call-invite-123');
   });
 
   it('marks the incoming-call path for auto-accept on the explicit accept action', () => {
     expect(
       getNotificationNavigationPath(
-        { type: 'incoming_call', roomId: 'room-123' },
+        {
+          type: 'incoming_call',
+          callInviteId: 'call-invite-123',
+          roomId: 'room-123',
+        },
         'accept',
       ),
-    ).toBe('/?call=1&conversationId=room-123&accept=1');
+    ).toBe(
+      '/?call=1&conversationId=room-123&callInviteId=call-invite-123&accept=1',
+    );
   });
 
   it('carries caller metadata for incoming call notification clicks', () => {
@@ -33,6 +40,7 @@ describe('notification click routing', () => {
       getNotificationNavigationPath(
         {
           type: 'incoming_call',
+          callInviteId: 'call-invite-123',
           roomId: 'room-123',
           callerId: 'caller-1',
           callerName: 'Caller Name',
@@ -41,7 +49,7 @@ describe('notification click routing', () => {
         undefined,
       ),
     ).toBe(
-      '/?call=1&conversationId=room-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
+      '/?call=1&conversationId=room-123&callInviteId=call-invite-123&callerId=caller-1&callerName=Caller+Name&timestamp=1774025000000',
     );
   });
 

--- a/src/push/sw/notification-click-handler.js
+++ b/src/push/sw/notification-click-handler.js
@@ -6,6 +6,7 @@ import { isIncomingCallType } from './notification-presentation.js';
 export function getNotificationNavigationPath(data, action) {
   const {
     type,
+    callInviteId,
     roomId,
     senderId,
     callerId,
@@ -21,6 +22,7 @@ export function getNotificationNavigationPath(data, action) {
     // call=1 routes the client to the incoming-call flow; a bare
     // conversationId just opens the conversation UI.
     const params = new URLSearchParams({ call: '1', conversationId: roomId });
+    if (callInviteId) params.set('callInviteId', callInviteId);
     if (callerId) params.set('callerId', callerId);
     if (callerName) params.set('callerName', callerName);
     if (audioOnly === true || audioOnly === 'true')

--- a/src/realtime/mailbox-channel.ts
+++ b/src/realtime/mailbox-channel.ts
@@ -66,9 +66,18 @@ export function createMailboxChannel(
       try {
         parsed = JSON.parse(event.data as string);
       } catch {
+        console.warn('[mailbox-channel] ignored malformed message');
         return;
       }
-      if (!isMailboxEnvelope(parsed)) return;
+      if (!isMailboxEnvelope(parsed)) {
+        console.warn('[mailbox-channel] ignored invalid envelope', {
+          type:
+            parsed && typeof parsed === 'object' && 't' in parsed
+              ? (parsed as { t?: unknown }).t
+              : undefined,
+        });
+        return;
+      }
       handlers.forEach((h) => h(parsed));
     });
     socket.addEventListener('close', () => {


### PR DESCRIPTION
## Summary

- Add caller-generated `callInviteId` correlation to the live invite, response, cancel, mailbox, and incoming push paths.
- Atomically consume only the exact unexpired pending invite before delivering a response, so an older attempt cannot accept or cancel a newer call in the same conversation.
- Keep the invite deadline active while media permission and `p2p.join` are pending; abort both and suppress the accepted response when time expires.
- Keep `callInviteId` out of missed-call notifications and active-room state.

Addresses the remaining finding from [#655](https://github.com/KristinnRoach/HangVidU/pull/655#discussion_r3787711218).

## Compatibility and intentionally deferred cleanup

- HTTP ingress temporarily accepts a missing `callInviteId` for already-deployed clients. This deliberately leaves those older sessions with the prior room-level behavior. Further work is explicitly deferred to [#657](https://github.com/KristinnRoach/HangVidU/issues/657): address it minimally only if production user experience after this PR is deployed shows meaningful impact; otherwise remove the fallback after old sessions have aged out.
- Cross-mailbox response delivery is not atomic after invite consumption. The rare infrastructure-failure path is explicitly deferred to [#658](https://github.com/KristinnRoach/HangVidU/issues/658), where it should be addressed with the smallest safe durable retry/outbox design.
- No `@kidlib/p2p` change is needed: its existing join `signal` support provides the required teardown behavior.
- No new abstraction or dependency was added.

## Validation

- `vp install`
- `vp check`
- `vp test` — 396 passed, 1 skipped
- `pnpm -C backend/cloudflare test` — 96 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unique invite tracking across incoming and outgoing calls.
  * Improved call notifications and navigation by preserving invite details.
  * Added expiration-aware call acceptance that cancels media setup when an invite expires.
  * Made accepted-call responses safely retryable until acknowledged.

* **Bug Fixes**
  * Prevented stale responses from affecting active call invites.
  * Ensured cancellations and acknowledgements target the matching invite.
  * Added warnings for malformed or invalid call messages.
  * Prevented notification dismissal errors when no service worker is available.

* **Tests**
  * Expanded coverage for retries, expiration, stale responses, notifications, and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->