### PR TITLE
Record busy calls in conversations

### DIFF
--- a/backend/cloudflare/test/data-worker.test.ts
+++ b/backend/cloudflare/test/data-worker.test.ts
@@ -515,7 +515,7 @@ describe('auth + membership guard on GET /conversations/:id/messages', () => {
 });
 
 describe('system messages', () => {
-  it.each(['call.unanswered', 'call.declined'] as const)(
+  it.each(['call.unanswered', 'call.declined', 'call.busy'] as const)(
     'persists and broadcasts %s with server-owned caller identity',
     async (systemType) => {
       const conversationId = await resolveOrCreateDirect(

--- a/shared/conversation-channel/protocol.ts
+++ b/shared/conversation-channel/protocol.ts
@@ -43,6 +43,7 @@ export interface WireReactionSummary extends WireReactionCount {
 export const SYSTEM_MESSAGE_TYPES = [
   'call.unanswered',
   'call.declined',
+  'call.busy',
   'call.completed',
 ] as const;
 export type SystemMessageType = (typeof SYSTEM_MESSAGE_TYPES)[number];

--- a/src/features/call/call-handshake-controller.test.js
+++ b/src/features/call/call-handshake-controller.test.js
@@ -989,6 +989,31 @@ describe('CallHandshakeController', () => {
     );
   });
 
+  it('publishes busy when the callee is already in a call', async () => {
+    mocks.getLoggedInUserId.mockReturnValue('caller-id');
+    const controller = createController(createP2PMock({ join: vi.fn() }), {
+      getCallerName: () => 'Caller',
+    });
+
+    await controller.startCall({
+      calleeId: 'callee-id',
+      calleeName: 'Callee',
+      audioOnly: false,
+    });
+    await mocks.responseCallback?.({
+      callInviteId: CALL_INVITE_ID,
+      roomId: 'room-1',
+      responseType: 'busy',
+      by: 'callee-id',
+      respondedAt: Date.now(),
+    });
+
+    expect(mocks.publish).toHaveBeenCalledWith(
+      'evt:call:invite:busy',
+      expect.objectContaining({ roomId: 'room-1', callerId: 'caller-id' }),
+    );
+  });
+
   it.each(['hangUp', 'cleanup'])(
     'publishes a completed call when %s ends the connection',
     async (endMethod) => {

--- a/src/features/call/call-handshake-controller.ts
+++ b/src/features/call/call-handshake-controller.ts
@@ -400,6 +400,7 @@ export class CallHandshakeController {
             () => Promise.resolve(localStream),
           );
         } else if (response.responseType === 'busy') {
+          publish('evt:call:invite:busy', nextOutgoingCall);
           this.stopMediaStream(localStream);
           if (this.pendingOutgoingLocalStream === localStream) {
             this.pendingOutgoingLocalStream = undefined;

--- a/src/features/conversations/__tests__/setup.test.js
+++ b/src/features/conversations/__tests__/setup.test.js
@@ -62,6 +62,7 @@ describe('conversations setup', () => {
   it.each([
     ['evt:call:invite:unanswered', 'call.unanswered'],
     ['evt:call:invite:declined', 'call.declined'],
+    ['evt:call:invite:busy', 'call.busy'],
   ])('records %s as a persistent system message', async (eventName, type) => {
     const { setup } = await import('../index');
     await setup();

--- a/src/features/conversations/components/MessageList.tsx
+++ b/src/features/conversations/components/MessageList.tsx
@@ -289,6 +289,9 @@ function SystemMessageRow(props: { message: SystemChatMessage }) {
     if (props.message.systemType === 'call.declined') {
       return t('conversation.call_declined');
     }
+    if (props.message.systemType === 'call.busy') {
+      return t('conversation.call_busy');
+    }
     return props.message.callerUId === state.myUserId
       ? t('conversation.call_unanswered_outgoing')
       : t('conversation.call_unanswered_incoming', {

--- a/src/features/conversations/components/MessageList.tsx
+++ b/src/features/conversations/components/MessageList.tsx
@@ -289,7 +289,10 @@ function SystemMessageRow(props: { message: SystemChatMessage }) {
     if (props.message.systemType === 'call.declined') {
       return t('conversation.call_declined');
     }
-    if (props.message.systemType === 'call.busy') {
+    if (
+      props.message.systemType === 'call.busy' &&
+      props.message.callerUId === state.myUserId
+    ) {
       return t('conversation.call_busy');
     }
     return props.message.callerUId === state.myUserId

--- a/src/features/conversations/index.ts
+++ b/src/features/conversations/index.ts
@@ -62,6 +62,13 @@ export const setup = createSingleFlightSetup({
     );
 
     subscribe(
+      'evt:call:invite:busy',
+      (call: { roomId: string; startedAt: number }) =>
+        recordCallSystemMessage('call.busy', call),
+      { signal },
+    );
+
+    subscribe(
       'evt:call:session:completed',
       (call: {
         roomId: string;

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -128,6 +128,7 @@
   "conversation.call_unanswered_outgoing": "Call not answered",
   "conversation.call_unanswered_incoming": "Missed call from {name}",
   "conversation.call_declined": "Call declined",
+  "conversation.call_busy": "Contact was busy",
   "conversation.unknown_caller": "Unknown caller",
   "message_input.placeholder": "Type a message...",
   "message.audioCall": "Audio call",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -128,6 +128,7 @@
   "conversation.call_unanswered_outgoing": "Símtali ekki svarað",
   "conversation.call_unanswered_incoming": "Ósvarað símtal frá {name}",
   "conversation.call_declined": "Símtali hafnað",
+  "conversation.call_busy": "Notandi var á tali",
   "conversation.unknown_caller": "Óþekktur hringjandi",
   "message_input.placeholder": "Skrifaðu skilaboð...",
   "message.audioCall": "Símtal",

--- a/src/storage/conversations/message-mapper.ts
+++ b/src/storage/conversations/message-mapper.ts
@@ -73,16 +73,10 @@ export function toIncomingMessage(m: WireMessage): IncomingMessage | null {
         audioOnly: m.systemMetadata.audioOnly,
         durationSeconds: m.systemMetadata.durationSeconds,
       };
-    } else if (m.systemType === 'call.declined') {
-      payload = {
-        type: 'system',
-        systemType: 'call.declined',
-        callerUId: m.senderId as UserId,
-      };
     } else {
       payload = {
         type: 'system',
-        systemType: 'call.unanswered',
+        systemType: m.systemType,
         callerUId: m.senderId as UserId,
       };
     }

--- a/src/storage/conversations/schema.test.js
+++ b/src/storage/conversations/schema.test.js
@@ -32,7 +32,7 @@ describe('conversations schema', () => {
     expect(message.delivery).toBe('private');
   });
 
-  it.each(['call.unanswered', 'call.declined'])(
+  it.each(['call.unanswered', 'call.declined', 'call.busy'])(
     'supports the %s system message payload',
     (systemType) => {
       const payload = SystemMessagePayloadSchema.parse({

--- a/src/storage/conversations/schema.ts
+++ b/src/storage/conversations/schema.ts
@@ -52,6 +52,9 @@ export const SystemMessagePayloadSchema = z.discriminatedUnion('systemType', [
     systemType: z.literal('call.declined'),
   }),
   CallSystemMessageBaseSchema.extend({
+    systemType: z.literal('call.busy'),
+  }),
+  CallSystemMessageBaseSchema.extend({
     systemType: z.literal('call.completed'),
     audioOnly: z.boolean(),
     durationSeconds: z.number().int().positive(),


### PR DESCRIPTION
## Summary

- publish a caller-side busy call event when the callee reports an active call
- persist `call.busy` in the shared conversation stream and render it for both participants
- add English and Icelandic copy plus client and worker coverage

## Root cause

The busy response only drove transient caller UI state. Unlike rejected and unanswered calls, it did not publish a conversation event, and the system-message protocol had no busy-call type.

## Impact

Busy call attempts now leave one deduplicated system message in the conversation while retaining the existing 2.5-second busy dialog and ringtone behavior.

## Validation

- `vp check`
- `vp test` — 405 passed, 1 skipped
- `pnpm -C backend/cloudflare test` — 99 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for busy call notifications during outgoing calls.
  * Conversations now record and display localized messages when a contact is busy.
  * Busy call events are supported in English and Icelandic.
  * Busy call details are preserved when notifications are stored and displayed.

* **Bug Fixes**
  * System call messages now retain their correct event type when displayed and stored.
  * Improved consistency for unanswered, declined, and busy call messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->