### PR TITLE
Add completed call messages

### DIFF
--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -38,10 +38,14 @@ import {
   type UserProfileRow,
 } from './repo';
 import type {
+  CallCompletedMetadata,
   ConversationServerEvent,
   WireMessage,
 } from '../../../../shared/conversation-channel/protocol';
-import { isSystemMessageType } from '../../../../shared/conversation-channel/protocol';
+import {
+  isCallCompletedMetadata,
+  isSystemMessageType,
+} from '../../../../shared/conversation-channel/protocol';
 import { CALLING_TTL_MS } from '../../../../shared/constants';
 
 const MAX_ATTACHMENT_FILE_NAME_LENGTH = 180;
@@ -693,13 +697,16 @@ export async function handleDataRequest(
     const payload = await readJson(request);
     const messageId = str(payload?.messageId);
     const systemType = payload?.systemType;
-    if (!messageId || !isSystemMessageType(systemType)) {
-      return json(
-        { error: 'messageId and supported systemType required' },
-        400,
-        cors,
-      );
+    const metadata = payload?.metadata;
+    if (
+      !messageId ||
+      !isSystemMessageType(systemType) ||
+      (systemType === 'call.completed' && !isCallCompletedMetadata(metadata))
+    ) {
+      return json({ error: 'valid call event required' }, 400, cors);
     }
+    const body =
+      systemType === 'call.completed' ? JSON.stringify(metadata) : null;
 
     const result = await insertCallSystemMessage(
       env.DB,
@@ -707,6 +714,7 @@ export async function handleDataRequest(
       messageId,
       callerId,
       systemType,
+      body,
       now,
     );
     if (!result) return json({ error: 'message_id_conflict' }, 409, cors);
@@ -782,6 +790,7 @@ function toWireMessage(row: MessageWithAttachments): WireMessage {
     kind: row.kind,
     body: row.body,
     systemType: row.system_type,
+    systemMetadata: parseCallCompletedMetadata(row),
     sentAt: row.created_at,
     attachments: row.attachments.map((a) => ({
       id: a.id,
@@ -819,13 +828,25 @@ async function publishMessageActivity(
           env.USER_MAILBOX.getByName(member.user_id).deliver({
             t: 'activity',
             conversationId,
-            senderId,
+            senderId: message.systemType === 'call.completed' ? null : senderId,
             sentAt: message.sentAt,
           }),
         ),
     );
   } catch (err) {
     console.warn('[data] activity fan-out failed', { conversationId, err });
+  }
+}
+
+function parseCallCompletedMetadata(
+  row: MessageWithAttachments,
+): CallCompletedMetadata | null {
+  if (row.system_type !== 'call.completed' || row.body === null) return null;
+  try {
+    const metadata: unknown = JSON.parse(row.body);
+    return isCallCompletedMetadata(metadata) ? metadata : null;
+  } catch {
+    return null;
   }
 }
 

--- a/backend/cloudflare/src/data/repo.ts
+++ b/backend/cloudflare/src/data/repo.ts
@@ -780,17 +780,18 @@ export async function insertCallSystemMessage(
   messageId: string,
   callerUId: string,
   systemType: SystemMessageType,
+  body: string | null,
   now: number,
 ): Promise<{ message: MessageWithAttachments; created: boolean } | null> {
   const inserted = await db
     .prepare(
       `INSERT INTO messages
          (id, conversation_id, sender_id, kind, body, system_type, created_at)
-       VALUES (?, ?, ?, 'system', NULL, ?, ?)
+       VALUES (?, ?, ?, 'system', ?, ?, ?)
        ON CONFLICT(id) DO NOTHING
        RETURNING id`,
     )
-    .bind(messageId, conversationId, callerUId, systemType, now)
+    .bind(messageId, conversationId, callerUId, body, systemType, now)
     .first<{ id: string }>();
 
   const created = inserted !== null;
@@ -807,6 +808,7 @@ export async function insertCallSystemMessage(
     message.conversation_id !== conversationId ||
     message.sender_id !== callerUId ||
     message.kind !== 'system' ||
+    message.body !== body ||
     message.system_type !== systemType
   ) {
     return null;
@@ -1051,7 +1053,9 @@ export async function listConversations(
               (SELECT msg.created_at FROM messages msg
                 WHERE msg.conversation_id = c.id
                 ORDER BY msg.created_at DESC, msg.id DESC LIMIT 1) AS latest_sent_at,
-              (SELECT msg.sender_id FROM messages msg
+              (SELECT CASE WHEN msg.system_type = 'call.completed'
+                           THEN NULL ELSE msg.sender_id END
+                 FROM messages msg
                 WHERE msg.conversation_id = c.id
                 ORDER BY msg.created_at DESC, msg.id DESC LIMIT 1) AS latest_sender_id
        FROM conversations c

--- a/backend/cloudflare/test/data-repo.test.ts
+++ b/backend/cloudflare/test/data-repo.test.ts
@@ -4,6 +4,7 @@ import {
   directDmKey,
   getConversation,
   getReactionSummaries,
+  insertCallSystemMessage,
   insertMessage,
   isMember,
   listConversations,
@@ -306,6 +307,23 @@ describe('listConversations', () => {
     const [conversation] = await listConversations(db, 'user-a');
     expect(conversation.latest_sent_at).toBe(2000);
     expect(conversation.latest_sender_id).toBe('user-b');
+  });
+
+  it('treats completed calls as neutral list activity', async () => {
+    const convoId = await resolveOrCreateDirect(db, 'user-a', 'user-b', 1000);
+    await insertCallSystemMessage(
+      db,
+      convoId,
+      'completed-1',
+      'user-a',
+      'call.completed',
+      JSON.stringify({ audioOnly: true, durationSeconds: 83 }),
+      2000,
+    );
+
+    const [conversation] = await listConversations(db, 'user-b');
+    expect(conversation.latest_sent_at).toBe(2000);
+    expect(conversation.latest_sender_id).toBeNull();
   });
 
   it("surfaces the caller's own read marker, defaulting to 0", async () => {

--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -583,6 +583,33 @@ describe('system messages', () => {
     },
   );
 
+  it('persists completed-call metadata', async () => {
+    const conversationId = await resolveOrCreateDirect(
+      env.DB,
+      'user-a',
+      'user-b',
+      1000,
+    );
+    const token = await signToken(validClaims('user-a'));
+
+    const response = await jsonPost(
+      `/conversations/${conversationId}/call-events`,
+      token,
+      {
+        messageId: 'completed-1',
+        systemType: 'call.completed',
+        metadata: { audioOnly: true, durationSeconds: 83 },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).message).toMatchObject({
+      kind: 'system',
+      systemType: 'call.completed',
+      systemMetadata: { audioOnly: true, durationSeconds: 83 },
+    });
+  });
+
   it('rejects unknown system message types', async () => {
     const conversationId = await resolveOrCreateDirect(
       env.DB,

--- a/shared/conversation-channel/protocol.ts
+++ b/shared/conversation-channel/protocol.ts
@@ -43,8 +43,27 @@ export interface WireReactionSummary extends WireReactionCount {
 export const SYSTEM_MESSAGE_TYPES = [
   'call.unanswered',
   'call.declined',
+  'call.completed',
 ] as const;
 export type SystemMessageType = (typeof SYSTEM_MESSAGE_TYPES)[number];
+
+export interface CallCompletedMetadata {
+  audioOnly: boolean;
+  durationSeconds: number;
+}
+
+export function isCallCompletedMetadata(
+  value: unknown,
+): value is CallCompletedMetadata {
+  if (!value || typeof value !== 'object') return false;
+  const metadata = value as Record<string, unknown>;
+  return (
+    typeof metadata.audioOnly === 'boolean' &&
+    typeof metadata.durationSeconds === 'number' &&
+    Number.isSafeInteger(metadata.durationSeconds) &&
+    metadata.durationSeconds > 0
+  );
+}
 
 export function isSystemMessageType(
   value: unknown,
@@ -60,6 +79,7 @@ export interface WireMessage {
   kind: 'text' | 'file' | 'system';
   body: string | null;
   systemType?: SystemMessageType | null;
+  systemMetadata?: CallCompletedMetadata | null;
   sentAt: number;
   attachments: WireAttachment[];
   reactions: WireReactionSummary[];
@@ -98,8 +118,12 @@ export function isConversationServerEvent(
     typeof m.senderId === 'string' &&
     (m.kind === 'text' || m.kind === 'file' || m.kind === 'system') &&
     (m.kind === 'system'
-      ? isSystemMessageType(m.systemType)
-      : m.systemType === null || m.systemType === undefined) &&
+      ? isSystemMessageType(m.systemType) &&
+        (m.systemType === 'call.completed'
+          ? isCallCompletedMetadata(m.systemMetadata)
+          : m.systemMetadata === null || m.systemMetadata === undefined)
+      : (m.systemType === null || m.systemType === undefined) &&
+        (m.systemMetadata === null || m.systemMetadata === undefined)) &&
     typeof m.sentAt === 'number' &&
     Array.isArray(m.attachments) &&
     isReactionList(m.reactions, true)

--- a/shared/user-mailbox/protocol.ts
+++ b/shared/user-mailbox/protocol.ts
@@ -50,7 +50,12 @@ export type MailboxEnvelope =
   | { t: 'handled'; callInviteId: string; roomId: string; by: string }
   // Fire-and-forget "a message landed in one of your conversations" ping, fanned
   // to every member except the sender. Not persisted (no resurface on reconnect).
-  | { t: 'activity'; conversationId: string; senderId: string; sentAt: number }
+  | {
+      t: 'activity';
+      conversationId: string;
+      senderId: string | null;
+      sentAt: number;
+    }
   // Fire-and-forget "someone sent you a contact request" nudge. Not persisted —
   // the recipient fetches pending requests from D1 on load (source of truth).
   | {
@@ -97,7 +102,7 @@ export function isMailboxEnvelope(value: unknown): value is MailboxEnvelope {
   if (e.t === 'activity') {
     return (
       typeof e.conversationId === 'string' &&
-      typeof e.senderId === 'string' &&
+      (typeof e.senderId === 'string' || e.senderId === null) &&
       typeof e.sentAt === 'number'
     );
   }

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -989,52 +989,55 @@ describe('CallHandshakeController', () => {
     );
   });
 
-  it('publishes a completed call after the connection ends', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-08-16T12:00:00Z'));
-    try {
-      vi.spyOn(console, 'log').mockImplementation(() => {});
-      mocks.getLoggedInUserId.mockReturnValue('caller-id');
-      let joinOptions;
-      const p2p = createP2PMock({
-        join: vi.fn(async (options) => {
-          joinOptions = options;
-          return { roomId: 'room-1', members: ['caller-id'] };
-        }),
-      });
-      const controller = createController(p2p, {
-        getCallerName: () => 'Caller',
-      });
+  it.each(['hangUp', 'cleanup'])(
+    'publishes a completed call when %s ends the connection',
+    async (endMethod) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-08-16T12:00:00Z'));
+      try {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        mocks.getLoggedInUserId.mockReturnValue('caller-id');
+        let joinOptions;
+        const p2p = createP2PMock({
+          join: vi.fn(async (options) => {
+            joinOptions = options;
+            return { roomId: 'room-1', members: ['caller-id'] };
+          }),
+        });
+        const controller = createController(p2p, {
+          getCallerName: () => 'Caller',
+        });
 
-      await controller.startCall({
-        calleeId: 'callee-id',
-        calleeName: 'Callee',
-        audioOnly: true,
-      });
-      await mocks.responseCallback?.({
-        callInviteId: CALL_INVITE_ID,
-        roomId: 'room-1',
-        responseType: 'accepted',
-        by: 'callee-id',
-        respondedAt: Date.now(),
-      });
-
-      joinOptions.onDataChannelOpen();
-      vi.advanceTimersByTime(83_000);
-      controller.hangUp();
-
-      expect(mocks.publish).toHaveBeenCalledWith(
-        'evt:call:session:completed',
-        expect.objectContaining({
-          roomId: 'room-1',
+        await controller.startCall({
+          calleeId: 'callee-id',
+          calleeName: 'Callee',
           audioOnly: true,
-          durationSeconds: 83,
-        }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        });
+        await mocks.responseCallback?.({
+          callInviteId: CALL_INVITE_ID,
+          roomId: 'room-1',
+          responseType: 'accepted',
+          by: 'callee-id',
+          respondedAt: Date.now(),
+        });
+
+        joinOptions.onDataChannelOpen();
+        vi.advanceTimersByTime(83_000);
+        controller[endMethod]();
+
+        expect(mocks.publish).toHaveBeenCalledWith(
+          'evt:call:session:completed',
+          expect.objectContaining({
+            roomId: 'room-1',
+            audioOnly: true,
+            durationSeconds: 83,
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it('publishes unanswered when the caller cancels while ringing', async () => {
     mocks.getLoggedInUserId.mockReturnValue('caller-id');

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -989,6 +989,53 @@ describe('CallHandshakeController', () => {
     );
   });
 
+  it('publishes a completed call after the connection ends', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-16T12:00:00Z'));
+    try {
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      mocks.getLoggedInUserId.mockReturnValue('caller-id');
+      let joinOptions;
+      const p2p = createP2PMock({
+        join: vi.fn(async (options) => {
+          joinOptions = options;
+          return { roomId: 'room-1', members: ['caller-id'] };
+        }),
+      });
+      const controller = createController(p2p, {
+        getCallerName: () => 'Caller',
+      });
+
+      await controller.startCall({
+        calleeId: 'callee-id',
+        calleeName: 'Callee',
+        audioOnly: true,
+      });
+      await mocks.responseCallback?.({
+        callInviteId: CALL_INVITE_ID,
+        roomId: 'room-1',
+        responseType: 'accepted',
+        by: 'callee-id',
+        respondedAt: Date.now(),
+      });
+
+      joinOptions.onDataChannelOpen();
+      vi.advanceTimersByTime(83_000);
+      controller.hangUp();
+
+      expect(mocks.publish).toHaveBeenCalledWith(
+        'evt:call:session:completed',
+        expect.objectContaining({
+          roomId: 'room-1',
+          audioOnly: true,
+          durationSeconds: 83,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('publishes unanswered when the caller cancels while ringing', async () => {
     mocks.getLoggedInUserId.mockReturnValue('caller-id');
     const controller = createController(createP2PMock({ join: vi.fn() }), {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -104,6 +104,11 @@ type EnterRoomOptions = {
   signal?: AbortSignal;
 };
 
+type ActiveOutgoingCall = OutgoingCall & {
+  connectedAt?: number;
+  disconnectedAt?: number;
+};
+
 /** Why a call was torn down — logged so field reports are unambiguous. */
 type HangUpReason =
   | 'user'
@@ -132,6 +137,7 @@ export class CallHandshakeController {
   private unsubCalleeResponse: (() => void) | undefined;
   private unsubscribeIncomingCall: (() => void) | undefined;
   private pendingOutgoingLocalStream: MediaStream | undefined;
+  private activeOutgoingCall: ActiveOutgoingCall | undefined;
   private outgoingMediaAttempt = 0;
   private lastBoundUID: string | undefined;
 
@@ -386,6 +392,7 @@ export class CallHandshakeController {
           if (this.pendingOutgoingLocalStream === localStream) {
             this.pendingOutgoingLocalStream = undefined;
           }
+          this.activeOutgoingCall = { ...nextOutgoingCall };
           await this.enterRoom(
             response.roomId,
             localUID,
@@ -526,9 +533,18 @@ export class CallHandshakeController {
           // A (re)join cancels any in-progress reconnect grace; the peer's back.
           if (autoExitOnEmpty) this.cancelReconnectGrace();
         },
+        onDataChannelOpen: () => {
+          const call = this.activeOutgoingCall;
+          if (!call || call.roomId !== roomId) return;
+          call.connectedAt ??= Date.now();
+          call.disconnectedAt = undefined;
+        },
         onAlone: (detail) => {
           if (import.meta.env.DEV) console.debug('Room is alone:', { detail });
           if (!autoExitOnEmpty) return;
+          if (this.activeOutgoingCall?.roomId === roomId) {
+            this.activeOutgoingCall.disconnectedAt = Date.now();
+          }
           // `left` = every departure that emptied the room was an explicit
           // signaling leave (intentional hangup) → exit now. `dropped` = a
           // silent drop → give the peer a grace window to re-join first.
@@ -773,6 +789,7 @@ export class CallHandshakeController {
       memberCount: this.p2p.members().length,
       state: this.p2p.state(),
     });
+    this.publishCompletedCall();
     this.resetReconnectState();
     // dispose() is async in @kidlib/p2p ≥0.4; hangUp stays sync (called from
     // click + timer callbacks). Surface teardown failures — a silently failed
@@ -781,6 +798,23 @@ export class CallHandshakeController {
       console.warn('[call] p2p dispose failed on hangUp:', err);
     });
   };
+
+  private publishCompletedCall(): void {
+    const call = this.activeOutgoingCall;
+    this.activeOutgoingCall = undefined;
+    if (call?.connectedAt == null) return;
+
+    const endedAt = call.disconnectedAt ?? Date.now();
+    publish('evt:call:session:completed', {
+      roomId: call.roomId,
+      startedAt: call.startedAt,
+      audioOnly: call.audioOnly,
+      durationSeconds: Math.max(
+        1,
+        Math.floor((endedAt - call.connectedAt) / 1000),
+      ),
+    });
+  }
 
   /**
    * A peer session that never reached `connected` within `connectedTimeoutMs`
@@ -879,6 +913,7 @@ export class CallHandshakeController {
     this.clearCalleeBusyResetTimeout();
     this.resetReconnectState();
     this.stopPendingOutgoingLocalStream();
+    this.activeOutgoingCall = undefined;
     this.setHandshakeState(null);
     this.onCalleeBusy(false);
     void this.p2p.dispose().catch((err) => {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -913,7 +913,7 @@ export class CallHandshakeController {
     this.clearCalleeBusyResetTimeout();
     this.resetReconnectState();
     this.stopPendingOutgoingLocalStream();
-    this.activeOutgoingCall = undefined;
+    this.publishCompletedCall();
     this.setHandshakeState(null);
     this.onCalleeBusy(false);
     void this.p2p.dispose().catch((err) => {

--- a/src/features/conversations/__tests__/setup.test.js
+++ b/src/features/conversations/__tests__/setup.test.js
@@ -78,6 +78,25 @@ describe('conversations setup', () => {
     );
   });
 
+  it('records completed calls with their type and duration', async () => {
+    const { setup } = await import('../index');
+    await setup();
+
+    mocks.handlers.get('evt:call:session:completed')({
+      roomId: 'conversation-1',
+      startedAt: 123,
+      audioOnly: true,
+      durationSeconds: 83,
+    });
+
+    expect(mocks.recordSystemMessage).toHaveBeenCalledWith(
+      'conversation-1',
+      'call.completed',
+      'call.completed:conversation-1:123',
+      { audioOnly: true, durationSeconds: 83 },
+    );
+  });
+
   it('resets conversation state when activity teardown throws', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mocks.stopConversationListSync.mockImplementation(() => {

--- a/src/features/conversations/components/MessageList.tsx
+++ b/src/features/conversations/components/MessageList.tsx
@@ -279,12 +279,22 @@ function SystemMessageRow(props: { message: SystemChatMessage }) {
     selectedConversation()?.members.find(
       (member) => member.user_id === props.message.senderId,
     )?.display_name ?? t('conversation.unknown_caller');
-  const text = () =>
-    props.message.callerUId === state.myUserId
+  const text = () => {
+    if (props.message.systemType === 'call.completed') {
+      const label = props.message.audioOnly
+        ? t('message.audioCall')
+        : t('message.videoCall');
+      return `${label} · ${formatCallDuration(props.message.durationSeconds)}`;
+    }
+    if (props.message.systemType === 'call.declined') {
+      return t('conversation.call_declined');
+    }
+    return props.message.callerUId === state.myUserId
       ? t('conversation.call_unanswered_outgoing')
       : t('conversation.call_unanswered_incoming', {
           name: callerName().split(' ')[0] ?? '',
         });
+  };
 
   return (
     <div class={styles.systemMessage} data-timestamp={props.message.sentAt}>
@@ -313,6 +323,15 @@ function SystemMessageRow(props: { message: SystemChatMessage }) {
       </Show>
     </div>
   );
+}
+
+function formatCallDuration(durationSeconds: number): string {
+  const hours = Math.floor(durationSeconds / 3600);
+  const minutes = Math.floor((durationSeconds % 3600) / 60);
+  const seconds = durationSeconds % 60;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+    : `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
 function FileAttachment(props: {

--- a/src/features/conversations/index.ts
+++ b/src/features/conversations/index.ts
@@ -7,7 +7,10 @@ import { resetConversationsState } from '../../stores/conversation/conversations
 import { resetConversationStore } from '../../stores/conversation/conversation-store.js';
 import { recordSystemMessage } from '../../stores/conversation/conversation-store.js';
 import { createSingleFlightSetup } from '@shared/utils/create-single-flight-setup.js';
-import type { SystemMessageType } from '../../../shared/conversation-channel/protocol';
+import type {
+  CallCompletedMetadata,
+  SystemMessageType,
+} from '../../../shared/conversation-channel/protocol';
 
 export { ConversationPanel } from './components/ConversationPanel.js';
 
@@ -29,17 +32,19 @@ export const setup = createSingleFlightSetup({
         roomId: conversationId,
         startedAt,
       }: { roomId: string; startedAt: number },
+      metadata?: CallCompletedMetadata,
     ) => {
       const messageId = `${systemType}:${conversationId}:${startedAt}`;
-      void recordSystemMessage(conversationId, systemType, messageId).catch(
-        (error) => {
-          console.warn('[conversations] system message write failed:', {
-            systemType,
-            conversationId,
-            error,
-          });
-        },
-      );
+      const write = metadata
+        ? recordSystemMessage(conversationId, systemType, messageId, metadata)
+        : recordSystemMessage(conversationId, systemType, messageId);
+      void write.catch((error) => {
+        console.warn('[conversations] system message write failed:', {
+          systemType,
+          conversationId,
+          error,
+        });
+      });
     };
 
     subscribe(
@@ -53,6 +58,21 @@ export const setup = createSingleFlightSetup({
       'evt:call:invite:declined',
       (call: { roomId: string; startedAt: number }) =>
         recordCallSystemMessage('call.declined', call),
+      { signal },
+    );
+
+    subscribe(
+      'evt:call:session:completed',
+      (call: {
+        roomId: string;
+        startedAt: number;
+        audioOnly: boolean;
+        durationSeconds: number;
+      }) =>
+        recordCallSystemMessage('call.completed', call, {
+          audioOnly: call.audioOnly,
+          durationSeconds: call.durationSeconds,
+        }),
       { signal },
     );
 

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -127,6 +127,7 @@
   "conversation.open_preview": "Open preview for {name}",
   "conversation.call_unanswered_outgoing": "Call not answered",
   "conversation.call_unanswered_incoming": "Missed call from {name}",
+  "conversation.call_declined": "Call declined",
   "conversation.unknown_caller": "Unknown caller",
   "message_input.placeholder": "Type a message...",
   "message.audioCall": "Audio call",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -127,6 +127,7 @@
   "conversation.open_preview": "Opna forskoðun fyrir {name}",
   "conversation.call_unanswered_outgoing": "Símtali ekki svarað",
   "conversation.call_unanswered_incoming": "Ósvarað símtal frá {name}",
+  "conversation.call_declined": "Símtali hafnað",
   "conversation.unknown_caller": "Óþekktur hringjandi",
   "message_input.placeholder": "Skrifaðu skilaboð...",
   "message.audioCall": "Símtal",

--- a/src/storage/conversations/data-client.ts
+++ b/src/storage/conversations/data-client.ts
@@ -5,6 +5,7 @@
 // /conversations/:id, and the message endpoints (/conversations/:id/messages).
 
 import type {
+  CallCompletedMetadata,
   SystemMessageType,
   WireMessage,
   WireReactionSummary,
@@ -70,7 +71,11 @@ export interface ConversationsClient {
   ): Promise<WireMessage>;
   recordCallSystemMessage(
     conversationId: string,
-    input: { messageId: string; systemType: SystemMessageType },
+    input: {
+      messageId: string;
+      systemType: SystemMessageType;
+      metadata?: CallCompletedMetadata;
+    },
   ): Promise<WireMessage>;
   setMyReaction(
     conversationId: string,

--- a/src/storage/conversations/message-mapper.ts
+++ b/src/storage/conversations/message-mapper.ts
@@ -1,9 +1,15 @@
 import type { Reaction } from '@lib/reactions/solid/solid.js';
 import type {
+  CallCompletedMetadata,
   SystemMessageType,
   WireMessage,
 } from '../../../shared/conversation-channel/protocol';
-import type { ConversationId, MessageEnvelope, UserId } from './types.js';
+import type {
+  ConversationId,
+  MessageEnvelope,
+  SystemMessagePayload,
+  UserId,
+} from './types.js';
 
 export type IncomingMessage = MessageEnvelope & {
   reactions: Reaction[];
@@ -14,6 +20,7 @@ export type SendMessageInput = {
   kind: 'text' | 'file' | 'system';
   body?: string | null;
   systemType?: SystemMessageType;
+  metadata?: CallCompletedMetadata;
   attachment?: {
     r2Key: string;
     bucket: string;
@@ -56,14 +63,30 @@ export function toIncomingMessage(m: WireMessage): IncomingMessage | null {
 
   if (m.kind === 'system') {
     if (!m.systemType) return null;
-    return {
-      ...base,
-      payload: {
+    let payload: SystemMessagePayload;
+    if (m.systemType === 'call.completed') {
+      if (!m.systemMetadata) return null;
+      payload = {
         type: 'system',
-        systemType: m.systemType,
+        systemType: 'call.completed',
         callerUId: m.senderId as UserId,
-      },
-    };
+        audioOnly: m.systemMetadata.audioOnly,
+        durationSeconds: m.systemMetadata.durationSeconds,
+      };
+    } else if (m.systemType === 'call.declined') {
+      payload = {
+        type: 'system',
+        systemType: 'call.declined',
+        callerUId: m.senderId as UserId,
+      };
+    } else {
+      payload = {
+        type: 'system',
+        systemType: 'call.unanswered',
+        callerUId: m.senderId as UserId,
+      };
+    }
+    return { ...base, payload };
   }
 
   if (typeof m.body !== 'string') return null;
@@ -95,5 +118,13 @@ export function toSendMessageInput(message: MessageEnvelope): SendMessageInput {
     messageId: message.messageId,
     kind: 'system',
     systemType: payload.systemType,
+    ...(payload.systemType === 'call.completed'
+      ? {
+          metadata: {
+            audioOnly: payload.audioOnly,
+            durationSeconds: payload.durationSeconds,
+          },
+        }
+      : {}),
   };
 }

--- a/src/storage/conversations/schema.test.js
+++ b/src/storage/conversations/schema.test.js
@@ -45,6 +45,26 @@ describe('conversations schema', () => {
     },
   );
 
+  it('requires call type and duration for completed calls', () => {
+    expect(
+      SystemMessagePayloadSchema.parse({
+        type: 'system',
+        systemType: 'call.completed',
+        callerUId: 'user-a',
+        audioOnly: false,
+        durationSeconds: 83,
+      }),
+    ).toMatchObject({ audioOnly: false, durationSeconds: 83 });
+
+    expect(() =>
+      SystemMessagePayloadSchema.parse({
+        type: 'system',
+        systemType: 'call.completed',
+        callerUId: 'user-a',
+      }),
+    ).toThrow();
+  });
+
   it('accepts R2-backed file payloads', () => {
     const message = MessageEnvelopeSchema.parse({
       messageId: 'msg-1',

--- a/src/storage/conversations/schema.ts
+++ b/src/storage/conversations/schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { SYSTEM_MESSAGE_TYPES } from '../../../shared/conversation-channel/protocol';
 
 export const UserIdSchema = z.string().trim().min(1);
 
@@ -40,11 +39,24 @@ export const FileMessagePayloadSchema = z.object({
   text: z.string().optional(),
 });
 
-export const SystemMessagePayloadSchema = z.object({
+const CallSystemMessageBaseSchema = z.object({
   type: z.literal('system'),
-  systemType: z.enum(SYSTEM_MESSAGE_TYPES),
   callerUId: UserIdSchema,
 });
+
+export const SystemMessagePayloadSchema = z.discriminatedUnion('systemType', [
+  CallSystemMessageBaseSchema.extend({
+    systemType: z.literal('call.unanswered'),
+  }),
+  CallSystemMessageBaseSchema.extend({
+    systemType: z.literal('call.declined'),
+  }),
+  CallSystemMessageBaseSchema.extend({
+    systemType: z.literal('call.completed'),
+    audioOnly: z.boolean(),
+    durationSeconds: z.number().int().positive(),
+  }),
+]);
 
 export const MessagePayloadSchema = z.discriminatedUnion('type', [
   TextMessagePayloadSchema,

--- a/src/stores/conversation/conversation-store.ts
+++ b/src/stores/conversation/conversation-store.ts
@@ -50,7 +50,10 @@ import type {
   IncomingMessage,
   MessageRepository,
 } from './types.js';
-import type { SystemMessageType } from '../../../shared/conversation-channel/protocol';
+import type {
+  CallCompletedMetadata,
+  SystemMessageType,
+} from '../../../shared/conversation-channel/protocol';
 import type {
   ConversationId,
   FileMessagePayload,
@@ -259,17 +262,24 @@ function fileAttachment(payload: FileMessagePayload) {
 
 function envelopeToChatMessage(message: IncomingMessage): ChatMessage | null {
   if (message.payload.type === 'system') {
-    return {
-      type: 'system',
+    const base = {
+      type: 'system' as const,
       id: message.messageId,
       conversationId: message.conversationId,
       senderId: message.senderId,
       callerUId: message.payload.callerUId,
-      systemType: message.payload.systemType,
       sentAt: message.sentAt,
-      status: 'sent',
+      status: 'sent' as const,
       reactions: [],
     };
+    return message.payload.systemType === 'call.completed'
+      ? {
+          ...base,
+          systemType: 'call.completed',
+          audioOnly: message.payload.audioOnly,
+          durationSeconds: message.payload.durationSeconds,
+        }
+      : { ...base, systemType: message.payload.systemType };
   }
 
   const text =
@@ -316,12 +326,14 @@ export async function recordSystemMessage(
   conversationId: ConversationId,
   systemType: SystemMessageType,
   messageId: string = crypto.randomUUID(),
+  metadata?: CallCompletedMetadata,
 ): Promise<void> {
   const message = await getConversationsClient().recordCallSystemMessage(
     conversationId,
     {
       messageId,
       systemType,
+      metadata,
     },
   );
   recordConversationListMessage(

--- a/src/stores/conversation/types.ts
+++ b/src/stores/conversation/types.ts
@@ -83,8 +83,16 @@ export type UserChatMessage = ChatMessageBase & {
 
 export type SystemChatMessage = ChatMessageBase & {
   type: 'system';
-  systemType: SystemMessageType;
   callerUId: UserId;
-};
+} & (
+    | {
+        systemType: 'call.completed';
+        audioOnly: boolean;
+        durationSeconds: number;
+      }
+    | {
+        systemType: Exclude<SystemMessageType, 'call.completed'>;
+      }
+  );
 
 export type ChatMessage = UserChatMessage | SystemChatMessage;


### PR DESCRIPTION
## Summary

- record a persistent system message when an outgoing call successfully connects and later ends
- show a minimal localized audio/video call label with the connected duration
- reuse the existing message activity pipeline to reorder conversations without marking completed calls unread

## Implementation

- start timing when the P2P data channel opens and preserve the original connection time across reconnects
- store validated call metadata in the existing nullable system-message body field
- keep the caller as the single writer and use the existing deterministic message id for idempotency

## Validation

- `vp check`
- `vp test` — 401 passed, 1 skipped
- `pnpm test:cf` — 98 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed calls are now recorded in conversation activity with audio/video status and duration.
  * Conversation messages display completed call details using formatted durations.
  * Declined calls now display a localized “Call declined” message.

* **Bug Fixes**
  * Invalid or incomplete call metadata is rejected safely.
  * Completed call activity no longer attributes the latest message to a sender.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->