### PR TITLE
Add DM read receipts

### DIFF
--- a/backend/cloudflare/src/data/handlers.ts
+++ b/backend/cloudflare/src/data/handlers.ts
@@ -621,6 +621,17 @@ export async function handleDataRequest(
     );
     // null = no member row updated: hide existence (same as GET).
     if (lastReadAt === null) return json({ error: 'not_found' }, 404, cors);
+
+    const event: ConversationServerEvent = {
+      t: 'read',
+      userId: callerId,
+      lastReadAt,
+    };
+    try {
+      await env.CONVERSATION_CHANNEL.getByName(conversationId).broadcast(event);
+    } catch (err) {
+      console.warn('[data] read broadcast failed', { conversationId, err });
+    }
     return json({ lastReadAt }, 200, cors);
   }
 

--- a/backend/cloudflare/src/data/repo.ts
+++ b/backend/cloudflare/src/data/repo.ts
@@ -17,6 +17,9 @@ export interface MemberRow {
   user_id: string;
   display_name: string | null;
   joined_at: number;
+  // Read receipts (DM-only today): each member's own read marker, so a DM
+  // peer can compute "seen" against their own messages' sentAt.
+  last_read_at: number;
 }
 
 /** Insert the user if absent; refresh display_name when a non-null one is given. */
@@ -1017,7 +1020,7 @@ export async function getMembers(
 ): Promise<MemberRow[]> {
   const { results } = await db
     .prepare(
-      `SELECT m.user_id, u.display_name, m.joined_at
+      `SELECT m.user_id, u.display_name, m.joined_at, m.last_read_at
        FROM conversation_members m
        JOIN users u ON u.id = m.user_id
        WHERE m.conversation_id = ?

--- a/shared/conversation-channel/protocol.ts
+++ b/shared/conversation-channel/protocol.ts
@@ -16,6 +16,9 @@
  * - `{ t: 'reaction', ... }` — authoritative counts after one user's reaction
  *   changed. The actor fields let each receiver derive its viewer-specific
  *   `reactedByMe` value from the shared broadcast.
+ * - `{ t: 'read', userId, lastReadAt }` — `userId` advanced their read marker
+ *   to `lastReadAt`. DM-only today (one peer); a group receiver can already
+ *   distinguish senders by `userId` if group support lands later.
  *
  * Keep payloads camelCase (wire shape), distinct from snake_case D1 rows.
  */
@@ -95,13 +98,17 @@ export type ConversationServerEvent =
       actorUserId: string;
       actorReactionKey: string | null;
       reactions: WireReactionCount[];
-    };
+    }
+  | { t: 'read'; userId: string; lastReadAt: number };
 
 export function isConversationServerEvent(
   value: unknown,
 ): value is ConversationServerEvent {
   if (!value || typeof value !== 'object') return false;
   const e = value as Record<string, unknown>;
+  if (e.t === 'read') {
+    return typeof e.userId === 'string' && typeof e.lastReadAt === 'number';
+  }
   if (e.t === 'reaction') {
     return (
       typeof e.messageId === 'string' &&

--- a/shared/conversation-channel/protocol.ts
+++ b/shared/conversation-channel/protocol.ts
@@ -107,7 +107,9 @@ export function isConversationServerEvent(
   if (!value || typeof value !== 'object') return false;
   const e = value as Record<string, unknown>;
   if (e.t === 'read') {
-    return typeof e.userId === 'string' && typeof e.lastReadAt === 'number';
+    // isFinite, not typeof: a NaN marker compares false against every sentAt
+    // and would silently disable receipts for the conversation.
+    return typeof e.userId === 'string' && Number.isFinite(e.lastReadAt);
   }
   if (e.t === 'reaction') {
     return (

--- a/src/features/conversations/components/MessageList.tsx
+++ b/src/features/conversations/components/MessageList.tsx
@@ -31,6 +31,7 @@ import {
   formatTimestamp,
   TIMESTAMP_THRESHOLD_MS,
 } from '../utils/format-timestamp.js';
+import { readReceiptsEnabled } from '../read-receipts.js';
 
 import { StartCallButton } from '@features/call';
 
@@ -43,7 +44,7 @@ import styles from './ConversationPanel.module.css';
  */
 export function MessageList() {
   const state = getConversationState();
-  const { locale } = useI18n();
+  const { locale, t } = useI18n();
 
   let messagesEl: HTMLDivElement | undefined;
   // True once the user scrolls away from the bottom to read earlier messages.
@@ -104,6 +105,22 @@ export function MessageList() {
       !previous || message.sentAt - previous.sentAt > TIMESTAMP_THRESHOLD_MS
     );
   }
+
+  // DM-only: the one other member's read marker. Group semantics (per-member
+  // breakdown / "read by all") are a later decision, not covered here.
+  const peerLastReadAt = () => {
+    const conversation = selectedConversation();
+    if (!conversation || conversation.kind !== 'direct') return 0;
+    const peer = conversation.members.find(
+      (member) => member.user_id !== state.myUserId,
+    );
+    return peer?.last_read_at ?? 0;
+  };
+
+  const isReadByPeer = (message: ChatMessage) =>
+    readReceiptsEnabled() &&
+    message.senderId === state.myUserId &&
+    message.sentAt <= peerLastReadAt();
 
   const attachmentUrl = (msg: ChatMessage) => {
     const conversationId = state.conversationId;
@@ -261,6 +278,19 @@ export function MessageList() {
                   </Show>
                   <Show when={userMessage().status === 'failed'}>
                     <span class={styles.msgStatus}>!</span>
+                  </Show>
+                  <Show
+                    when={
+                      userMessage().status === 'sent' &&
+                      isReadByPeer(userMessage())
+                    }
+                  >
+                    <span
+                      class={styles.msgStatus}
+                      aria-label={t('conversation.read')}
+                    >
+                      ✓
+                    </span>
                   </Show>
                 </div>
               )}

--- a/src/features/conversations/components/MessageList.tsx
+++ b/src/features/conversations/components/MessageList.tsx
@@ -1,4 +1,12 @@
-import { For, Show, createEffect, createSignal, on, onCleanup } from 'solid-js';
+import {
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  on,
+  onCleanup,
+} from 'solid-js';
 import { Download } from 'lucide-solid';
 import { useI18n } from '@shared/i18n';
 // eslint-disable-next-line no-unused-vars -- consumed by the Solid `use:reactions` directive
@@ -117,10 +125,26 @@ export function MessageList() {
     return peer?.last_read_at ?? 0;
   };
 
-  const isReadByPeer = (message: ChatMessage) =>
-    readReceiptsEnabled() &&
-    message.senderId === state.myUserId &&
-    message.sentAt <= peerLastReadAt();
+  // Id of the newest own message the peer has read. Only that one shows the
+  // checkmark — a tick on every earlier message is noise, since read is
+  // cumulative. Null when receipts are off or nothing has been read yet.
+  const lastReadByPeerId = createMemo(() => {
+    if (!readReceiptsEnabled()) return null;
+    const readAt = peerLastReadAt();
+    if (!readAt) return null;
+    for (let i = state.messages.length - 1; i >= 0; i--) {
+      const message = state.messages[i];
+      if (
+        message?.type === 'user' &&
+        message.senderId === state.myUserId &&
+        message.status === 'sent' &&
+        message.sentAt <= readAt
+      ) {
+        return message.id;
+      }
+    }
+    return null;
+  });
 
   const attachmentUrl = (msg: ChatMessage) => {
     const conversationId = state.conversationId;
@@ -273,20 +297,30 @@ export function MessageList() {
                       />
                     )}
                   </Show>
+                  {/* role="img" so the aria-label is exposed: ARIA ignores
+                      aria-label on a plain (role=generic) span. */}
                   <Show when={userMessage().status === 'sending'}>
-                    <span class={styles.msgStatus}>…</span>
-                  </Show>
-                  <Show when={userMessage().status === 'failed'}>
-                    <span class={styles.msgStatus}>!</span>
-                  </Show>
-                  <Show
-                    when={
-                      userMessage().status === 'sent' &&
-                      isReadByPeer(userMessage())
-                    }
-                  >
                     <span
                       class={styles.msgStatus}
+                      role='img'
+                      aria-label={t('conversation.sending')}
+                    >
+                      …
+                    </span>
+                  </Show>
+                  <Show when={userMessage().status === 'failed'}>
+                    <span
+                      class={styles.msgStatus}
+                      role='img'
+                      aria-label={t('conversation.send_failed')}
+                    >
+                      !
+                    </span>
+                  </Show>
+                  <Show when={userMessage().id === lastReadByPeerId()}>
+                    <span
+                      class={styles.msgStatus}
+                      role='img'
                       aria-label={t('conversation.read')}
                     >
                       ✓

--- a/src/features/conversations/read-receipts.ts
+++ b/src/features/conversations/read-receipts.ts
@@ -1,8 +1,13 @@
 // Single on/off switch for the read-receipt checkmark. Static for now (env
 // var, no reload needed beyond a rebuild); the settings-menu slice will swap
-// the body for a per-user signal (disclose my read status / show others'
-// checkmarks) without touching call sites, which only ever call
-// readReceiptsEnabled().
+// the body for a per-user signal without touching call sites, which only ever
+// call readReceiptsEnabled().
+//
+// Scope: this hides OTHERS' checkmarks on this client. It does NOT stop your
+// own reads from being disclosed — the server broadcasts every read marker and
+// getMembers returns last_read_at to all members regardless. A "don't disclose
+// my read status" setting needs server enforcement (suppress the broadcast and
+// null the column for opted-out users), not a change here.
 const READ_RECEIPTS_ENABLED =
   import.meta.env.VITE_READ_RECEIPTS_ENABLED !== 'false';
 

--- a/src/features/conversations/read-receipts.ts
+++ b/src/features/conversations/read-receipts.ts
@@ -1,0 +1,11 @@
+// Single on/off switch for the read-receipt checkmark. Static for now (env
+// var, no reload needed beyond a rebuild); the settings-menu slice will swap
+// the body for a per-user signal (disclose my read status / show others'
+// checkmarks) without touching call sites, which only ever call
+// readReceiptsEnabled().
+const READ_RECEIPTS_ENABLED =
+  import.meta.env.VITE_READ_RECEIPTS_ENABLED !== 'false';
+
+export function readReceiptsEnabled(): boolean {
+  return READ_RECEIPTS_ENABLED;
+}

--- a/src/realtime/conversation-protocol.test.js
+++ b/src/realtime/conversation-protocol.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { isConversationServerEvent } from './conversation-protocol';
 
-describe('conversation reaction protocol', () => {
+describe('conversation protocol', () => {
   it('accepts authoritative reaction broadcasts and rejects malformed counts', () => {
     const event = {
       t: 'reaction',
@@ -18,5 +18,19 @@ describe('conversation reaction protocol', () => {
         reactions: [{ key: 'heart', count: 0 }],
       }),
     ).toBe(false);
+  });
+
+  it('accepts read markers and rejects non-finite ones', () => {
+    expect(
+      isConversationServerEvent({ t: 'read', userId: 'user-a', lastReadAt: 5 }),
+    ).toBe(true);
+    expect(
+      isConversationServerEvent({
+        t: 'read',
+        userId: 'user-a',
+        lastReadAt: Number.NaN,
+      }),
+    ).toBe(false);
+    expect(isConversationServerEvent({ t: 'read', lastReadAt: 5 })).toBe(false);
   });
 });

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -125,6 +125,7 @@
   "conversation.file_too_large": "Choose a smaller file.",
   "conversation.file_send_failed": "File send failed.",
   "conversation.open_preview": "Open preview for {name}",
+  "conversation.read": "Read",
   "conversation.call_unanswered_outgoing": "Call not answered",
   "conversation.call_unanswered_incoming": "Missed call from {name}",
   "conversation.call_declined": "Call declined",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -126,6 +126,8 @@
   "conversation.file_send_failed": "File send failed.",
   "conversation.open_preview": "Open preview for {name}",
   "conversation.read": "Read",
+  "conversation.sending": "Sending",
+  "conversation.send_failed": "Send failed",
   "conversation.call_unanswered_outgoing": "Call not answered",
   "conversation.call_unanswered_incoming": "Missed call from {name}",
   "conversation.call_declined": "Call declined",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -126,6 +126,8 @@
   "conversation.file_send_failed": "Ekki tókst að senda skrána.",
   "conversation.open_preview": "Opna forskoðun fyrir {name}",
   "conversation.read": "Lesið",
+  "conversation.sending": "Sendi",
+  "conversation.send_failed": "Sending mistókst",
   "conversation.call_unanswered_outgoing": "Símtali ekki svarað",
   "conversation.call_unanswered_incoming": "Ósvarað símtal frá {name}",
   "conversation.call_declined": "Símtali hafnað",

--- a/src/shared/i18n/is.json
+++ b/src/shared/i18n/is.json
@@ -125,6 +125,7 @@
   "conversation.file_too_large": "Veldu minni skrá.",
   "conversation.file_send_failed": "Ekki tókst að senda skrána.",
   "conversation.open_preview": "Opna forskoðun fyrir {name}",
+  "conversation.read": "Lesið",
   "conversation.call_unanswered_outgoing": "Símtali ekki svarað",
   "conversation.call_unanswered_incoming": "Ósvarað símtal frá {name}",
   "conversation.call_declined": "Símtali hafnað",

--- a/src/storage/conversations/data-client.ts
+++ b/src/storage/conversations/data-client.ts
@@ -36,6 +36,8 @@ export interface ConversationMember {
   user_id: string;
   display_name: string | null;
   joined_at: number;
+  // Read receipts (DM-only today): this member's own read marker. 0 = never read.
+  last_read_at: number;
 }
 
 export interface Conversation {

--- a/src/stores/conversation/conversation-list-state.test.js
+++ b/src/stores/conversation/conversation-list-state.test.js
@@ -28,6 +28,7 @@ import {
   recordConversationListMessage,
   refreshConversationListState,
   startConversationListSync,
+  updateMemberLastReadAt,
   stopConversationListSync,
 } from './conversation-list-state';
 
@@ -101,6 +102,42 @@ describe('markConversationRead', () => {
     });
   });
 
+  it('takes seed members but keeps a read marker a broadcast moved past', async () => {
+    vi.mocked(getLoggedInUserId).mockReturnValue('me');
+    const row = (peerReadAt, latestSentAt) => ({
+      id: 'dm-1',
+      kind: 'direct',
+      title: null,
+      updated_at: 1000,
+      members: [
+        { user_id: 'me', display_name: 'Me', last_read_at: 0 },
+        { user_id: 'peer', display_name: 'Peer', last_read_at: peerReadAt },
+      ],
+      latest_sent_at: latestSentAt,
+      latest_sender_id: 'me',
+    });
+
+    vi.mocked(getConversationsClient).mockReturnValue({
+      list: vi.fn().mockResolvedValue([row(100, 1000)]),
+    });
+    await refreshConversationListState();
+
+    // Live broadcast + a local send, both newer than the next snapshot.
+    updateMemberLastReadAt('dm-1', 'peer', 900);
+    recordConversationListMessage('dm-1', 2000, 'me');
+
+    vi.mocked(getConversationsClient).mockReturnValue({
+      list: vi.fn().mockResolvedValue([row(100, 1000)]),
+    });
+    await refreshConversationListState();
+
+    const seeded = conversationListState().get('dm-1');
+    expect(
+      seeded.members.find((member) => member.user_id === 'peer'),
+    ).toMatchObject({ display_name: 'Peer', last_read_at: 900 });
+    expect(seeded.latestSentAt).toBe(2000);
+  });
+
   it('can subscribe again after being stopped', () => {
     startConversationListSync();
     stopConversationListSync();
@@ -109,5 +146,63 @@ describe('markConversationRead', () => {
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
     expect(mocks.close).toHaveBeenCalledOnce();
     expect(mocks.subscribe).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('updateMemberLastReadAt', () => {
+  async function seedDirect() {
+    vi.mocked(getLoggedInUserId).mockReturnValue('me');
+    vi.mocked(getConversationsClient).mockReturnValue({
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 'dm-1',
+          kind: 'direct',
+          title: null,
+          updated_at: 1000,
+          members: [
+            { user_id: 'me', display_name: 'Me', last_read_at: 0 },
+            { user_id: 'peer', display_name: 'Peer', last_read_at: 500 },
+          ],
+          latest_sent_at: 1000,
+          latest_sender_id: 'me',
+        },
+      ]),
+    });
+    await refreshConversationListState();
+  }
+
+  const peerReadAt = () =>
+    conversationListState()
+      .get('dm-1')
+      ?.members.find((member) => member.user_id === 'peer')?.last_read_at;
+
+  it('advances the peer marker without touching other members', async () => {
+    await seedDirect();
+
+    updateMemberLastReadAt('dm-1', 'peer', 900);
+
+    expect(peerReadAt()).toBe(900);
+    expect(
+      conversationListState()
+        .get('dm-1')
+        ?.members.find((member) => member.user_id === 'me')?.last_read_at,
+    ).toBe(0);
+  });
+
+  it('never moves a marker backwards on a replayed event', async () => {
+    await seedDirect();
+
+    updateMemberLastReadAt('dm-1', 'peer', 900);
+    updateMemberLastReadAt('dm-1', 'peer', 700);
+
+    expect(peerReadAt()).toBe(900);
+  });
+
+  it('ignores an unseeded conversation', async () => {
+    await seedDirect();
+
+    updateMemberLastReadAt('dm-404', 'peer', 900);
+
+    expect(conversationListState().get('dm-404')).toBeUndefined();
   });
 });

--- a/src/stores/conversation/conversation-list-state.ts
+++ b/src/stores/conversation/conversation-list-state.ts
@@ -107,6 +107,28 @@ export function markConversationRead(
   if (nextLastReadAt !== lastReadAt) setReadVersion((v) => v + 1);
 }
 
+/**
+ * Fold a peer's live read-marker update into their member row. DM-only today
+ * (no group fan-out semantics); matched by user_id within the conversation's
+ * existing member list, so a conversation not yet seeded is a no-op.
+ */
+export function updateMemberLastReadAt(
+  conversationId: string,
+  userId: string,
+  lastReadAt: number,
+): void {
+  setListState((prev) => {
+    const cur = prev.get(conversationId);
+    if (!cur) return prev;
+    const members = cur.members.map((member) =>
+      member.user_id === userId
+        ? { ...member, last_read_at: lastReadAt }
+        : member,
+    );
+    return new Map(prev).set(conversationId, { ...cur, members });
+  });
+}
+
 function upsert(conversationId: string, next: Partial<Conversation>): void {
   setListState((prev) => {
     const cur = prev.get(conversationId);

--- a/src/stores/conversation/conversation-list-state.ts
+++ b/src/stores/conversation/conversation-list-state.ts
@@ -122,7 +122,12 @@ export function updateMemberLastReadAt(
     if (!cur) return prev;
     const members = cur.members.map((member) =>
       member.user_id === userId
-        ? { ...member, last_read_at: lastReadAt }
+        ? {
+            ...member,
+            // Monotonic, mirroring the server's MAX(last_read_at, ?): a
+            // replayed or out-of-order broadcast must not un-read messages.
+            last_read_at: Math.max(member.last_read_at, lastReadAt),
+          }
         : member,
     );
     return new Map(prev).set(conversationId, { ...cur, members });
@@ -174,6 +179,33 @@ export function ensureDirectConversationListed(
   upsert(conversationId, { kind: 'direct', members: [peer] });
 }
 
+function knownReadAt(members: ConversationMember[], userId: string): number {
+  return members.find((member) => member.user_id === userId)?.last_read_at ?? 0;
+}
+
+function hasNewerReadMarker(
+  existing: Conversation,
+  fetched: Conversation,
+): boolean {
+  return fetched.members.some(
+    (member) =>
+      knownReadAt(existing.members, member.user_id) > member.last_read_at,
+  );
+}
+
+/** Seed members, keeping any read marker a live broadcast already moved past. */
+function mergeReadMarkers(
+  existing: ConversationMember[],
+  fetched: ConversationMember[],
+): ConversationMember[] {
+  return fetched.map((member) => {
+    const known = knownReadAt(existing, member.user_id);
+    return known > member.last_read_at
+      ? { ...member, last_read_at: known }
+      : member;
+  });
+}
+
 /** Refetch the current conversation-list state snapshot (seed). */
 export async function refreshConversationListState(): Promise<void> {
   const me = getLoggedInUserId();
@@ -198,9 +230,23 @@ export async function refreshConversationListState(): Promise<void> {
     setListState((current) => {
       for (const [rowKey, existing] of current) {
         const fetched = map.get(rowKey);
-        if (fetched && existing.latestSentAt > fetched.latestSentAt) {
-          map.set(rowKey, existing);
-        }
+        if (!fetched) continue;
+        // The seed row wins (fresher members: read markers, display names),
+        // but two things the local row can hold are newer than the snapshot:
+        // activity recorded in-tab since the request went out, and a read
+        // marker a live broadcast advanced past what the query returned.
+        const locallyNewer = existing.latestSentAt > fetched.latestSentAt;
+        if (!locallyNewer && !hasNewerReadMarker(existing, fetched)) continue;
+        map.set(rowKey, {
+          ...fetched,
+          members: mergeReadMarkers(existing.members, fetched.members),
+          latestSentAt: locallyNewer
+            ? existing.latestSentAt
+            : fetched.latestSentAt,
+          latestSenderId: locallyNewer
+            ? existing.latestSenderId
+            : fetched.latestSenderId,
+        });
       }
       return map;
     });

--- a/src/stores/conversation/conversation-store.test.js
+++ b/src/stores/conversation/conversation-store.test.js
@@ -194,6 +194,32 @@ describe('conversation-store', () => {
     expect(repo.markConversationRead).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps the newer request marker when an older request fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let failFirst;
+    repo.markConversationRead
+      .mockImplementationOnce(
+        () => new Promise((_resolve, reject) => (failFirst = reject)),
+      )
+      .mockResolvedValue(undefined);
+    const store = await import('./conversation-store.js');
+    await store.openDirectConversation('contact-1');
+
+    watch.emit([envelope({ messageId: 'msg-1', sentAt: 1 })]);
+    store.markActiveConversationRead();
+    watch.emit([envelope({ messageId: 'msg-2', sentAt: 2 })]);
+    store.markActiveConversationRead();
+    expect(repo.markConversationRead).toHaveBeenCalledTimes(2);
+
+    // The stale failure must not roll back the newer marker, or the next
+    // batch re-sends a PUT (and its broadcast) for a marker already stored.
+    failFirst(new Error('offline'));
+    await vi.waitFor(() => expect(console.warn).toHaveBeenCalled());
+    store.markActiveConversationRead();
+
+    expect(repo.markConversationRead).toHaveBeenCalledTimes(2);
+  });
+
   it('merges watcher snapshots in chronological order and maps file envelopes', async () => {
     const store = await import('./conversation-store.js');
     await store.openDirectConversation('contact-1');

--- a/src/stores/conversation/conversation-store.test.js
+++ b/src/stores/conversation/conversation-store.test.js
@@ -145,6 +145,7 @@ describe('conversation-store', () => {
       'conversation-1',
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
   });
 

--- a/src/stores/conversation/conversation-store.test.js
+++ b/src/stores/conversation/conversation-store.test.js
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   recordConversationListMessage: vi.fn(),
   ensureDirectConversationListed: vi.fn(),
   refreshConversationListState: vi.fn(),
+  updateMemberLastReadAt: vi.fn(),
   conversationListState: vi.fn(() => new Map()),
   resolveDirectConversationId: vi.fn(),
   getContactById: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('./conversation-list-state', () => ({
   recordConversationListMessage: mocks.recordConversationListMessage,
   ensureDirectConversationListed: mocks.ensureDirectConversationListed,
   refreshConversationListState: mocks.refreshConversationListState,
+  updateMemberLastReadAt: mocks.updateMemberLastReadAt,
   conversationListState: mocks.conversationListState,
   conversationPeers: (conversation) =>
     conversation.members
@@ -157,6 +159,39 @@ describe('conversation-store', () => {
     expect(store.loadSelectedConversationId()).toBe('group-1');
     // Unknown id: the list reseeds so kind/members/label fill in.
     expect(mocks.refreshConversationListState).toHaveBeenCalled();
+  });
+
+  it('sends the read marker once per advance, not once per watcher batch', async () => {
+    const store = await import('./conversation-store.js');
+    await store.openDirectConversation('contact-1');
+
+    watch.emit([envelope({ messageId: 'msg-1', sentAt: 1 })]);
+    store.markActiveConversationRead();
+    store.markActiveConversationRead();
+
+    // Every PUT fans a `read` broadcast to the channel, so an unchanged
+    // marker must not hit the network.
+    expect(repo.markConversationRead).toHaveBeenCalledTimes(1);
+
+    watch.emit([envelope({ messageId: 'msg-2', sentAt: 2 })]);
+    store.markActiveConversationRead();
+
+    expect(repo.markConversationRead).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries the read marker after a failed request', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    repo.markConversationRead.mockRejectedValueOnce(new Error('offline'));
+    const store = await import('./conversation-store.js');
+    await store.openDirectConversation('contact-1');
+
+    watch.emit([envelope({ messageId: 'msg-1', sentAt: 1 })]);
+    store.markActiveConversationRead();
+    await vi.waitFor(() => expect(console.warn).toHaveBeenCalled());
+
+    store.markActiveConversationRead();
+
+    expect(repo.markConversationRead).toHaveBeenCalledTimes(2);
   });
 
   it('merges watcher snapshots in chronological order and maps file envelopes', async () => {

--- a/src/stores/conversation/conversation-store.ts
+++ b/src/stores/conversation/conversation-store.ts
@@ -770,7 +770,13 @@ export function markActiveConversationRead(): void {
   void Promise.resolve(
     getRepo().markConversationRead(conversationId, candidate.myUserId),
   ).catch((error) => {
-    sentReadMarkers.delete(conversationId);
+    // Roll back only our own marker. A newer request may already have
+    // recorded a higher one, and clearing that would re-send it. The
+    // timestamp is token enough: the guard above only lets strictly
+    // increasing values through, so two in-flight requests never match.
+    if (sentReadMarkers.get(conversationId) === candidate.sentAt) {
+      sentReadMarkers.delete(conversationId);
+    }
     console.warn('[conversation] failed to mark conversation read', {
       conversationId,
       error,

--- a/src/stores/conversation/conversation-store.ts
+++ b/src/stores/conversation/conversation-store.ts
@@ -14,6 +14,7 @@ import {
   markConversationRead,
   recordConversationListMessage,
   refreshConversationListState,
+  updateMemberLastReadAt,
   type Conversation,
 } from './conversation-list-state.js';
 import {
@@ -426,6 +427,11 @@ function startWatch(
       }
       setState({ history: 'error', historyError: error });
     },
+    (userId, lastReadAt) => {
+      if (disposed || conversationId !== state.conversationId) return;
+      if (userId === myUserId) return; // only the peer's marker moves the checkmark
+      updateMemberLastReadAt(conversationId, userId, lastReadAt);
+    },
   );
 
   if (typeof result === 'function') {
@@ -529,6 +535,7 @@ export async function openDirectConversation(
     user_id: contactId,
     display_name: contact ? getContactLabel(contact) : null,
     joined_at: 0,
+    last_read_at: 0,
   });
   openConversation(conversationId, { displayUI: opts?.displayUI });
 }

--- a/src/stores/conversation/conversation-store.ts
+++ b/src/stores/conversation/conversation-store.ts
@@ -146,6 +146,11 @@ export function selectedConversation(): Conversation | null {
   return sel ? (conversationListState().get(sel.conversationId) ?? null) : null;
 }
 
+// Read markers the server has already accepted, per conversation. Guards the
+// PUT in markActiveConversationRead; cleared on logout with the rest of the
+// login-scoped state.
+const sentReadMarkers = new Map<ConversationId, number>();
+
 const [latestReadCandidate, setLatestReadCandidate] = createSignal<{
   conversationId: ConversationId;
   myUserId: UserId;
@@ -458,6 +463,7 @@ function startWatch(
 function activate(next: ConversationSelection | null) {
   flushDraftSave();
   stopWatch?.();
+  sentReadMarkers.clear();
   setLatestReadCandidate(null);
   setSelection(next);
 
@@ -752,14 +758,21 @@ export function markActiveConversationRead(): void {
   if (!candidate || candidate.conversationId !== state.conversationId) return;
 
   markConversationRead(candidate.conversationId, candidate.sentAt);
+
+  // The caller re-runs on every watcher batch, including our own sends, so the
+  // marker often hasn't moved. Skip the PUT then: each one also fans a `read`
+  // broadcast to every connected member. Recorded before the request so a
+  // second batch can't double-send; dropped on failure so the next one retries.
+  const conversationId = candidate.conversationId;
+  if (candidate.sentAt <= (sentReadMarkers.get(conversationId) ?? 0)) return;
+  sentReadMarkers.set(conversationId, candidate.sentAt);
+
   void Promise.resolve(
-    getRepo().markConversationRead(
-      candidate.conversationId,
-      candidate.myUserId,
-    ),
+    getRepo().markConversationRead(conversationId, candidate.myUserId),
   ).catch((error) => {
+    sentReadMarkers.delete(conversationId);
     console.warn('[conversation] failed to mark conversation read', {
-      conversationId: candidate.conversationId,
+      conversationId,
       error,
     });
   });

--- a/src/stores/conversation/message-sync.ts
+++ b/src/stores/conversation/message-sync.ts
@@ -75,7 +75,7 @@ export function createMessageSyncRepository(
       return snapshot(conversationId);
     },
 
-    async watchRecentMessages(conversationId, onMessages, onError) {
+    async watchRecentMessages(conversationId, onMessages, onError, onPeerRead) {
       // Window keyed by id so the live echo dedupes against the snapshot.
       const window = new Map<string, IncomingMessage>();
       const pendingEvents: ConversationServerEvent[] = [];
@@ -104,6 +104,11 @@ export function createMessageSyncRepository(
           if (!incoming) return;
           window.set(incoming.messageId, incoming);
           emit();
+          return;
+        }
+
+        if (event.t === 'read') {
+          onPeerRead?.(event.userId, event.lastReadAt);
           return;
         }
 

--- a/src/stores/conversation/types.ts
+++ b/src/stores/conversation/types.ts
@@ -32,6 +32,8 @@ export type MessageRepository = {
     conversationId: ConversationId,
     onMessages: (messages: IncomingMessage[]) => void,
     onError?: (error: unknown) => void,
+    /** A member (DM peer) advanced their read marker. DM-only today. */
+    onPeerRead?: (userId: UserId, lastReadAt: number) => void,
   ): (() => void) | Promise<() => void>;
 
   send(


### PR DESCRIPTION
## Summary
- Exposes each conversation member's `last_read_at` (already stored per-member in D1, previously only queried for the caller) and broadcasts it as a new `read` channel event, mirroring the existing `message`/`reaction` events.
- `MessageList` shows a checkmark on your own sent messages once the peer's read marker passes the message's `sentAt`.
- DM-only — group semantics (per-member breakdown / read-by-all) are intentionally out of scope.
- Gated by `readReceiptsEnabled()` (`VITE_READ_RECEIPTS_ENABLED` env var), so the future settings-menu slice can swap it for a per-user signal without touching call sites.

## Test plan
- [x] Backend: `pnpm -C backend/cloudflare test` (data-repo, data-worker)
- [x] Frontend: `vp test` (conversation-store, conversation-list-state, message-sync)
- [x] `vp check` (format/lint/typecheck) and backend `typecheck` clean
- [x] Manually verified in browser (dev server, two-user DM conversation)

## Review follow-ups (b7ba198c, 33cfb7fb, cce67534)

- Client read marker is monotonic (`Math.max`), matching the server's `MAX()` — a replayed or out-of-order broadcast can't un-read messages.
- Checkmark renders only on the newest read message, not every read message.
- `role="img"` on the status spans (`…`, `!`, `✓`); ARIA drops `aria-label` on a plain span. Adds `conversation.sending` / `conversation.send_failed` (en + is).
- Protocol validator rejects non-finite `lastReadAt`.
- Read PUT is skipped when the marker hasn't advanced. The effect re-runs on every watcher batch including our own sends, and each PUT now fans a `read` broadcast, so this was ~3x realtime traffic per DM message.
- Seed merge takes the server's members but keeps a read marker a live broadcast advanced past the snapshot.
- `read-receipts.ts` comment corrected: the flag hides *others'* checkmarks on this client, it does not stop your own reads being disclosed. Server-side opt-out tracked in #662.

Also: `src/realtime/conversation-protocol.test.ts` had never run — vp only collects `*.test.js`/`.jsx`, so it was dead since #601. Renamed to `.test.js`; it passes.

CodeRabbit follow-up (cce67534): the read-marker rollback deleted by `conversationId` alone, so a failed PUT for an older timestamp wiped the marker a newer in-flight PUT had recorded, causing a duplicate PUT + broadcast on the next batch. Rolls back only when the stored marker is still ours.

Tests added: monotonic/advance/unseeded cases for `updateMemberLastReadAt`, the `read` branch of the validator, read-PUT dedupe, retry-on-failure, stale-rollback race, seed-merge preservation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added read receipts for direct conversations, including localized “Read” indicators.
  - Read status now updates in real time across conversation views.
  - Added English and Icelandic translations for read-receipt and message-sending states.
- **Enhancements**
  - Read receipts can be enabled or disabled through application configuration.
  - Read markers remain accurate during refreshes and out-of-order updates.
  - Failed read-status updates can be retried without losing newer updates.
  - Improved accessibility labels for message status indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
